### PR TITLE
Phase 0 safety rails + Phase 1 messaging_listen non-push closeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ octo-santa takes the collaboration path. Instead of making one agent smarter, it
 - **Brain** — a knowledge layer that makes agents into domain experts. Each project declares its domain via config, agents get indexed access to curated docs, and a discovery mechanism (`brain_find_expert`) lets agents find the right expert to DM. Cross-domain knowledge flows through agent-to-agent conversation, not shared document stores.
 - **Per-domain config** (`.octo-santa/config.json`) — projects declare their identity, domain expertise, and brain directories. The agent's role in the network is defined by the repo it lives in.
 - **REPL** — interactive chat terminal for humans to observe, participate in, and moderate agent conversations in real time.
+- **Safety rails** — per-channel hop counter (default 50 agent messages before block), self-mention guard, `_system` block notifications, and human-only `/continue` REPL command. Prevents runaway agent loops; humans control resumption.
+- **Persistent agent profiles** — YAML profile store at `~/.octo-santa/profiles/` lets agents register with a profile-derived pool slot (e.g. `os-dev` → `os-dev-1`), inheriting persona, objective, and instructions across sessions.
+- **`messaging_listen`** — blocking pull mode for non-push MCP clients (Codex, Gemini CLI, OpenCode, local-model clients).
 
 **Planned:**
 - **Plugin distribution** — repackage octo-santa as a Claude Code plugin for install via `/plugin install` instead of manual MCP config. Enables SessionStart hooks for automatic brain priming, plugin channels for message delivery, and marketplace distribution.
@@ -95,15 +98,17 @@ Push and poll are fully compatible — agents using either mode can communicate 
 | Tool | Description |
 |------|-------------|
 | `messaging_register` | Register an agent with a unique name |
-| `messaging_create_channel` | Create a named channel |
+| `messaging_create_channel` | Create a named channel (optional `max_hops` override, default 50, max 50) |
 | `messaging_subscribe` | Subscribe to an existing channel for notifications |
-| `messaging_send_message` | Send a message to an existing channel |
+| `messaging_send_message` | Send a message to an existing channel (subject to per-channel hop limit) |
 | `messaging_read_messages` | Read unread messages with cursor tracking |
 | `messaging_direct_message` | Send a DM — creates channel and subscribes both parties |
+| `messaging_listen` | Block and wait for new messages across subscribed channels (non-push fallback, max 30s) |
 | `messaging_list_channels` | List all channels |
 | `messaging_list_agents` | List agents (active by default) |
 | `messaging_list_members` | List channel members with active/inactive status |
 | `messaging_rename_channel` | Rename a channel (members only) |
+| `messaging_get_instructions` | Re-read profile instructions and universal messaging guidance |
 
 ### Brain
 
@@ -161,6 +166,16 @@ Docs in `~/.octo-santa/brain/` are accessible to all agents across all repos via
 ### Cross-domain queries
 
 The cross-domain flow: discover an expert with `brain_find_expert`, then DM them with `messaging_direct_message`. The expert agent reads its brain docs and answers. No cross-domain brain access — the agent IS the query interface.
+
+## Safety Rails
+
+Per-channel hop counter prevents runaway agent loops. Each channel has a `max_hops` limit (default **50**). Every agent-sourced message increments the counter; when it reaches the limit, sends are blocked and a `_system` notice is posted to the channel announcing the block.
+
+- **Default:** 50 agent messages per channel before block. Override via `messaging_create_channel`'s `max_hops` argument (range 1–50; lower = stricter loop guard).
+- **Reset:** any message sent with the `human: true` flag (REPL-only) resets the counter to 0.
+- **Human-only resume:** the REPL `/continue [N]` command bumps the allowance by N (default 4). This is **not** an MCP tool — agents cannot invoke it. Enforcement is by transport boundary: only the REPL transport sets `SendOptions.human` and only the REPL surfaces `/continue`.
+- **Self-mention guard:** agents cannot `@mention` themselves in a message; the send is rejected.
+- **Migration note:** `messaging_005_safety_rails` adds `max_hops` and `hop_count` columns to existing channels with `DEFAULT 50, 0`. No action required on upgrade — pre-existing channels gain the default limit transparently.
 
 ## REPL
 

--- a/docs/analysis/2026-04-13-approach1-permutation-evaluation.md
+++ b/docs/analysis/2026-04-13-approach1-permutation-evaluation.md
@@ -1,0 +1,281 @@
+# Approach 1 Permutation Evaluation Report
+
+**Date:** 2026-04-13
+**Approach:** Profile `instructions` field (free-text) + MCP instruction refresh
+**Method:** Replay transcript scenarios and edge cases against Approach 1, evaluating whether the design resolves each failure
+
+---
+
+## Design Under Evaluation
+
+**Layer A (MCP Instructions):** Universal floor. Enhanced with event→action rules, tool scoping, capability boundaries. Delivered to every agent at connection time. ~500 words. Must stay under 2KB (Claude Code truncation limit).
+
+**Layer C (Profile Instructions):** Role-specific behavioral guidance. Free-text field in profile YAML. Delivered in the `messaging_register` response. Agent/harness responsible for keeping it in context.
+
+---
+
+## Scenario Replays
+
+### Scenario 1: os-pm told to "periodically check latest message"
+
+**Original failure:** Agent spirals for 3+ minutes considering bash loops, python scripts, curl, subagents, todo tools. Never arrives at a simple `read_messages` call.
+
+**With Approach 1:**
+
+| Layer | Guidance injected | Expected effect |
+|-------|-------------------|-----------------|
+| A (MCP instructions) | "You CANNOT run background tasks or polling loops. When asked to monitor a channel, call `messaging_read_messages`. Your harness or the human will prompt you again later." | Eliminates the spiral. Agent sees a clear boundary and a clear action. |
+| C (Profile instructions) | "When checking channels, read messages and act on any addressed to you. Summarize only if nothing requires action." | Adds role-specific framing on top. |
+
+**Verdict: RESOLVED.** The capability boundary statement in Layer A directly addresses the root cause. Even a 7B model can follow "do X, don't try Y."
+
+**Residual risk:** The agent might still not know HOW OFTEN to check. Layer A can't solve this — it's a harness concern (polling interval). Noted for harness integration follow-up.
+
+---
+
+### Scenario 2: os-pm receives a message but doesn't act until human says "perform action"
+
+**Original failure:** Agent reads the message, summarizes it as "The latest message is from os-tl and addresses a draft...", then stops. Doesn't recognize it should respond.
+
+**With Approach 1:**
+
+| Layer | Guidance injected | Expected effect |
+|-------|-------------------|-----------------|
+| A (MCP instructions) | "After calling `messaging_read_messages`, if any message is addressed to you (@your-name or @all), you MUST: (1) understand what is being asked, (2) decide on a response, (3) call `messaging_send_message` to reply. Never just summarize — always act." | Direct event→action rule. The word MUST + numbered steps gives weak models a clear procedure. |
+| C (Profile instructions) | "As a PM, when you receive a proposal or draft, evaluate it against project priorities and provide a clear decision or feedback with reasoning." | Adds role-specific decision framework. |
+
+**Verdict: LIKELY RESOLVED.** The event→action rule is explicit enough for 20-30B models. For 7-13B models, there's a risk they still summarize first and "forget" to act — the numbered steps help but aren't guaranteed.
+
+**Residual risk:** Very weak models may interpret "understand what is being asked" as a terminal action (they "understood" it, done). Mitigation: the numbered list makes step 3 (send_message) explicit and hard to skip.
+
+---
+
+### Scenario 3: os-tl sends a bare directive "@os-pm decide what the next roadmap items to tackle"
+
+**Original failure:** Message lacks context, constraints, or expected response format. Even a capable receiver would struggle to give a good answer.
+
+**With Approach 1:**
+
+| Layer | Guidance injected | Expected effect |
+|-------|-------------------|-----------------|
+| A (MCP instructions) | "When sending a message, include: (1) what you're asking or proposing, (2) relevant context, (3) what kind of response you need. Poor example: 'decide the roadmap.' Good example: '@os-pm We need to pick the next 2 roadmap items. Candidates: A, B, C. Constraints: team bandwidth is 1 dev for 2 weeks. Which should we prioritize and why?'" | Few-shot example teaches message quality. |
+| C (Profile instructions for os-tl) | "As a tech lead, when requesting decisions from the PM, always include: the options you've identified, technical constraints, and your recommendation." | Role-specific message template. |
+
+**Verdict: PARTIALLY RESOLVED.** The few-shot example in Layer A helps significantly — weak models excel at pattern matching. However, the agent must actually READ and INTERNALIZE the MCP instructions when composing a message. If it's already in "just send it" mode, it may skip the guidance.
+
+**Residual risk:** MCP instructions are delivered at connection time. By the time the agent is composing a message (possibly many turns later), the instructions may be out of active context for smaller context-window models. This is a fundamental limitation of one-time delivery.
+
+---
+
+### Scenario 4: os-tl monitors channel and reports "No new messages" despite messages existing
+
+**Original failure:** Agent calls `read_messages` twice in quick succession, gets results the first time, then reports "no new messages" because the second call returns empty (messages already marked read).
+
+**With Approach 1:**
+
+| Layer | Guidance injected | Expected effect |
+|-------|-------------------|-----------------|
+| A (MCP instructions) | "When you call `messaging_read_messages`, messages are marked as read. You will NOT see them again on the next call. If the first call returned messages, act on them — do not call read again expecting to see the same messages." | Explains read-once semantics. |
+
+**Verdict: RESOLVED.** This is a tool semantics issue. Clear documentation in Layer A prevents the double-read mistake.
+
+---
+
+## Edge Cases
+
+### Edge Case 1: Agent registers without a profile (no Layer C)
+
+**Scenario:** An agent connects with `messaging_register("random-bot")` — no profile YAML exists.
+
+**With Approach 1:** Agent gets Layer A (MCP instructions) only. No profile instructions.
+
+**Assessment:** This is the baseline. Layer A must be self-sufficient for agents without profiles. The event→action rules, tool scoping, and capability boundaries all apply universally. The agent won't have role-specific guidance but can still participate effectively in messaging.
+
+**Verdict: ACCEPTABLE.** Layer A alone is a significant improvement over the current state. Profile instructions are additive, not required.
+
+---
+
+### Edge Case 2: Profile instructions contradict MCP instructions
+
+**Scenario:** MCP instructions say "always respond to messages addressed to you." Profile instructions say "only respond to messages tagged #urgent."
+
+**With Approach 1:** No explicit precedence rule. The agent sees both instructions and must reconcile.
+
+**Assessment:** For capable models, this is fine — they'll recognize the profile as a refinement of the general rule. For weak models, contradictions cause unpredictable behavior (they may follow whichever instruction they processed last).
+
+**Mitigation:** Add a precedence statement to Layer A: "Profile instructions refine but do not override these base rules. If your profile instructions seem to conflict with these rules, the profile instructions take precedence for role-specific behavior."
+
+**Verdict: NEEDS DESIGN DECISION.** The precedence rule should be part of the spec.
+
+---
+
+### Edge Case 3: Profile instructions are too long for agent context
+
+**Scenario:** A profile has 2000 words of detailed instructions. The agent is running on a model with 4K-8K context window. The instructions consume a significant portion of available context.
+
+**With Approach 1:** Instructions are delivered in the registration response as a text field. It's up to the harness to decide how much to keep in context.
+
+**Assessment:** This is a harness-level concern, not a framework concern. However, we should provide guidance: "Keep profile instructions under 500 words. For detailed role playbooks, use brain documents and reference them from profile instructions."
+
+**Mitigation:** Add a recommended length guideline to the profile YAML schema docs. Optionally: warn at profile load time if instructions exceed a threshold.
+
+**Verdict: ACCEPTABLE with guideline.** Document the recommendation; don't enforce it in code.
+
+---
+
+### Edge Case 4: Multiple agents with the same profile (pool scenario)
+
+**Scenario:** Three `os-dev` instances register (os-dev-1, os-dev-2, os-dev-3). All get the same profile instructions.
+
+**With Approach 1:** All pool members get identical instructions from the profile. No instance-specific differentiation.
+
+**Assessment:** This is correct behavior. Pool members SHOULD have the same behavioral baseline. If differentiation is needed (e.g., "os-dev-1 handles frontend, os-dev-2 handles backend"), that's coordination — handled via channel messages, not profile instructions.
+
+**Verdict: CORRECT BY DESIGN.** Pool-wide consistency is the right default.
+
+---
+
+### Edge Case 5: Agent receives a message but is not the intended recipient
+
+**Scenario:** Agent os-dev-1 reads channel messages and sees a message addressed to `@os-pm`. The event→action rule says "if any message is addressed to you, act on it."
+
+**With Approach 1:** Layer A says "addressed to you (@your-name or @all)." The agent should recognize that `@os-pm` is not `@os-dev-1` and skip it.
+
+**Assessment:** Capable models handle this. Weak models might interpret "addressed to you" loosely and respond to every message they read.
+
+**Mitigation:** Make the rule more explicit: "addressed to you means the message contains @your-registered-name or @all or @your-pool-name. Messages mentioning other agents are not addressed to you — do not respond to them unless you have relevant information to contribute."
+
+**Verdict: NEEDS REFINEMENT.** The event→action rule needs tighter scoping on "addressed to you."
+
+---
+
+### Edge Case 6: Harness doesn't support injecting registration response into context
+
+**Scenario:** A minimal harness (basic MCP client) calls `messaging_register` and gets back the profile instructions in the response, but doesn't have a mechanism to persist that text in the agent's system prompt or ongoing context. It just shows the tool result once.
+
+**With Approach 1:** Instructions are delivered but may be lost after the first turn in some harnesses.
+
+**Assessment:** This is a real concern for minimal harnesses. Claude Code and opencode both keep tool results in conversation history, so the instructions persist until context compaction. But a bare MCP client might not.
+
+**Mitigation options:**
+1. Document that harnesses SHOULD persist registration response instructions
+2. Also include a condensed version of instructions in the MCP server instructions (Layer A) as a fallback
+3. Provide a `messaging_get_instructions` tool that agents can call later to re-read their profile instructions
+
+**Verdict: NEEDS MITIGATION.** Option 3 (re-readable instructions) is the most robust. Consider adding it to the spec.
+
+---
+
+### Edge Case 7: MCP instruction token budget (2KB Claude Code limit)
+
+**Scenario:** Claude Code truncates server instructions at 2KB. Our enhanced MCP instructions need to fit within this budget while covering event→action rules, tool scoping, capability boundaries, and message quality templates.
+
+**With Approach 1:** Current MCP instructions are ~1.5KB. Adding event→action rules and few-shot examples could push past 2KB.
+
+**Assessment:** This is a hard constraint for Claude Code. Other harnesses (opencode, Pi) may not have this limit, but we should design for the lowest common denominator.
+
+**Mitigation:**
+1. Prioritize ruthlessly — event→action rules and capability boundaries are highest impact per token
+2. Move few-shot examples to profile instructions or brain docs
+3. Use terse, imperative language (not prose)
+4. Test the actual byte count before finalizing
+
+**Verdict: HARD CONSTRAINT.** Must budget the MCP instruction content carefully. Few-shot examples may not fit in Layer A.
+
+---
+
+### Edge Case 8: Agent on a model that doesn't support tool calling natively
+
+**Scenario:** Some very small models (7B) have unreliable tool calling — they hallucinate tool names, miss required parameters, or format JSON incorrectly.
+
+**With Approach 1:** The guidance assumes the agent can reliably call tools. If it can't, no amount of behavioral instructions helps.
+
+**Assessment:** This is out of scope for octo-santa. Tool calling reliability is a model + harness problem. The harness is responsible for tool call formatting and error recovery.
+
+**Verdict: OUT OF SCOPE.** Document that the guidance assumes basic tool calling works. Harness integration patterns (follow-up task) should address tool calling reliability.
+
+---
+
+### Edge Case 9: Cross-harness instruction format compatibility
+
+**Scenario:** Different harnesses expect instructions in different formats:
+- **Claude Code:** MCP server instructions as text, tool descriptions in JSON schema. Truncates at 2KB. Supports `instructions` field on MCP server config.
+- **opencode:** Skills as SKILL.md files with YAML frontmatter. Searches `.opencode/skills/`, `.claude/skills/`, `.agents/skills/`.
+- **Pi:** Loads AGENTS.md from project and parent dirs. Supports SYSTEM.md per-project. Extensions can inject messages before each turn.
+- **Codex:** Plugins with bundled skills. MCP servers configured in plugin manifests.
+
+**With Approach 1:** Profile instructions are delivered via MCP tool response (registration). MCP server instructions are universal. Both are harness-agnostic — they travel through the MCP protocol, which all harnesses implement.
+
+**Assessment:** This is actually the strongest argument FOR Approach 1. MCP is the universal transport. By delivering guidance through MCP tool responses and server instructions, we avoid harness-specific integration entirely. The guidance arrives through the same channel regardless of whether the agent runs on Claude Code, opencode, Pi, or Codex.
+
+**Residual concern:** Each harness handles MCP server instructions differently:
+- Claude Code: shows them in `<system-reminder>` tags, truncates at 2KB
+- opencode: surfaces as part of tool context (exact mechanism varies)
+- Pi: MCP tool results are in conversation history, extensions can filter
+- Codex: MCP server instructions surface as tool context
+
+**Verdict: STRONG ADVANTAGE.** MCP-level delivery is the right abstraction. Harness-specific formatting is a display concern, not a content concern.
+
+---
+
+### Edge Case 10: Instructions reference tools that don't exist in the agent's environment
+
+**Scenario:** Profile instructions say "use brain_read to find the coordinator playbook." But the octo-santa instance doesn't have brain configured (no `brain` key in config.json). The `brain_read` tool doesn't exist.
+
+**With Approach 1:** Instructions are static text in YAML. They don't know which tools are actually available.
+
+**Assessment:** For capable models, they'd try `brain_read`, get an error, and adapt. For weak models, a tool that doesn't exist causes confusion or hallucinated tool calls.
+
+**Mitigation:**
+1. Profile instructions should only reference tools that are guaranteed to exist (all messaging tools exist if octo-santa is running)
+2. Add a guideline: "Profile instructions SHOULD only reference messaging_* tools. References to brain_* tools should be conditional: 'If brain is available, ...'"
+3. Alternatively: the registration response could include a list of available tool categories
+
+**Verdict: MINOR RISK.** Add a documentation guideline. Not worth adding code complexity.
+
+---
+
+## Cross-Harness Compatibility Matrix
+
+| Harness | Layer A (MCP Instructions) | Layer C (Profile Instructions) | Notes |
+|---------|---------------------------|-------------------------------|-------|
+| **Claude Code** | Delivered as `<system-reminder>`. 2KB limit. Always in context. | Delivered in `messaging_register` tool result. Persists in conversation history until compaction. | Best support. Both layers work well. Few-shot examples may not fit in Layer A due to 2KB limit. |
+| **opencode** | Surfaced as tool context. No documented size limit. | Delivered in `messaging_register` tool result. Persists in conversation. | Works. Skills system could complement with harness-side playbooks, but not required. |
+| **Pi** | MCP tool context. Extensions can filter/augment. | Delivered in tool result. Extensions can re-inject if needed. | Works. Pi's extension system could persist profile instructions across compaction if desired. |
+| **Codex** | MCP server instructions in plugin context. | Delivered in tool result. | Works. Codex plugins could add complementary skills, but MCP delivery is sufficient. |
+| **Bare MCP client** | Server instructions at connection time. | Delivered in tool result. May be lost after first turn. | Minimal support. Consider `messaging_get_instructions` tool as fallback. |
+
+---
+
+## Failure Mode Summary
+
+| # | Scenario | Resolved? | Residual Risk | Mitigation Needed? |
+|---|----------|-----------|---------------|---------------------|
+| S1 | Polling spiral | YES | Harness polling config | No (harness concern) |
+| S2 | No action on messages | LIKELY YES | Very weak models may still stop at "understand" | Refine numbered steps |
+| S3 | Bare directive messages | PARTIAL | Instructions may be out of context by send time | Few-shot in Layer A helps |
+| S4 | Double-read confusion | YES | None | No |
+| E1 | No profile (Layer A only) | ACCEPTABLE | Less guidance but functional | No |
+| E2 | Contradicting instructions | NEEDS DECISION | Weak models confused by contradictions | Add precedence rule |
+| E3 | Instructions too long | ACCEPTABLE | Context pressure on small models | Add length guideline |
+| E4 | Pool same instructions | CORRECT | None | No |
+| E5 | Wrong recipient | NEEDS REFINEMENT | Weak models respond to all messages | Tighten "addressed to you" |
+| E6 | Harness doesn't persist | NEEDS MITIGATION | Instructions lost after first turn | Add re-readable tool |
+| E7 | 2KB token budget | HARD CONSTRAINT | Few-shot examples may not fit | Budget carefully, move examples to Layer C |
+| E8 | Bad tool calling | OUT OF SCOPE | Model/harness problem | Document assumption |
+| E9 | Cross-harness compat | STRONG | MCP is universal transport | None needed |
+| E10 | Missing tools referenced | MINOR | Weak models confused | Documentation guideline |
+
+---
+
+## Recommendations for Spec
+
+Based on this evaluation, Approach 1 should include:
+
+1. **Precedence rule** in Layer A: profile instructions refine but layer A is the behavioral floor
+2. **Tight "addressed to you" definition** in the event→action rule
+3. **`messaging_get_instructions` tool** for re-reading profile instructions (mitigates harness persistence issues)
+4. **Length guideline** for profile instructions (recommend ≤500 words)
+5. **2KB budget plan** for Layer A content — prioritize event→action rules and capability boundaries; move few-shot examples to Layer C
+6. **Tool reference guideline** — profile instructions should only reference guaranteed-available tools
+7. **One concrete playbook** (os-pm) as validation artifact

--- a/docs/analysis/2026-04-13-less-capable-agent-failure-analysis.md
+++ b/docs/analysis/2026-04-13-less-capable-agent-failure-analysis.md
@@ -1,0 +1,123 @@
+# Less Capable Agent Failure Analysis
+
+**Date:** 2026-04-13
+**Context:** Testing Gemma4:26b via opencode harness with two agents (os-pm, os-tl) collaborating through octo-santa messaging.
+
+---
+
+## Observable Failure Modes
+
+### 1. Excessive reasoning about tool mechanics
+Both agents spend enormous amounts of their thinking budget figuring out HOW to call tools, rather than WHAT to accomplish. os-pm's thinking about "periodically check" is 90% about whether it CAN loop, not about the business goal.
+
+### 2. No autonomous reaction to incoming messages
+When os-pm receives a message, nothing happens until the human explicitly says "perform action based on the message, then respond." The agent doesn't recognize that receiving a channel notification should trigger action.
+
+### 3. Confusion about async/background capabilities
+os-pm spirals into whether it can run bash loops, write python scripts, use curl, spawn subagents — all to solve "periodically check." It doesn't know its own capabilities or boundaries.
+
+### 4. Shallow message comprehension
+os-tl receives messages and summarizes them as "No new messages have arrived since my last check" without actually engaging with the content or deciding on next actions.
+
+### 5. Over-serialized execution
+Both agents think step-by-step through trivial tool calls (register then subscribe) when they could be parallel.
+
+### 6. No proactive behavior
+Neither agent initiates. They wait for explicit human instructions for every micro-step.
+
+---
+
+## Root Causes
+
+### Root Cause 1: Absent mental model of self
+The agent doesn't know what it IS. It doesn't know it's a messaging participant with a role. It treats each tool call as an isolated API request rather than understanding "I am os-pm, a product manager, participating in an async conversation." Claude/Codex internalizes identity from system prompts; weaker models treat system prompts as reference text, not identity.
+
+### Root Cause 2: No event-action mapping
+There's no guidance that says "when you receive a message addressed to you, you MUST read it and respond." The agent treats message receipt as informational, not as a trigger. Capable models infer this from context; weaker models need explicit event→action rules.
+
+### Root Cause 3: Tool selection paralysis from too many options
+The thinking traces show the agent considering bash, python, curl, subagents, todo tools — it's overwhelmed by optionality. A capable model prunes irrelevant tools instantly; a weaker model enumerates all possibilities linearly.
+
+### Root Cause 4: No workflow state machine
+The agent has no concept of "I am in state X, the valid next actions are Y." Each turn starts from scratch. There's no persistent sense of "I sent a message, now I should wait for a reply, and when it comes, I should act on it."
+
+### Root Cause 5: Instruction following vs. goal pursuing
+These agents are instruction-followers, not goal-pursuers. They do exactly what they're told, nothing more. "Check messages" → they check. But they don't reason "I checked, there's a new message asking me something, therefore I should respond."
+
+---
+
+## Gap Analysis: What Octo-Santa Provides vs What Agents Need
+
+### What octo-santa provides today:
+- Tool descriptions (register, subscribe, send, read, etc.)
+- MCP server instructions (brief — "call messaging_register before sending", "use @mentions to get attention")
+- Channel notification tags when messages arrive
+
+### What's MISSING for less capable agents:
+
+1. **Role playbook** — No document says "You are a PM. When you receive a message, here's your decision framework." The role is just a name.
+
+2. **Tool selection guide** — No document says "For messaging tasks, use ONLY these 5 tools. Ignore bash, ignore subagents, ignore todo." The agent wastes cycles considering irrelevant tools.
+
+3. **Event-reaction rules** — No document says "When you see `<channel source='octo-santa'>`, IMMEDIATELY read the channel and formulate a response." The notification is just data, not a trigger.
+
+4. **Workflow templates** — No document says "The messaging workflow is: register → subscribe → send/read loop. Here are examples of each step." The agent has to infer the workflow from tool descriptions.
+
+5. **Response format guidance** — No document says "When responding to a message, quote the relevant part, state your position, and ask a clear follow-up question." The agents produce vague summaries instead of substantive replies.
+
+6. **Capability boundaries** — No document says "You CANNOT run background loops. You CAN be polled by the harness. Don't try to solve async monitoring yourself." The agent wastes time on impossible approaches.
+
+---
+
+## Specific Fix Mapping
+
+| Failure | Fix Needed |
+|---------|-----------|
+| os-pm spirals on "periodically check" | Clear capability boundary statement: "You cannot run background tasks. To monitor a channel, the human or harness will prompt you to check. When prompted, call read_messages and act on what you find." |
+| os-pm doesn't act on received messages | Event-reaction rule: "After reading messages, if any message is addressed to you, you MUST: (1) understand the request, (2) formulate a substantive response, (3) send your response back to the channel. Never just summarize — always act." |
+| os-tl sends a bare directive without context | Message quality template: "When sending a message, include: (1) what you're asking, (2) relevant context or constraints, (3) what kind of response you need." |
+| Both agents treat each turn as isolated | State tracking: "Before each action, review your recent message history in the channel to understand the conversation state." |
+| os-pm considers bash, python, curl for messaging | Tool scoping: "For channel communication, use ONLY: messaging_register, messaging_subscribe, messaging_send_message, messaging_read_messages. Do NOT use bash, file operations, or other tools for messaging tasks." |
+
+---
+
+## Core Insight
+
+**The gap isn't in the tools — the tools work fine. The gap is in the GUIDANCE LAYER between the tools and the agent's decision-making.** Capable models generate this layer internally; weaker models need it externally.
+
+---
+
+## Solution Framework: "Scaffolding for Less Capable Agents"
+
+Three intervention points, ordered by impact and feasibility:
+
+### 1. Enhanced MCP Instructions (High impact, Easy)
+Expand server instructions with:
+- Explicit event→action rules
+- Tool scoping per task type
+- Capability boundary statements
+- Message quality templates
+
+### 2. Brain-Stored Playbooks (High impact, Medium)
+Create brain documents for:
+- Role-specific behavior guides
+- Workflow state machines with transition rules
+- Few-shot example libraries
+- Troubleshooting / "when stuck" guides
+
+### 3. Harness-Level Integration Patterns (Medium impact, Hard)
+Provide reference implementations for:
+- Polling loops with automatic read-and-react
+- System prompt templates per role
+- Event handler patterns
+- State persistence between turns
+
+---
+
+## Architectural Consideration: Two-Tier Guidance
+
+**Tier 1 (MCP instructions):** Essential event-reaction rules, tool scoping, capability boundaries. Always in context. ~500 words. This is the minimum viable fix — improves ALL agents regardless of harness.
+
+**Tier 2 (Brain documents):** Role playbooks, workflow templates, few-shot examples. Pulled on demand. Unlimited length. Opt-in — capable models ignore them, weaker models pull them.
+
+The key insight for tier placement: a weak model won't know to ask for help (it doesn't know what it doesn't know). So the MINIMUM guidance must be in the MCP instructions themselves. The brain is for EXTENDED guidance.

--- a/docs/repl.md
+++ b/docs/repl.md
@@ -36,6 +36,7 @@ Type a slash command at the prompt and press Enter.
 | `/history [N]` | Show last N messages (default 20) |
 | `/send -f <path>` | Send a file's contents as a message |
 | `/members` | List members of the current channel |
+| `/continue [N]` | Resume a hop-limited channel by bumping the allowance by N (default 4). Human-only — not exposed to agents. |
 | `/help` | Show command help |
 | `/quit` | Exit the REPL |
 

--- a/docs/specs/2026-04-13-agent-guidance-framework-design.md
+++ b/docs/specs/2026-04-13-agent-guidance-framework-design.md
@@ -1,0 +1,313 @@
+# Agent Guidance Framework
+
+**Date:** 2026-04-13
+**Status:** Draft
+**Branch:** TBD
+**Depends on:** Persistent Agent Profiles (feat/persistent-agent-profiles)
+
+## Problem
+
+Less capable foundation models (20-30B and 7-13B parameter range) fail at multi-agent
+collaboration through octo-santa because they lack emergent capabilities that stronger
+models use to bridge gaps in guidance: identity internalization, event-driven reasoning,
+tool pruning, and goal pursuit.
+
+Observable failures from testing Gemma4:26b via opencode:
+
+1. Agents spiral on tool mechanics instead of pursuing business goals
+2. No autonomous reaction to incoming messages — require explicit human prompting
+3. Tool selection paralysis — consider bash, python, curl for messaging tasks
+4. Shallow message comprehension — summarize instead of acting
+5. No conversation state awareness — each turn starts from scratch
+6. Zero proactive behavior — pure instruction-followers
+
+Root cause: the gap isn't in the tools. It's in the **guidance layer** between tools and
+agent decision-making. Capable models generate this layer internally; weaker models need
+it externally.
+
+## Solution
+
+A two-tier, transport-agnostic guidance framework:
+
+- **Tier 1 (Universal):** Event-action rules, tool scoping, capability boundaries.
+  Delivered to every agent regardless of role. ~500 words.
+- **Tier 2 (Role-specific):** Behavioral directives tailored to the agent's role.
+  Delivered via profile `instructions` field. ≤500 words recommended.
+
+The guidance content is transport-agnostic. The same content can be delivered via MCP
+server instructions, skill files (SKILL.md), AGENTS.md, or CLI tool READMEs. This spec
+covers the content and the MCP delivery mechanism. Skill-based delivery is a follow-up.
+
+## Design
+
+### Tier 1: Enhanced MCP Server Instructions
+
+Replaces the current MCP server instructions text. Must fit within 2KB (Claude Code
+truncation limit). Current instructions are ~1.5KB; the enhanced version is ~1.6KB
+with room for the conditional BRAIN section.
+
+Key additions over current instructions:
+
+- **REACTING TO MESSAGES** section with read-once semantics and a numbered MUST-act rule
+- **Message quality guidance** in SENDING section
+- **BOUNDARIES** section (new) — capability boundaries and tool scoping
+- **Profile instructions callout** — tells agents to follow profile instructions as
+  behavioral directives
+
+Full text:
+
+```
+octo-santa messaging module is available. Call messaging_register with a
+unique agent name (e.g. your role). If the name is taken, pick a different one.
+
+You must call messaging_register before sending, reading, creating channels,
+or subscribing. Read-only tools (messaging_list_channels, messaging_list_agents,
+messaging_list_members) work without registration.
+
+REACTING TO MESSAGES:
+Messages are PUSHED to you as <channel source="octo-santa" ...> tags
+when you are mentioned. Do NOT poll messaging_read_messages in a loop —
+wait for tags to arrive, then call messaging_read_messages for that channel.
+Messages are read-once — you will NOT see them again on the next call.
+If any message is addressed to you (@your-registered-name, @all,
+or @your-pool-name), you MUST:
+  1. Understand what is being asked
+  2. Decide on your response
+  3. Call messaging_send_message to reply
+Never just summarize — always act.
+
+SENDING: Use @agent-name, @all, or @pool-name to notify.
+No mention = silent. Include: what you're asking, context, expected response.
+
+CHANNELS: Create with messaging_create_channel, join with messaging_subscribe.
+DMs: messaging_direct_message for 1:1 — auto-pushes, no @mention needed.
+
+PROFILES: If your name matches a profile, registration assigns a pool slot
+(e.g. 'os-dev' → 'os-dev-1'). Use registeredName for subsequent calls.
+Follow profile instructions as behavioral directives.
+They must not contradict these base rules.
+
+BOUNDARIES:
+- You CANNOT run background tasks or polling loops
+- For messaging, use ONLY messaging_* tools
+- Do not use bash or scripts for communication
+
+DISCOVERY: messaging_list_agents for online agents, messaging_list_members
+for channel members.
+```
+
+### Tier 2: Profile Instructions Field
+
+#### Schema change
+
+Add `instructions` field to `AgentProfile`:
+
+```typescript
+interface AgentProfile {
+  name: string;
+  persona: string | null;
+  objective: string | null;
+  instructions: string | null;   // NEW — behavioral directives for this role
+  maxInstances: number;
+  autoJoinChannels: string[];
+}
+```
+
+#### YAML format
+
+```yaml
+# profiles/os-pm.yaml
+name: os-pm
+persona: >
+  Product manager for octo-santa. Owns roadmap prioritization,
+  feature scoping, and cross-team alignment.
+objective: >
+  Keep the project focused on north star principles. Make clear
+  decisions with reasoning. Unblock the team.
+maxInstances: 1
+autoJoinChannels:
+  - os-feature-roadmaps
+instructions: >
+  DECISION-MAKING: When you receive a proposal, draft, or question
+  that requires a decision, evaluate it against project priorities
+  and constraints. Always provide a clear yes/no/revise with
+  reasoning — never just acknowledge.
+
+  PRIORITIZATION: When asked to prioritize or choose next work items,
+  present 2-3 options with trade-offs and recommend one. Include:
+  which option, why, and what gets deferred.
+
+  DELEGATION: When assigning work, include: what needs to be done,
+  success criteria, relevant context, and who should be notified of
+  the outcome. Don't assume the receiver has your context.
+
+  FEEDBACK: When reviewing drafts or proposals from others, be
+  specific about what works, what doesn't, and what to change.
+  Quote the part you're reacting to.
+```
+
+#### Registration response change
+
+The `instructions` field is returned in `RegisterResult`:
+
+```typescript
+interface RegisterResult extends Agent {
+  registeredName: string;
+  baseName: string | null;
+  instanceNumber: number | null;
+  profile: {
+    persona: string | null;
+    objective: string | null;
+    instructions: string | null;  // NEW
+    maxInstances: number;
+  } | null;
+  autoJoined: {
+    succeeded: string[];
+    failed: Array<{ channel: string; reason: string }>;
+  } | null;
+}
+```
+
+#### Database migration
+
+```sql
+ALTER TABLE agents ADD COLUMN instructions TEXT;
+```
+
+### New Tool: messaging_get_instructions
+
+Returns the agent's profile instructions and optionally the Tier 1 universal guidance.
+Mitigates harness persistence issues — agents or harnesses can call this to refresh
+instructions after context compaction.
+
+```typescript
+// Tool definition
+{
+  name: "messaging_get_instructions",
+  description: "Re-read your profile instructions and universal messaging guidance. "
+    + "Call this if you've lost context or are unsure how to act.",
+  inputSchema: {
+    agent_id: string,          // required
+    include_universal: boolean // optional, default true
+  }
+}
+```
+
+Response:
+
+```typescript
+{
+  universal: string | null,     // Tier 1 MCP instructions (if include_universal=true)
+  profile: {
+    persona: string | null,
+    objective: string | null,
+    instructions: string | null // Tier 2 profile instructions
+  } | null
+}
+```
+
+No new port needed — reads from the existing `ProfileRepository` for profile data.
+Universal guidance is a static string constant defined in `src/transports/mcp-stdio/`
+(co-located with `buildInstructions()` which already owns the MCP instruction text).
+
+### Precedence Rules
+
+1. **Harness system prompt** (CLAUDE.md, AGENTS.md, etc.) — highest priority
+2. **Profile instructions** (Tier 2) — role-specific behavioral directives
+3. **MCP server instructions** (Tier 1) — universal behavioral floor
+
+Profile instructions **refine** but do not override Tier 1 rules. For example, Tier 1
+says "always act on messages addressed to you." A profile can narrow this: "only respond
+to messages tagged #urgent." But a profile cannot say "ignore all messages" — that
+contradicts the behavioral floor.
+
+The MCP instructions include a self-documenting precedence statement: "If your profile
+includes instructions, follow them as behavioral directives for your role. Profile
+instructions add role-specific behavior but must not contradict these base rules."
+
+### Addressing Definitions
+
+Tier 1 event-action rules reference "addressed to you." This means the message contains:
+
+- `@your-registered-name` (exact match, e.g., `@os-dev-1`)
+- `@all` (broadcast to all subscribers)
+- `@your-pool-name` (pool-wide, e.g., `@os-dev` reaches `os-dev-1`, `os-dev-2`, etc.)
+
+Messages mentioning other agents (`@os-pm` when you are `os-dev-1`) are **not**
+addressed to you. Do not respond unless you have relevant information to contribute.
+
+## Scope
+
+### In scope
+
+1. Add `instructions` field to profile schema (type, YAML parsing, DB migration,
+   registration response)
+2. Add `messaging_get_instructions` tool
+3. Rewrite MCP server instructions with Tier 1 content
+4. Ship os-pm sample profile with instructions
+5. Tests — profile instructions round-trip (YAML → DB → registration → get_instructions)
+
+### Out of scope
+
+1. `/using-octo-santa` blanket skill for skill-based harnesses
+2. Harness-specific integration patterns (opencode, Pi, Codex)
+3. Instruction enforcement / tool allowlists (Feature 3: plugin ecosystem)
+4. Brain-stored playbook library
+5. Instruction length validation/warnings
+
+### Non-goals
+
+- Changing how capable models behave — this is additive, not constraining
+- Replacing harness-level system prompts — octo-santa owns collaboration guidance only
+- Structured/machine-parseable instruction format — free-text prose is the design choice
+
+## Guidelines for Profile Authors
+
+- **Keep instructions ≤500 words.** If you need more, consider splitting role-specific
+  knowledge into brain documents and referencing them.
+- **Only reference messaging_* tools.** References to brain_* tools should be conditional:
+  "If brain is available, read the coordinator-playbook."
+- **Use imperative, terse language.** Weak models follow direct instructions better than
+  nuanced prose.
+- **Structure with labeled sections.** E.g., "DECISION-MAKING:", "DELEGATION:". This
+  helps weak models locate relevant guidance.
+- **Don't duplicate Tier 1 rules.** The universal guidance already covers event-action
+  rules, tool scoping, and boundaries. Profile instructions handle role-specific behavior.
+
+## Validation
+
+### Automated tests (required before merge)
+
+- Profile instructions round-trip: YAML → DB → registration response → getInstructions
+- `messaging_get_instructions` tool: profiled agent, unprofiled agent, include_universal toggle, binding enforcement
+- `buildInstructions` byte budget: must stay under 2KB with and without brain config
+- `buildInstructions` content: REACTING TO MESSAGES, BOUNDARIES, BRAIN, precedence statement
+
+### Transcript replay test (planned follow-up)
+
+The os-pm sample profile should resolve three of four transcript failures when used with
+Tier 1 instructions (Scenario 3 is only partially mitigated without an os-tl profile):
+
+1. **Polling spiral** — RESOLVED. Tier 1 BOUNDARIES section eliminates bash/script consideration
+2. **No action on messages** — RESOLVED. Tier 1 REACTING TO MESSAGES MUST-act rule + Tier 2
+   DECISION-MAKING directive
+3. **Bare directive messages** — PARTIALLY MITIGATED. Tier 1 SENDING message quality
+   guidance helps, but full resolution requires an os-tl profile with DELEGATION instructions
+   (sender-side guidance). This spec ships os-pm only; os-tl is a follow-up.
+4. **Double-read confusion** — RESOLVED. Tier 1 read-once semantics explanation
+
+**Known residual risk:** The failure analysis identifies state-tracking guidance ("before
+each action, review your recent message history") as a gap. This is intentionally omitted
+from v1 — it requires harness-level support for context persistence, which is out of scope.
+
+### Cross-harness test (planned follow-up)
+
+Profile instructions delivered via `messaging_register` response should be visible in
+conversation history on Claude Code, opencode, and any MCP-compatible harness. This is
+a manual validation step, not an automated test.
+
+## Analysis
+
+Full failure analysis and permutation evaluation available in:
+- `docs/analysis/2026-04-13-less-capable-agent-failure-analysis.md`
+- `docs/analysis/2026-04-13-approach1-permutation-evaluation.md`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "octo-santa",
   "description": "Local-first agent collaboration framework — messaging, channels, and an interactive REPL, all backed by SQLite",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "module": "src/main.ts",
   "type": "module",
   "scripts": {

--- a/scripts/smoke-non-push.ts
+++ b/scripts/smoke-non-push.ts
@@ -1,0 +1,189 @@
+// scripts/smoke-non-push.ts
+//
+// Non-push MCP client smoke test (Phase 1 success criterion #4).
+//
+// Spawns two real MCP stdio server processes (sharing a temp SQLite DB) and
+// drives them as if from a non-push client — using messaging_listen in place
+// of pushed <channel> tags. Verifies the inline-delivery listen-poll flow:
+//
+//   1. register as os-listen-tester
+//   2. subscribe to a test channel
+//   3. messaging_listen (5s timeout) with no traffic  → timed_out: true
+//   4. second process sends a message to the channel
+//   5. messaging_listen again                          → channels non-empty,
+//      messages arrive inline under channels[].messages (no follow-up
+//      messaging_read_messages needed). A subsequent messaging_listen
+//      times out, proving the cursor advanced and the same batch is not
+//      re-served.
+//
+// Run: bun run scripts/smoke-non-push.ts
+// Exit code 0 on success, 1 on failure.
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import pkg from "../package.json";
+
+function log(step: string, msg: string): void {
+  console.log(`[${step}] ${msg}`);
+}
+
+async function connect(clientName: string, dbPath: string): Promise<Client> {
+  const transport = new StdioClientTransport({
+    command: "bun",
+    args: ["run", "src/main.ts"],
+    env: {
+      ...(process.env as Record<string, string>),
+      OCTO_SANTA_DB: dbPath,
+    },
+  });
+  const client = new Client(
+    { name: clientName, version: "0.0.0-smoke" },
+    { capabilities: {} }
+  );
+  await client.connect(transport);
+  return client;
+}
+
+async function callJson<T = unknown>(
+  client: Client,
+  name: string,
+  args: Record<string, unknown>
+): Promise<T> {
+  const res = await client.callTool({ name, arguments: args });
+  const content = res.content as Array<{ type: string; text?: string }> | undefined;
+  const text = content?.[0]?.text ?? "{}";
+  if (res.isError) {
+    throw new Error(`${name} tool error: ${text}`);
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch (err) {
+    throw new Error(`${name} response not JSON: ${text.slice(0, 200)}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const tmp = mkdtempSync(join(tmpdir(), "octo-santa-smoke-"));
+  const dbPath = join(tmp, "messages.db");
+  log("version", `octo-santa ${pkg.version} (db: ${dbPath})`);
+
+  let tester: Client | null = null;
+  let sender: Client | null = null;
+  try {
+    tester = await connect("smoke-tester", dbPath);
+    sender = await connect("smoke-sender", dbPath);
+
+    // Confirm the server instructions text advertises the non-push loop.
+    const instr = tester.getInstructions() ?? "";
+    const bytes = Buffer.byteLength(instr, "utf-8");
+    if (!instr.includes("NON-PUSH CLIENTS")) {
+      throw new Error(
+        `instructions missing NON-PUSH CLIENTS block (got ${bytes} B)`
+      );
+    }
+    log("instructions", `${bytes} B, NON-PUSH CLIENTS block present`);
+
+    // Step 1: register
+    const reg = await callJson<{ registeredName: string }>(
+      tester,
+      "messaging_register",
+      { agent_id: "os-listen-tester" }
+    );
+    log("step1", `registered as ${reg.registeredName}`);
+
+    await callJson(sender, "messaging_register", { agent_id: "os-listen-sender" });
+
+    // Step 2: subscribe to test channel (sender creates, tester subscribes)
+    await callJson(sender, "messaging_create_channel", {
+      agent_id: "os-listen-sender",
+      name: "smoke-listen",
+    });
+    await callJson(tester, "messaging_subscribe", {
+      agent_id: "os-listen-tester",
+      channel: "smoke-listen",
+    });
+    log("step2", "subscribed os-listen-tester to smoke-listen");
+
+    // Step 3: listen with no traffic → timed_out
+    const t0 = Date.now();
+    const idle = await callJson<{ channels: unknown[]; timed_out: boolean }>(
+      tester,
+      "messaging_listen",
+      { agent_id: "os-listen-tester", timeout_ms: 5000 }
+    );
+    const idleDt = Date.now() - t0;
+    if (!idle.timed_out || idle.channels.length !== 0) {
+      throw new Error(
+        `step3 expected timed_out:true, channels:[]; got ${JSON.stringify(idle)}`
+      );
+    }
+    log("step3", `listen timed out after ${idleDt}ms, channels=[]`);
+
+    // Step 4: sender sends a message to the channel
+    const sent = await callJson<{ id: number }>(sender, "messaging_send_message", {
+      agent_id: "os-listen-sender",
+      channel: "smoke-listen",
+      content: "hello from non-push smoke test @os-listen-tester",
+    });
+    log("step4", `sender posted message id=${sent.id}`);
+
+    // Step 5a: listen again → channel entry with the message INLINE (no
+    // separate messaging_read_messages call needed; that is the steady-state
+    // non-push contract after os-pm's decision A on msg 1807).
+    const t1 = Date.now();
+    const hit = await callJson<{
+      channels: Array<{ channel: string; messages: Array<{ id: number; content: string }> }>;
+      timed_out: boolean;
+    }>(tester, "messaging_listen", { agent_id: "os-listen-tester", timeout_ms: 5000 });
+    const hitDt = Date.now() - t1;
+    const smoke = hit.channels.find((c) => c.channel === "smoke-listen");
+    if (hit.timed_out || !smoke) {
+      throw new Error(
+        `step5 expected smoke-listen in channels; got ${JSON.stringify(hit)}`
+      );
+    }
+    const inline = smoke.messages ?? [];
+    if (inline.length === 0 || inline[0]!.id !== sent.id) {
+      throw new Error(
+        `step5 expected inline message id=${sent.id}; got ${JSON.stringify(inline)}`
+      );
+    }
+    log(
+      "step5a",
+      `listen returned after ${hitDt}ms: inline ${inline.length} message(s) on smoke-listen (id=${inline[0]!.id})`
+    );
+
+    // Step 5b: cursor-advance proof — subsequent listen must time out because
+    // the previous listen already consumed the unread batch.
+    const t2 = Date.now();
+    const drained = await callJson<{ channels: unknown[]; timed_out: boolean }>(
+      tester,
+      "messaging_listen",
+      { agent_id: "os-listen-tester", timeout_ms: 3000 }
+    );
+    const drainDt = Date.now() - t2;
+    if (!drained.timed_out || drained.channels.length !== 0) {
+      throw new Error(
+        `step5b expected timed_out:true, channels:[] (cursor should have advanced); got ${JSON.stringify(drained)}`
+      );
+    }
+    log(
+      "step5b",
+      `cursor proof: follow-up listen timed out after ${drainDt}ms (inline batch not re-served)`
+    );
+
+    console.log("\n✓ non-push smoke test passed — Phase 1 criterion #4 verified");
+  } finally {
+    await tester?.close().catch(() => {});
+    await sender?.close().catch(() => {});
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+main().catch((err) => {
+  console.error("✗ non-push smoke test failed:", err);
+  process.exit(1);
+});

--- a/src/bin/repl.ts
+++ b/src/bin/repl.ts
@@ -5,6 +5,7 @@ import { createSqliteRepos } from "../storage/sqlite";
 import { MessagingService } from "../core/messaging/service";
 import { startApp } from "../transports/repl/app";
 import { startupRepl } from "../transports/repl/startup";
+import { YamlProfileStore } from "../storage/yaml-profiles/store";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -31,13 +32,15 @@ const dbPath = expandHome(process.env.OCTO_SANTA_DB ?? join(homedir(), ".octo-sa
 const db = createDb(dbPath);
 runMigrations(db, allMigrations);
 const repos = createSqliteRepos(db);
-const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid);
+const profilesDir = expandHome(process.env.OCTO_SANTA_PROFILES_DIR ?? "~/.octo-santa/profiles");
+const profiles = new YamlProfileStore(profilesDir);
+const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid, undefined, profiles);
 
-startupRepl(svc, agentId, channel);
+const resolvedName = startupRepl(svc, agentId, channel);
 
 const pollIntervalMs = Number(process.env.OCTO_SANTA_POLL_INTERVAL_MS) || 1000;
 const kittyTerminals = new Set(["ghostty", "WezTerm", "iTerm2", "kitty"]);
 const termProgram = process.env.TERM_PROGRAM ?? "";
 const kittyEnabled = kittyTerminals.has(termProgram) || process.env.OCTO_SANTA_KITTY === "1";
 
-startApp({ svc, channelRepo: repos.channels, agentId, channel, pollIntervalMs, kittyEnabled });
+startApp({ svc, channelRepo: repos.channels, agentId: resolvedName, channel, pollIntervalMs, kittyEnabled });

--- a/src/core/messaging/service.ts
+++ b/src/core/messaging/service.ts
@@ -12,6 +12,8 @@ import type {
   Message,
   ReadOptions,
   UnreadResult,
+  SendOptions,
+  ContinueResult,
 } from "./types";
 import type { RegisterResult, AutoJoinResult } from "../profiles/types";
 import {
@@ -180,10 +182,13 @@ export class MessagingService {
     this.agents.clearPid(agentId, this.pid);
   }
 
-  createChannel(agentId: string, name: string): Channel {
+  createChannel(agentId: string, name: string, maxHops?: number): Channel {
     if (!name.trim()) throw new Error("channel name must not be empty");
+    if (maxHops !== undefined && maxHops < 1) {
+      throw new Error("maxHops must be at least 1");
+    }
     this.requireRegistered(agentId);
-    return this.channels.create(name, agentId);
+    return this.channels.create(name, agentId, maxHops);
   }
 
   subscribe(agentId: string, channelName: string): void {
@@ -194,7 +199,7 @@ export class MessagingService {
     this.channels.addMember(agentId, channel.id, 0);
   }
 
-  send(agentId: string, channelName: string, content: string): Message {
+  send(agentId: string, channelName: string, content: string, options?: SendOptions): Message {
     if (!content.trim()) throw new Error("message content must not be empty");
     this.requireRegistered(agentId);
     assertDmAccess(channelName, agentId);
@@ -207,6 +212,26 @@ export class MessagingService {
     const allAgents = this.agents.listAll();
     const validIds = allAgents.map((a) => a.id);
     const mentions = extractMentions(content, validIds, this.profiles?.getBaseNames());
+    if (mentions.includes(agentId)) throw new Error("Cannot @mention yourself in a message");
+
+    // Hop counter logic
+    if (options?.human) {
+      this.channels.resetHopCount(channel.id);
+    } else {
+      const hop = this.channels.checkAndIncrementHop(channel.id);
+      if (!hop.allowed) {
+        if (!this.hasRecentHopNotice(channel.id)) {
+          this.sendSystemNotice(
+            channel,
+            `hop limit reached (${hop.hopCount}/${hop.maxHops}) in #${channelName} -- message from @${agentId} blocked. Waiting for human input.`
+          );
+        }
+        throw new Error(
+          `Hop limit reached (${hop.hopCount}/${hop.maxHops}) in #${channelName}. Message dropped. Only a human can /continue.`
+        );
+      }
+    }
+
     const message = this.messages.insertAndJoinSender(
       channel.id,
       agentId,
@@ -310,6 +335,22 @@ export class MessagingService {
     const allAgents = this.agents.listAll();
     const validIds = allAgents.map((a) => a.id);
     const mentions = extractMentions(content, validIds, this.profiles?.getBaseNames());
+    if (mentions.includes(agentId)) throw new Error("Cannot @mention yourself in a message");
+
+    // Hop counter logic for DMs (always agent, no human option)
+    const hopResult = this.channels.checkAndIncrementHop(channel.id);
+    if (!hopResult.allowed) {
+      if (!this.hasRecentHopNotice(channel.id)) {
+        this.sendSystemNotice(
+          channel,
+          `hop limit reached (${hopResult.hopCount}/${hopResult.maxHops}) in #${channelName} -- message from @${agentId} blocked. Waiting for human input.`
+        );
+      }
+      throw new Error(
+        `Hop limit reached (${hopResult.hopCount}/${hopResult.maxHops}) in #${channelName}. Message dropped. Only a human can /continue.`
+      );
+    }
+
     const message = this.messages.insertAndJoinSender(
       channel.id,
       agentId,
@@ -329,6 +370,56 @@ export class MessagingService {
     }
 
     return message;
+  }
+
+  /**
+   * Best-effort dedup for hop-limit `_system` notices.
+   *
+   * **Race window accepted by design.** This read sits OUTSIDE the
+   * checkAndIncrementHop transaction, so under concurrent multi-agent load
+   * (N processes hitting the limit simultaneously) up to N duplicate notices
+   * may be emitted. That is the intended trade-off:
+   *
+   *   (a) The dedup-inside-txn alternative would serialize the increment hot
+   *       path. Hop checks happen on every send; serializing them under load
+   *       is a correctness win for dedup but a throughput cliff for messaging.
+   *   (b) Downstream consumers (REPL display, future Slack mirror, audit log)
+   *       must already tolerate duplicate messages from at-least-once delivery
+   *       semantics — duplicate hop notices are a strict subset of that
+   *       tolerance requirement.
+   *   (c) Noise is bounded: max(duplicates) === count(concurrent listening
+   *       processes hitting the limit at the same instant). Once the limit is
+   *       hit, subsequent sends are blocked and stop emitting notices, so the
+   *       fan-out self-resolves within one increment cycle.
+   *
+   * If the empirical fan-out is ever observed > ~3 duplicates in production,
+   * revisit by either (i) moving dedup into the increment transaction, or
+   * (ii) adding an INSERT … WHERE NOT EXISTS guard at the storage layer.
+   */
+  private hasRecentHopNotice(channelId: number): boolean {
+    const recent = this.messages.readRecent(channelId, 1);
+    return recent.length > 0
+      && recent[0]!.agent_id === '_system'
+      && recent[0]!.content.startsWith('hop limit reached');
+  }
+
+  private sendSystemNotice(channel: Channel, content: string): void {
+    const message = this.messages.insertAndJoinSender(channel.id, '_system', content, ['*']);
+
+    if (this.dispatch) {
+      const members = this.channels.getMembers(channel.id);
+      const targetAgents = members.map((m) => m.id).filter((id) => id !== '_system');
+      if (targetAgents.length > 0) {
+        this.dispatch.dispatch({
+          channelName: channel.name,
+          sender: '_system',
+          content,
+          messageId: message.id,
+          isDm: isDmChannel(channel.name),
+          targetAgents,
+        });
+      }
+    }
   }
 
   renameChannel(
@@ -395,6 +486,37 @@ export class MessagingService {
         instructions: agent.instructions,
       },
     };
+  }
+
+  /**
+   * Bump a channel's hop allowance to resume after a hop-limit block.
+   *
+   * **Human-only / transport-restricted.** This method MUST only be invoked
+   * from a transport that enforces the human-source invariant by construction.
+   * The REPL `/continue` command is the canonical surface; the future `ocs
+   * continue` CLI subcommand will be the second.
+   *
+   * Do NOT expose this method via any MCP tool, RPC endpoint, HTTP handler, or
+   * other agent-callable interface. Agents bypassing this restriction would
+   * defeat the safety-rails design — they could indefinitely extend their own
+   * hop budget. The original `messaging_continue` MCP tool was removed for
+   * exactly this reason; see `tests/hex/transports/no-messaging-continue-tool.test.ts`
+   * and `tests/hex/core/continue-channel-transport-boundary.test.ts` for the
+   * regression guards.
+   *
+   * Enforcement is by transport boundary, not by code-level role check. Adding
+   * a check here is impractical — the core has no concept of "human" beyond the
+   * `SendOptions.human` flag, which is itself transport-set. The contract is:
+   * if you wire a new transport, you are responsible for ensuring this method
+   * is invoked only from a human-driven code path.
+   */
+  continueChannel(agentId: string, channelName: string, amount: number = 4): ContinueResult {
+    this.requireRegistered(agentId);
+    if (amount < 1) throw new Error("amount must be at least 1");
+    const channel = this.channels.findByName(channelName);
+    if (!channel) throw new Error(`Channel "${channelName}" not found`);
+    const result = this.channels.bumpHopAllowance(channel.id, amount);
+    return { channel: channelName, hopCount: result.hopCount, maxHops: result.maxHops, bumped: amount };
   }
 
   readRecent(channelId: number, limit: number): Message[] {

--- a/src/core/messaging/service.ts
+++ b/src/core/messaging/service.ts
@@ -4,6 +4,7 @@ import type {
   MessageRepository,
   CursorRepository,
   NotificationDispatch,
+  ProfileRepository,
 } from "../ports";
 import type {
   Agent,
@@ -11,6 +12,7 @@ import type {
   Message,
   ReadOptions,
 } from "./types";
+import type { RegisterResult, AutoJoinResult } from "../profiles/types";
 import {
   validateAgentName,
   assertDmAccess,
@@ -26,7 +28,8 @@ export class MessagingService {
     private readonly messages: MessageRepository,
     private readonly cursors: CursorRepository,
     private readonly pid: number,
-    private readonly dispatch?: NotificationDispatch
+    private readonly dispatch?: NotificationDispatch,
+    private readonly profiles?: ProfileRepository
   ) {}
 
   private requireRegistered(agentId: string): void {
@@ -69,7 +72,24 @@ export class MessagingService {
 
     const members = this.channels.getMembers(channelId);
     const memberIds = new Set(members.map((m) => m.id));
-    const targetAgents = mentions.filter(
+    const baseNames = this.profiles?.getBaseNames();
+
+    const expandedTargets = new Set<string>();
+    for (const mention of mentions) {
+      if (baseNames?.has(mention)) {
+        // Expand base-name mention to live instances
+        const instances = this.agents.findByBaseName(mention);
+        for (const inst of instances) {
+          if (isAgentActive(inst)) {
+            expandedTargets.add(inst.id);
+          }
+        }
+      } else {
+        expandedTargets.add(mention);
+      }
+    }
+
+    const targetAgents = [...expandedTargets].filter(
       (id) => id !== senderId && memberIds.has(id)
     );
     return { targetAgents, isDm: false };
@@ -87,9 +107,72 @@ export class MessagingService {
     return memberIds.has(match[1]!) && memberIds.has(match[2]!);
   }
 
-  register(agentId: string): Agent {
+  register(agentId: string): RegisterResult {
     validateAgentName(agentId);
-    return this.agents.register(agentId, this.pid);
+
+    // (1) Exact profile match → delegate to agents.registerWithProfile()
+    const profile = this.profiles?.getProfile(agentId) ?? null;
+    if (profile) {
+      const { agent, registeredName, instanceNumber } = this.agents.registerWithProfile(
+        profile.name,
+        this.pid,
+        profile.maxInstances,
+        { persona: profile.persona, objective: profile.objective, instructions: profile.instructions }
+      );
+      const autoJoined = this.performAutoJoin(registeredName, profile.autoJoinChannels);
+      return {
+        ...agent,
+        registeredName,
+        baseName: profile.name,
+        instanceNumber,
+        profile: {
+          persona: profile.persona,
+          objective: profile.objective,
+          instructions: profile.instructions,
+          maxInstances: profile.maxInstances,
+        },
+        autoJoined,
+      };
+    }
+
+    // (2) Suffixed namespace reservation: name matches {base}-\d+ for existing profile → reject
+    if (this.profiles) {
+      const match = /^(.+)-(\d+)$/.exec(agentId);
+      if (match) {
+        const baseName = match[1]!;
+        const existingProfile = this.profiles.getProfile(baseName);
+        if (existingProfile) {
+          throw new Error(
+            `Name "${agentId}" is reserved by pool profile "${baseName}". Register as "${baseName}" to join the pool.`
+          );
+        }
+      }
+    }
+
+    // (3) No match → current behavior
+    const agent = this.agents.register(agentId, this.pid);
+    return {
+      ...agent,
+      registeredName: agentId,
+      baseName: null,
+      instanceNumber: null,
+      profile: null,
+      autoJoined: null,
+    };
+  }
+
+  private performAutoJoin(agentId: string, channels: string[]): AutoJoinResult {
+    const succeeded: string[] = [];
+    const failed: Array<{ channel: string; reason: string }> = [];
+    for (const channelName of channels) {
+      try {
+        this.subscribe(agentId, channelName);
+        succeeded.push(channelName);
+      } catch (err) {
+        failed.push({ channel: channelName, reason: String(err) });
+      }
+    }
+    return { succeeded, failed };
   }
 
   unregister(agentId: string): void {
@@ -122,7 +205,7 @@ export class MessagingService {
     }
     const allAgents = this.agents.listAll();
     const validIds = allAgents.map((a) => a.id);
-    const mentions = extractMentions(content, validIds);
+    const mentions = extractMentions(content, validIds, this.profiles?.getBaseNames());
     const message = this.messages.insertAndJoinSender(
       channel.id,
       agentId,
@@ -209,7 +292,7 @@ export class MessagingService {
 
     const allAgents = this.agents.listAll();
     const validIds = allAgents.map((a) => a.id);
-    const mentions = extractMentions(content, validIds);
+    const mentions = extractMentions(content, validIds, this.profiles?.getBaseNames());
     const message = this.messages.insertAndJoinSender(
       channel.id,
       agentId,
@@ -271,6 +354,30 @@ export class MessagingService {
       agent_id: agent.id,
       active: isAgentActive(agent),
     }));
+  }
+
+  getInstructions(agentId: string): {
+    universal: string | null;
+    profile: { persona: string | null; objective: string | null; instructions: string | null } | null;
+  } {
+    this.requireRegistered(agentId);
+    const agent = this.agents.findById(agentId);
+    if (!agent) return { universal: null, profile: null };
+
+    // Read from persisted DB data, not live YAML — instructions are
+    // snapshotted at registration time and should not change mid-session.
+    if (!agent.base_name) {
+      return { universal: null, profile: null };
+    }
+
+    return {
+      universal: null, // Populated by the transport layer (adapter owns the text)
+      profile: {
+        persona: agent.persona,
+        objective: agent.objective,
+        instructions: agent.instructions,
+      },
+    };
   }
 
   readRecent(channelId: number, limit: number): Message[] {

--- a/src/core/messaging/service.ts
+++ b/src/core/messaging/service.ts
@@ -11,6 +11,7 @@ import type {
   Channel,
   Message,
   ReadOptions,
+  UnreadResult,
 } from "./types";
 import type { RegisterResult, AutoJoinResult } from "../profiles/types";
 import {
@@ -262,6 +263,22 @@ export class MessagingService {
       channel.id,
       opts?.limit ?? 100
     );
+  }
+
+  readAllUnread(agentId: string): UnreadResult[] {
+    this.requireRegistered(agentId);
+    const cursorList = this.cursors.listForAgent(agentId);
+    const results: UnreadResult[] = [];
+    for (const cursor of cursorList) {
+      const messages = this.messages.readForwardAndAdvance(agentId, cursor.channelId, 100);
+      if (messages.length === 0) continue;
+      results.push({
+        channel: cursor.channelName,
+        messages,
+        is_dm: isDmChannel(cursor.channelName),
+      });
+    }
+    return results;
   }
 
   /**

--- a/src/core/messaging/types.ts
+++ b/src/core/messaging/types.ts
@@ -16,6 +16,25 @@ export interface Channel {
   name: string;
   created_by: string;
   created_at: number;
+  max_hops: number;
+  hop_count: number;
+}
+
+export interface HopCheckResult {
+  allowed: boolean;
+  hopCount: number;
+  maxHops: number;
+}
+
+export interface SendOptions {
+  human?: boolean;
+}
+
+export interface ContinueResult {
+  channel: string;
+  hopCount: number;
+  maxHops: number;
+  bumped: number;
 }
 
 export interface Message {

--- a/src/core/messaging/types.ts
+++ b/src/core/messaging/types.ts
@@ -4,6 +4,11 @@ export interface Agent {
   last_seen_at: number;
   pid: number | null;
   registered_at: number | null;
+  // New nullable fields (added for persistent agent profiles)
+  base_name: string | null;
+  persona: string | null;
+  objective: string | null;
+  instructions: string | null;
 }
 
 export interface Channel {

--- a/src/core/messaging/types.ts
+++ b/src/core/messaging/types.ts
@@ -44,3 +44,9 @@ export interface CursorWithChannel {
 }
 
 export type HeartbeatResult = "ok" | "lost";
+
+export interface UnreadResult {
+  channel: string;
+  messages: Message[];
+  is_dm: boolean;
+}

--- a/src/core/ports.ts
+++ b/src/core/ports.ts
@@ -5,6 +5,7 @@ import type {
   Message,
   CursorWithChannel,
   HeartbeatResult,
+  HopCheckResult,
 } from "./messaging/types";
 import type { BrainDoc, DomainWithClaims } from "./brain/types";
 import type { AgentProfile } from "./profiles/types";
@@ -36,7 +37,7 @@ export interface ProfileRepository {
 
 export interface ChannelRepository {
   findByName(name: string): Channel | null;
-  create(name: string, createdBy: string): Channel;
+  create(name: string, createdBy: string, maxHops?: number): Channel;
   list(): Channel[];
   addMember(agentId: string, channelId: number, initialCursorId: number): void;
   getMembers(channelId: number): Agent[];
@@ -46,6 +47,9 @@ export interface ChannelRepository {
     newName: string,
     agentId: string
   ): Channel;
+  checkAndIncrementHop(channelId: number): HopCheckResult;
+  resetHopCount(channelId: number): void;
+  bumpHopAllowance(channelId: number, amount: number): HopCheckResult;
 }
 
 export interface MessageRepository {

--- a/src/core/ports.ts
+++ b/src/core/ports.ts
@@ -7,15 +7,31 @@ import type {
   HeartbeatResult,
 } from "./messaging/types";
 import type { BrainDoc, DomainWithClaims } from "./brain/types";
+import type { AgentProfile } from "./profiles/types";
 
 // --- Storage ports (core defines, adapters implement) ---
 
 export interface AgentRepository {
   findById(id: string): Agent | null;
-  register(agentId: string, pid: number): Agent;
+  register(agentId: string, pid: number, profileFields?: {
+    baseName: string; persona: string | null; objective: string | null; instructions: string | null;
+  }): Agent;
   heartbeatOrReclaim(agentId: string, pid: number): HeartbeatResult;
   listAll(): Agent[];
   clearPid(id: string, expectedPid: number): void;
+  findByBaseName(baseName: string): Agent[];
+  registerWithProfile(
+    baseName: string,
+    pid: number,
+    maxInstances: number,
+    profileFields: { persona: string | null; objective: string | null; instructions: string | null }
+  ): { agent: Agent; registeredName: string; instanceNumber: number | null };
+}
+
+export interface ProfileRepository {
+  getProfile(baseName: string): AgentProfile | null;
+  listProfiles(): AgentProfile[];
+  getBaseNames(): Set<string>;
 }
 
 export interface ChannelRepository {

--- a/src/core/profiles/types.ts
+++ b/src/core/profiles/types.ts
@@ -1,0 +1,28 @@
+import type { Agent } from "../messaging/types";
+
+export interface AgentProfile {
+  name: string;          // base name
+  persona: string | null;
+  objective: string | null;
+  instructions: string | null;
+  maxInstances: number;  // >= 1
+  autoJoinChannels: string[];
+}
+
+export interface AutoJoinResult {
+  succeeded: string[];
+  failed: Array<{ channel: string; reason: string }>;
+}
+
+export interface RegisterResult extends Agent {
+  registeredName: string;
+  baseName: string | null;
+  instanceNumber: number | null;
+  profile: {
+    persona: string | null;
+    objective: string | null;
+    instructions: string | null;
+    maxInstances: number;
+  } | null;
+  autoJoined: AutoJoinResult | null;
+}

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -42,7 +42,8 @@ export function validateAgentName(agentId: string): void {
 
 export function extractMentions(
   content: string,
-  validAgentIds: string[]
+  validAgentIds: string[],
+  profileBaseNames?: Set<string>
 ): string[] {
   const matches = content.matchAll(MENTION_RE);
   const validSet = new Set(validAgentIds);
@@ -54,6 +55,10 @@ export function extractMentions(
     if (name === "all" || name === "here") {
       hasBroadcast = true;
     } else if (validSet.has(name)) {
+      // Direct agent ID — preferred over base name
+      result.add(name);
+    } else if (profileBaseNames?.has(name)) {
+      // Pool base name mention — stored as-is; expanded at dispatch time
       result.add(name);
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import { MessagingService } from "./core/messaging/service";
 import { BrainService } from "./core/brain/service";
 import { startMcpStdio } from "./transports/mcp-stdio/adapter";
 import { createNotificationDispatcher } from "./notifications/dispatch/dispatcher";
+import { YamlProfileStore } from "./storage/yaml-profiles/store";
 import { log } from "./log";
 
 function expandHome(p: string): string {
@@ -38,6 +39,12 @@ async function main() {
   // 4. Notification dispatcher
   const dispatcher = createNotificationDispatcher();
 
+  // 4b. Profile store
+  const profilesDir = expandHome(
+    process.env.OCTO_SANTA_PROFILES_DIR ?? "~/.octo-santa/profiles"
+  );
+  const profiles = new YamlProfileStore(profilesDir);
+
   // 5. Services
   const messaging = new MessagingService(
     repos.agents,
@@ -45,7 +52,8 @@ async function main() {
     repos.messages,
     repos.cursors,
     process.pid,
-    dispatcher
+    dispatcher,
+    profiles
   );
 
   const brain = new BrainService(
@@ -74,12 +82,13 @@ async function main() {
     registerNotificationHandler: dispatcher.register.bind(dispatcher),
     unregisterNotificationHandler: dispatcher.unregister.bind(dispatcher),
     agents: repos.agents,
-    startPoller: (port, agentId) => {
+    startPoller: (port, agentId, baseName) => {
       const poller = createNotificationPoller({
         getNewMessagesForAgent: notificationQueries.getNewMessagesForAgent.bind(notificationQueries),
         getMaxMessageId: notificationQueries.getMaxMessageId.bind(notificationQueries),
         port,
         agentId,
+        baseName,
       });
       poller.start();
       return poller;

--- a/src/notifications/poller/poller.ts
+++ b/src/notifications/poller/poller.ts
@@ -14,9 +14,10 @@ export function createNotificationPoller(opts: {
   getMaxMessageId: () => number;
   port: NotificationPort;
   agentId: string;
+  baseName?: string;
   intervalMs?: number;
 }): { start(): void; stop(): void; _tick(): Promise<void> } {
-  const { getNewMessagesForAgent, getMaxMessageId, port, agentId, intervalMs = 2000 } = opts;
+  const { getNewMessagesForAgent, getMaxMessageId, port, agentId, baseName, intervalMs = 2000 } = opts;
   let hwm = 0;
   let timer: ReturnType<typeof setInterval> | null = null;
 
@@ -50,7 +51,7 @@ export function createNotificationPoller(opts: {
     }
     try {
       const mentions: string[] = JSON.parse(mentionsJson);
-      return mentions.includes(agentId) || mentions.includes("*");
+      return mentions.includes(agentId) || (baseName != null && mentions.includes(baseName)) || mentions.includes("*");
     } catch {
       return false;
     }

--- a/src/storage/sqlite/agent-repo.ts
+++ b/src/storage/sqlite/agent-repo.ts
@@ -11,9 +11,62 @@ export class SqliteAgentRepo implements AgentRepository {
     return (this.db.query("SELECT * FROM agents WHERE id = ?").get(id) as Agent) ?? null;
   }
 
-  register(agentId: string, pid: number): Agent {
+  findByBaseName(baseName: string): Agent[] {
+    return this.db
+      .query("SELECT * FROM agents WHERE base_name = ? ORDER BY id")
+      .all(baseName) as Agent[];
+  }
+
+  /**
+   * Private helper: performs INSERT/ON CONFLICT upsert without wrapping in its own transaction.
+   * The caller (register or registerWithProfile) must wrap this in an EXCLUSIVE transaction.
+   * When profileFields is omitted, sets base_name/persona/objective to NULL (clears stale data).
+   */
+  private _upsertAgent(
+    agentId: string,
+    pid: number,
+    profileFields?: { baseName: string; persona: string | null; objective: string | null; instructions: string | null }
+  ): void {
+    const now = Date.now();
+    if (profileFields) {
+      this.db
+        .query(
+          `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective, instructions)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(id) DO UPDATE SET
+             last_seen_at = excluded.last_seen_at,
+             pid = excluded.pid,
+             registered_at = excluded.registered_at,
+             base_name = excluded.base_name,
+             persona = excluded.persona,
+             objective = excluded.objective,
+             instructions = excluded.instructions`
+        )
+        .run(agentId, now, now, pid, now, profileFields.baseName, profileFields.persona, profileFields.objective, profileFields.instructions);
+    } else {
+      this.db
+        .query(
+          `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective, instructions)
+           VALUES (?, ?, ?, ?, ?, NULL, NULL, NULL, NULL)
+           ON CONFLICT(id) DO UPDATE SET
+             last_seen_at = excluded.last_seen_at,
+             pid = excluded.pid,
+             registered_at = excluded.registered_at,
+             base_name = excluded.base_name,
+             persona = excluded.persona,
+             objective = excluded.objective,
+             instructions = excluded.instructions`
+        )
+        .run(agentId, now, now, pid, now);
+    }
+  }
+
+  register(
+    agentId: string,
+    pid: number,
+    profileFields?: { baseName: string; persona: string | null; objective: string | null; instructions: string | null }
+  ): Agent {
     const doRegister = this.db.transaction(() => {
-      const now = Date.now();
       const existing = this.findById(agentId);
 
       if (existing && existing.pid !== null && existing.pid !== pid) {
@@ -24,13 +77,90 @@ export class SqliteAgentRepo implements AgentRepository {
         }
       }
 
-      this.db.run(
-        `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at) VALUES (?, ?, ?, ?, ?)
-         ON CONFLICT(id) DO UPDATE SET last_seen_at = excluded.last_seen_at, pid = excluded.pid, registered_at = excluded.registered_at`,
-        [agentId, now, now, pid, now]
-      );
-
+      this._upsertAgent(agentId, pid, profileFields);
       return this.findById(agentId)!;
+    });
+
+    return withRetrySync(() => doRegister.exclusive());
+  }
+
+  registerWithProfile(
+    baseName: string,
+    pid: number,
+    maxInstances: number,
+    profileFields: { persona: string | null; objective: string | null; instructions: string | null }
+  ): { agent: Agent; registeredName: string; instanceNumber: number | null } {
+    const doRegister = this.db.transaction(() => {
+      const existing = this.findByBaseName(baseName);
+
+      // Same-PID idempotency: if this PID already owns a slot, return it
+      const ownedSlot = existing.find((a) => a.pid === pid);
+      if (ownedSlot) {
+        const instanceNumber =
+          maxInstances === 1 ? null : extractInstanceNumber(ownedSlot.id, baseName);
+        return {
+          agent: ownedSlot,
+          registeredName: ownedSlot.id,
+          instanceNumber,
+        };
+      }
+
+      if (maxInstances === 1) {
+        // Singleton: registered name equals base name
+        const current = existing[0] ?? null;
+        if (current && current.pid !== null && current.pid !== pid) {
+          if (isProcessAlive(current.pid) && Date.now() - current.last_seen_at <= PID_STALE_MS) {
+            throw new Error(
+              `Agent "${baseName}" is already active (pid ${current.pid}). Max instances: 1.`
+            );
+          }
+        }
+        this._upsertAgent(baseName, pid, { baseName, ...profileFields });
+        const agent = this.findById(baseName)!;
+        return { agent, registeredName: baseName, instanceNumber: null };
+      }
+
+      // Pool: scan existing slots to find dead ones or next available
+      const liveSlots = new Set<number>();
+      const deadSlots: Array<{ slot: number; agentId: string }> = [];
+
+      for (const a of existing) {
+        const slot = extractInstanceNumber(a.id, baseName);
+        if (slot === null) continue;
+        const isDead =
+          a.pid === null ||
+          !isProcessAlive(a.pid) ||
+          Date.now() - a.last_seen_at > PID_STALE_MS;
+        if (isDead) {
+          deadSlots.push({ slot, agentId: a.id });
+        } else {
+          liveSlots.add(slot);
+        }
+      }
+
+      // Prefer reclaiming the lowest dead slot; otherwise use next unused slot number
+      deadSlots.sort((a, b) => a.slot - b.slot);
+
+      let chosenSlot: number;
+      if (deadSlots.length > 0) {
+        chosenSlot = deadSlots[0]!.slot;
+      } else if (liveSlots.size < maxInstances) {
+        chosenSlot = 1;
+        while (liveSlots.has(chosenSlot)) chosenSlot++;
+      } else {
+        const activeList = existing
+          .filter((a) => a.pid !== null && isProcessAlive(a.pid) && Date.now() - a.last_seen_at <= PID_STALE_MS)
+          .map((a) => `${a.id} (pid ${a.pid})`)
+          .join(", ");
+        throw new Error(
+          `Agent pool "${baseName}" is at capacity (${maxInstances}/${maxInstances} instances). Active instances: ${activeList}`
+        );
+      }
+
+      const registeredName = `${baseName}-${chosenSlot}`;
+      this._upsertAgent(registeredName, pid, { baseName, ...profileFields });
+      const agent = this.findById(registeredName)!;
+      return { agent, registeredName, instanceNumber: chosenSlot };
     });
 
     return withRetrySync(() => doRegister.exclusive());
@@ -41,14 +171,11 @@ export class SqliteAgentRepo implements AgentRepository {
       const now = Date.now();
 
       // (1) Try UPDATE WHERE pid=? — happy path heartbeat
-      const result = this.db.run(
-        "UPDATE agents SET last_seen_at = ? WHERE id = ? AND pid = ?",
-        [now, agentId, pid]
-      );
+      const result = this.db
+        .query("UPDATE agents SET last_seen_at = ? WHERE id = ? AND pid = ?")
+        .run(now, agentId, pid);
 
-      if (result.changes > 0) {
-        return "ok";
-      }
+      if (result.changes > 0) return "ok";
 
       // (2) 0 rows updated — check current owner
       const current = this.findById(agentId);
@@ -64,10 +191,11 @@ export class SqliteAgentRepo implements AgentRepository {
       }
 
       // (3) Current owner is stale — CAS reclaim
-      const reclaim = this.db.run(
-        "UPDATE agents SET pid = ?, registered_at = ?, last_seen_at = ? WHERE id = ? AND pid = ?",
-        [pid, now, now, agentId, current.pid]
-      );
+      const reclaim = this.db
+        .query(
+          "UPDATE agents SET pid = ?, registered_at = ?, last_seen_at = ? WHERE id = ? AND pid = ?"
+        )
+        .run(pid, now, now, agentId, current.pid);
 
       return reclaim.changes > 0 ? "ok" : "lost";
     });
@@ -76,15 +204,31 @@ export class SqliteAgentRepo implements AgentRepository {
   }
 
   listAll(): Agent[] {
-    return this.db.query("SELECT * FROM agents WHERE id != '_system' ORDER BY id").all() as Agent[];
+    return this.db
+      .query("SELECT * FROM agents WHERE id != '_system' ORDER BY id")
+      .all() as Agent[];
   }
 
   clearPid(id: string, expectedPid: number): void {
-    withRetrySync(() => {
-      this.db.run(
-        "UPDATE agents SET pid = NULL, registered_at = NULL WHERE id = ? AND pid = ?",
-        [id, expectedPid]
-      );
+    const doClear = this.db.transaction(() => {
+      this.db
+        .query("UPDATE agents SET pid = NULL, registered_at = NULL WHERE id = ? AND pid = ?")
+        .run(id, expectedPid);
     });
+    withRetrySync(() => doClear.exclusive());
   }
+}
+
+/**
+ * Extracts the numeric slot suffix from a pool agent ID.
+ * e.g. extractInstanceNumber("worker-2", "worker") → 2
+ * Returns null if the ID doesn't match the expected pool pattern.
+ */
+function extractInstanceNumber(agentId: string, baseName: string): number | null {
+  const prefix = `${baseName}-`;
+  if (!agentId.startsWith(prefix)) return null;
+  const suffix = agentId.slice(prefix.length);
+  const n = parseInt(suffix, 10);
+  if (isNaN(n) || n <= 0 || String(n) !== suffix) return null;
+  return n;
 }

--- a/src/storage/sqlite/channel-repo.ts
+++ b/src/storage/sqlite/channel-repo.ts
@@ -1,6 +1,6 @@
 import type { Database } from "bun:sqlite";
 import type { ChannelRepository } from "../../core/ports";
-import type { Agent, Channel } from "../../core/messaging/types";
+import type { Agent, Channel, HopCheckResult } from "../../core/messaging/types";
 import { withRetrySync } from "./db";
 
 export class SqliteChannelRepo implements ChannelRepository {
@@ -10,13 +10,21 @@ export class SqliteChannelRepo implements ChannelRepository {
     return (this.db.query("SELECT * FROM channels WHERE name = ?").get(name) as Channel) ?? null;
   }
 
-  create(name: string, createdBy: string): Channel {
+  create(name: string, createdBy: string, maxHops?: number): Channel {
     return withRetrySync(() => {
-      this.db.run(
-        `INSERT INTO channels (name, created_by, created_at) VALUES (?, ?, ?)
-         ON CONFLICT(name) DO NOTHING`,
-        [name, createdBy, Date.now()]
-      );
+      if (maxHops !== undefined) {
+        this.db.run(
+          `INSERT INTO channels (name, created_by, created_at, max_hops) VALUES (?, ?, ?, ?)
+           ON CONFLICT(name) DO NOTHING`,
+          [name, createdBy, Date.now(), maxHops]
+        );
+      } else {
+        this.db.run(
+          `INSERT INTO channels (name, created_by, created_at) VALUES (?, ?, ?)
+           ON CONFLICT(name) DO NOTHING`,
+          [name, createdBy, Date.now()]
+        );
+      }
       return this.findByName(name) as Channel;
     });
   }
@@ -51,6 +59,33 @@ export class SqliteChannelRepo implements ChannelRepository {
       .query("SELECT COUNT(*) as count FROM cursors WHERE channel_id = ?")
       .get(channelId) as { count: number };
     return row.count;
+  }
+
+  checkAndIncrementHop(channelId: number): HopCheckResult {
+    const doCheck = this.db.transaction(() => {
+      const row = this.db.query("SELECT hop_count, max_hops FROM channels WHERE id = ?").get(channelId) as { hop_count: number; max_hops: number };
+      if (row.hop_count < row.max_hops) {
+        this.db.run("UPDATE channels SET hop_count = hop_count + 1 WHERE id = ?", [channelId]);
+        return { allowed: true, hopCount: row.hop_count + 1, maxHops: row.max_hops };
+      }
+      return { allowed: false, hopCount: row.hop_count, maxHops: row.max_hops };
+    });
+    return withRetrySync(() => doCheck.immediate());
+  }
+
+  resetHopCount(channelId: number): void {
+    withRetrySync(() => {
+      this.db.run("UPDATE channels SET hop_count = 0 WHERE id = ?", [channelId]);
+    });
+  }
+
+  bumpHopAllowance(channelId: number, amount: number): HopCheckResult {
+    const doBump = this.db.transaction(() => {
+      this.db.run("UPDATE channels SET hop_count = MAX(0, hop_count - ?) WHERE id = ?", [amount, channelId]);
+      const row = this.db.query("SELECT hop_count, max_hops FROM channels WHERE id = ?").get(channelId) as { hop_count: number; max_hops: number };
+      return { allowed: row.hop_count < row.max_hops, hopCount: row.hop_count, maxHops: row.max_hops };
+    });
+    return withRetrySync(() => doBump.immediate());
   }
 
   renameWithAnnouncement(channelId: number, newName: string, agentId: string): Channel {

--- a/src/storage/sqlite/domain-repo.ts
+++ b/src/storage/sqlite/domain-repo.ts
@@ -48,7 +48,7 @@ export class SqliteDomainRepo implements DomainRepository {
       claims: claims.filter((c) => c.domain_identifier === d.identifier).map((c) => ({
         agent_id: c.agent_id,
         pid: c.pid,
-        agent: { id: c.id, created_at: c.created_at, last_seen_at: c.last_seen_at, pid: c.agent_pid, registered_at: c.registered_at } as Agent,
+        agent: { id: c.id, created_at: c.created_at, last_seen_at: c.last_seen_at, pid: c.agent_pid, registered_at: c.registered_at, base_name: null, persona: null, objective: null, instructions: null } as Agent,
       })),
     }));
   }

--- a/src/storage/sqlite/migrations.ts
+++ b/src/storage/sqlite/migrations.ts
@@ -149,6 +149,13 @@ const messagingMigrations: Migration[] = [
       ALTER TABLE agents ADD COLUMN instructions TEXT;
     `,
   },
+  {
+    name: "messaging_005_safety_rails",
+    up: `
+      ALTER TABLE channels ADD COLUMN max_hops INTEGER NOT NULL DEFAULT 50;
+      ALTER TABLE channels ADD COLUMN hop_count INTEGER NOT NULL DEFAULT 0;
+    `,
+  },
 ];
 
 const brainMigrations: Migration[] = [

--- a/src/storage/sqlite/migrations.ts
+++ b/src/storage/sqlite/migrations.ts
@@ -134,6 +134,21 @@ const messagingMigrations: Migration[] = [
       ALTER TABLE messages ADD COLUMN mentions TEXT NOT NULL DEFAULT '[]';
     `,
   },
+  {
+    name: "messaging_003_agent_profiles",
+    up: `
+      ALTER TABLE agents ADD COLUMN base_name TEXT;
+      ALTER TABLE agents ADD COLUMN persona TEXT;
+      ALTER TABLE agents ADD COLUMN objective TEXT;
+      CREATE INDEX idx_agents_base_name ON agents(base_name);
+    `,
+  },
+  {
+    name: "messaging_004_agent_instructions",
+    up: `
+      ALTER TABLE agents ADD COLUMN instructions TEXT;
+    `,
+  },
 ];
 
 const brainMigrations: Migration[] = [

--- a/src/storage/yaml-profiles/store.ts
+++ b/src/storage/yaml-profiles/store.ts
@@ -1,0 +1,199 @@
+// src/storage/yaml-profiles/store.ts
+//
+// YAML filesystem adapter implementing ProfileRepository.
+// Reads all .yaml files from a configured directory on construction.
+// One bad file aborts startup (fail-fast).
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join, basename } from "node:path";
+import type { ProfileRepository } from "../../core/ports";
+import type { AgentProfile } from "../../core/profiles/types";
+import { validateAgentName } from "../../core/utils";
+import { log } from "../../log";
+
+// Known fields — unknown ones trigger a warning
+const KNOWN_FIELDS = new Set([
+  "name",
+  "persona",
+  "objective",
+  "instructions",
+  "maxInstances",
+  "autoJoinChannels",
+]);
+
+// Pattern: <baseName>-<digits>
+const POOL_SUFFIX_RE = /^(.+)-(\d+)$/;
+
+function parseProfile(filePath: string, content: string): AgentProfile {
+  const fileName = basename(filePath, ".yaml");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const raw: any = Bun.YAML.parse(content);
+
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error(`Profile file "${filePath}" must contain a YAML mapping`);
+  }
+
+  // Warn about unknown fields
+  for (const key of Object.keys(raw)) {
+    if (!KNOWN_FIELDS.has(key)) {
+      log(`Warning: unknown field "${key}" in profile "${filePath}" — ignoring`);
+    }
+  }
+
+  // --- name ---
+  const name: string = raw["name"];
+  if (typeof name !== "string" || !name.trim()) {
+    throw new Error(`Profile file "${filePath}": "name" must be a non-empty string`);
+  }
+  // Validates format ([\w-]+) and reserved names
+  validateAgentName(name);
+
+  // Filename must match name
+  if (fileName !== name) {
+    throw new Error(
+      `Profile filename mismatch: file is "${fileName}.yaml" but name field is "${name}"`
+    );
+  }
+
+  // --- persona ---
+  const rawPersona = raw["persona"];
+  let persona: string | null = null;
+  if (rawPersona !== undefined && rawPersona !== null) {
+    if (typeof rawPersona !== "string") {
+      throw new Error(
+        `Profile "${name}": persona must be a string or null/undefined, got ${typeof rawPersona}`
+      );
+    }
+    persona = rawPersona;
+  }
+
+  // --- objective ---
+  const rawObjective = raw["objective"];
+  let objective: string | null = null;
+  if (rawObjective !== undefined && rawObjective !== null) {
+    if (typeof rawObjective !== "string") {
+      throw new Error(
+        `Profile "${name}": objective must be a string or null/undefined, got ${typeof rawObjective}`
+      );
+    }
+    objective = rawObjective;
+  }
+
+  // --- instructions ---
+  const rawInstructions = raw["instructions"];
+  let instructions: string | null = null;
+  if (rawInstructions !== undefined && rawInstructions !== null) {
+    if (typeof rawInstructions !== "string") {
+      throw new Error(
+        `Profile "${name}": instructions must be a string or null/undefined, got ${typeof rawInstructions}`
+      );
+    }
+    instructions = rawInstructions;
+  }
+
+  // --- maxInstances ---
+  const rawMax = raw["maxInstances"];
+  let maxInstances = 1;
+  if (rawMax !== undefined && rawMax !== null) {
+    if (typeof rawMax !== "number" || !Number.isInteger(rawMax) || rawMax < 1) {
+      throw new Error(
+        `Profile "${name}": maxInstances must be a positive integer >= 1, got ${rawMax}`
+      );
+    }
+    maxInstances = rawMax;
+  }
+
+  // --- autoJoinChannels ---
+  const rawChannels = raw["autoJoinChannels"];
+  let autoJoinChannels: string[] = [];
+  if (rawChannels !== undefined && rawChannels !== null) {
+    if (!Array.isArray(rawChannels)) {
+      throw new Error(
+        `Profile "${name}": autoJoinChannels must be an array of strings`
+      );
+    }
+    for (let i = 0; i < rawChannels.length; i++) {
+      if (typeof rawChannels[i] !== "string") {
+        throw new Error(
+          `Profile "${name}": autoJoinChannels[${i}] must be a string, got ${typeof rawChannels[i]}`
+        );
+      }
+    }
+    autoJoinChannels = rawChannels as string[];
+  }
+
+  return { name, persona, objective, instructions, maxInstances, autoJoinChannels };
+}
+
+function checkPoolNameCollisions(profiles: AgentProfile[]): void {
+  const nameSet = new Set(profiles.map((p) => p.name));
+  for (const profile of profiles) {
+    const m = POOL_SUFFIX_RE.exec(profile.name);
+    if (m) {
+      const baseName = m[1]!;
+      if (nameSet.has(baseName)) {
+        throw new Error(
+          `Profile name "${profile.name}" collides with pool namespace of profile "${baseName}". ` +
+          `Instance names like "${profile.name}" are reserved for the pool of "${baseName}".`
+        );
+      }
+    }
+  }
+}
+
+export class YamlProfileStore implements ProfileRepository {
+  private readonly profiles: Map<string, AgentProfile>;
+
+  constructor(dirPath: string) {
+    this.profiles = new Map();
+    this.load(dirPath);
+  }
+
+  private load(dirPath: string): void {
+    let files: string[];
+    try {
+      files = readdirSync(dirPath);
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      if (e.code === "ENOENT") {
+        // Directory doesn't exist — silently treat as empty
+        return;
+      }
+      throw err;
+    }
+
+    const yamlFiles = files.filter((f) => f.endsWith(".yaml")).sort();
+    const parsed: AgentProfile[] = [];
+
+    for (const file of yamlFiles) {
+      const filePath = join(dirPath, file);
+      const content = readFileSync(filePath, "utf-8");
+      const profile = parseProfile(filePath, content);
+
+      // Check for duplicate names (defensive; filesystem prevents same basename)
+      if (this.profiles.has(profile.name)) {
+        throw new Error(
+          `Duplicate profile name "${profile.name}" found in directory "${dirPath}"`
+        );
+      }
+
+      parsed.push(profile);
+      this.profiles.set(profile.name, profile);
+    }
+
+    // After all files parsed, check pool namespace collisions
+    checkPoolNameCollisions(parsed);
+  }
+
+  getProfile(baseName: string): AgentProfile | null {
+    return this.profiles.get(baseName) ?? null;
+  }
+
+  listProfiles(): AgentProfile[] {
+    return [...this.profiles.values()];
+  }
+
+  getBaseNames(): Set<string> {
+    return new Set(this.profiles.keys());
+  }
+}

--- a/src/transports/mcp-stdio/adapter.ts
+++ b/src/transports/mcp-stdio/adapter.ts
@@ -19,52 +19,76 @@ export function buildInstructions(
   let instructions =
     "octo-santa messaging module is available. Call messaging_register with a " +
     "unique agent name (e.g. your role). If the name is taken, pick a different one.\n\n" +
-    "You must call messaging_register before sending, reading, creating channels, or subscribing. " +
-    "Read-only tools (messaging_list_channels, messaging_list_agents, messaging_list_members) work without registration.\n\n" +
-    "Messages from other agents arrive as <channel source=\"octo-santa\" ...> tags. " +
-    "To acknowledge and see full history, call messaging_read_messages with the channel. " +
-    "To reply, call messaging_send_message with the same channel.\n\n" +
-    "CHANNELS: Messages live in named channels. Create channels with messaging_create_channel, " +
-    "then subscribe with messaging_subscribe to receive notifications. " +
-    "Channels must exist before sending — use messaging_create_channel to create them.\n\n" +
-    "MENTIONS:\n" +
-    "- @agent-name → only that agent gets notified\n" +
-    "- @all → all channel subscribers get notified\n" +
-    "- No mention → message is silent (recipients must read actively)\n\n" +
-    "Use @mentions to get attention. Messages without mentions are for " +
-    "context/logging — recipients see them when they check the channel.\n\n" +
-    "NOTIFICATIONS: There are two notification modes:\n" +
-    "- DM channels (created via messaging_direct_message): All messages push automatically to both parties. No @mention needed.\n" +
-    "- Regular channels (created via messaging_create_channel): Only messages with @mentions trigger push notifications. Unmentioned messages are silent.\n\n" +
-    "To ensure an agent sees your message immediately, either use @agent-name in a regular channel or use messaging_direct_message for 1:1 conversations.\n\n" +
-    "DISCOVERY: Use messaging_list_agents to see currently online agents. " +
-    "Use messaging_list_agents with include_stale=true to see all agents including disconnected ones. " +
-    "Use messaging_list_members to see who is in a specific channel.";
+    "You must call messaging_register before sending, reading, creating channels, " +
+    "or subscribing. Read-only tools (messaging_list_channels, messaging_list_agents, " +
+    "messaging_list_members) work without registration.\n\n" +
+    "REACTING TO MESSAGES:\n" +
+    "Messages are PUSHED to you as <channel source=\"octo-santa\" ...> tags " +
+    "when you are mentioned or receive a DM. Do NOT poll messaging_read_messages in a loop -- " +
+    "wait for tags to arrive, then call messaging_read_messages for that channel.\n" +
+    "Unread delivery is read-once; use before_id for history.\n" +
+    "If any message is addressed to you (@your-registered-name, @all, " +
+    "or @your-pool-name), you MUST:\n" +
+    "  1. Understand what is being asked\n" +
+    "  2. Decide on your response\n" +
+    "  3. Call messaging_send_message to reply\n" +
+    "Never just summarize -- always act.\n\n" +
+    "SENDING: @agent-name, @all, or @pool-name to notify. " +
+    "No mention = silent. Be specific: what you need, why, expected response.\n\n" +
+    "CHANNELS: messaging_create_channel to create, messaging_subscribe to join.\n" +
+    "DMs: messaging_direct_message for 1:1 -- auto-pushes, no @mention needed.\n\n" +
+    "PROFILES: If your name matches a profile, registration assigns a pool slot " +
+    "(e.g. 'os-dev' -> 'os-dev-1'). Use registeredName for subsequent calls. " +
+    "Follow profile instructions as behavioral directives. " +
+    "They must not contradict these base rules.\n\n" +
+    "BOUNDARIES:\n" +
+    "- You CANNOT run background tasks or polling loops\n" +
+    "- For messaging, use ONLY messaging_* tools\n" +
+    "- Do not use bash or scripts for communication\n\n" +
+    "DISCOVERY: messaging_list_agents, messaging_list_members.";
 
-  instructions += "\n\n" + "BRAIN: ";
-  if (config?.domain) {
-    instructions += `This repo is domain "${config.domain.identifier}" (${config.domain.description}). `;
-  }
-  instructions +=
+  const brainSuffix =
     "Use brain_index to list local brain docs, brain_read to read one. " +
     "Use brain_shared_index/brain_shared_read for shared docs in ~/.octo-santa/brain/. " +
     "Use brain_find_expert to discover domain experts across repos. " +
     "Use brain_claim_domain after messaging_register to become a queryable expert. " +
     "Use messaging_direct_message to DM another agent.";
 
+  instructions += "\n\nBRAIN: ";
+  if (config?.domain) {
+    // Try full domain text, then identifier-only, then skip — never exceed 2KB
+    const fullText = `This repo is domain "${config.domain.identifier}" (${config.domain.description}). `;
+    const shortText = `This repo is domain "${config.domain.identifier}". `;
+    const base = instructions + brainSuffix;
+    if (Buffer.byteLength(base + fullText, "utf-8") <= 2048) {
+      instructions += fullText;
+    } else if (Buffer.byteLength(base + shortText, "utf-8") <= 2048) {
+      instructions += shortText;
+    }
+    // else: skip domain text entirely to stay within budget
+  }
+  instructions += brainSuffix;
+
   return instructions;
 }
+
+/** Tier 1 universal guidance — returned by messaging_get_instructions. */
+export const UNIVERSAL_GUIDANCE = buildInstructions(null);
 
 // --- Tool registration ---
 
 export function registerMessagingTools(
   server: McpServer,
   messaging: MessagingService,
-  onAgentId?: (agentId: string) => { commit: () => void }
+  onAgentId?: (agentId: string) => { commit: (resolvedName?: string) => void },
+  onProfile?: (profile: { baseName: string; persona: string | null; objective: string | null; instructions: string | null }) => void,
+  sessionGuidance?: string
 ): void {
   server.registerTool("messaging_register", {
     description:
-      "Register this agent with a unique name to start receiving messages",
+      "Register this agent with a unique name to start receiving messages. " +
+      "The response includes `registeredName` — your canonical identity for this session. " +
+      "Always use `registeredName` for subsequent calls.",
     inputSchema: {
       agent_id: z
         .string()
@@ -77,9 +101,18 @@ export function registerMessagingTools(
         .describe("Your agent/project name"),
     },
   }, async ({ agent_id }) => {
-    return withAgent(onAgentId, agent_id, () =>
-      jsonResult(messaging.register(agent_id))
-    );
+    const handle = onAgentId?.(agent_id);
+    const result = messaging.register(agent_id);
+    handle?.commit(result.registeredName);
+    if (result.baseName) {
+      onProfile?.({
+        baseName: result.baseName,
+        persona: result.profile?.persona ?? null,
+        objective: result.profile?.objective ?? null,
+        instructions: result.profile?.instructions ?? null,
+      });
+    }
+    return jsonResult(result);
   });
 
   server.registerTool("messaging_create_channel", {
@@ -205,6 +238,28 @@ export function registerMessagingTools(
     return jsonResult(messaging.listMembers(channel));
   });
 
+  server.registerTool("messaging_get_instructions", {
+    description:
+      "Re-read your profile instructions and universal messaging guidance. " +
+      "Call this if you've lost context or are unsure how to act.",
+    inputSchema: {
+      agent_id: z.string().trim().min(1).describe("Your registered agent name"),
+      include_universal: z
+        .boolean()
+        .optional()
+        .default(true)
+        .describe("Include universal messaging guidance (default: true)"),
+    },
+  }, async ({ agent_id, include_universal }) => {
+    return withAgent(onAgentId, agent_id, () => {
+      const result = messaging.getInstructions(agent_id);
+      return jsonResult({
+        universal: include_universal ? (sessionGuidance ?? UNIVERSAL_GUIDANCE) : null,
+        profile: result.profile,
+      });
+    });
+  });
+
   server.registerTool("messaging_rename_channel", {
     description: "Rename a channel. You must be a member of the channel.",
     inputSchema: {
@@ -224,7 +279,7 @@ export function registerBrainTools(
   brain: BrainService,
   config: OctoSantaConfig | null,
   hasBrain: boolean,
-  onAgentId?: (agentId: string) => { commit: () => void }
+  onAgentId?: (agentId: string) => { commit: (resolvedName?: string) => void }
 ): void {
   server.registerTool("brain_index", {
     description:
@@ -321,7 +376,7 @@ export interface McpStdioOpts {
   unregisterNotificationHandler: (agentId: string) => void;
   agents: AgentRepository;
   /** Factory invoked once per session when an agent binds. Returns a handle with stop(). */
-  startPoller: (port: NotificationPort, agentId: string) => { stop(): void };
+  startPoller: (port: NotificationPort, agentId: string, baseName?: string) => { stop(): void };
   heartbeatIntervalMs?: number;
   onDisconnect: (agentId: string, pid: number) => void;
 }
@@ -355,8 +410,9 @@ export async function startMcpStdio(opts: McpStdioOpts): Promise<void> {
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   let boundAgentId: string | null = null;
   let pollerRef: { stop(): void } | null = null;
+  let boundProfile: { baseName: string; persona: string | null; objective: string | null; instructions: string | null } | null = null;
 
-  function onAgentId(agentId: string): { commit: () => void } {
+  function onAgentId(agentId: string): { commit: (resolvedName?: string) => void } {
     if (boundAgentId !== null) {
       if (boundAgentId !== agentId) {
         throw new Error(
@@ -367,9 +423,10 @@ export async function startMcpStdio(opts: McpStdioOpts): Promise<void> {
     }
     // Deferred binding — caller must commit() after successful operation
     return {
-      commit: () => {
+      commit: (resolvedName?: string) => {
         if (boundAgentId !== null) return; // Already bound (concurrent commit)
-        boundAgentId = agentId;
+        const effectiveId = resolvedName ?? agentId;
+        boundAgentId = effectiveId;
         const port: NotificationPort = {
           notify: (content, meta) =>
             mcpServer.server.notification({
@@ -377,10 +434,10 @@ export async function startMcpStdio(opts: McpStdioOpts): Promise<void> {
               params: { content, meta },
             }),
         };
-        registerNotificationHandler(agentId, port);
-        pollerRef = startPoller(port, agentId);
+        registerNotificationHandler(effectiveId, port);
+        pollerRef = startPoller(port, effectiveId, boundProfile?.baseName);
         heartbeatTimer = setInterval(() => {
-          const result = agents.heartbeatOrReclaim(agentId, process.pid);
+          const result = agents.heartbeatOrReclaim(effectiveId, process.pid);
           if (result === "lost") {
             clearInterval(heartbeatTimer!);
             heartbeatTimer = null;
@@ -391,7 +448,10 @@ export async function startMcpStdio(opts: McpStdioOpts): Promise<void> {
     };
   }
 
-  registerMessagingTools(mcpServer, messaging, onAgentId);
+  const sessionInstructions = buildInstructions(config, brainIndex);
+  registerMessagingTools(mcpServer, messaging, onAgentId, (profile) => {
+    boundProfile = profile;
+  }, sessionInstructions);
   registerBrainTools(mcpServer, brain, config, hasBrain, onAgentId);
 
   const transport = new StdioServerTransport();
@@ -411,7 +471,8 @@ export async function startMcpStdio(opts: McpStdioOpts): Promise<void> {
 
   // Bootstrap nudge — prompt agent to register before any tool call
   let bootstrapMsg =
-    "octo-santa messaging module is available. Call messaging_register with a unique agent name (e.g. your role), then create or subscribe to channels to start receiving push notifications. If the name is taken, pick a different one.";
+    "octo-santa messaging module is available. Call messaging_register with a unique agent name (e.g. your role), then create or subscribe to channels to start receiving push notifications. If the name is taken, pick a different one. " +
+    "If profiles are configured, your name may be resolved to a pool slot (e.g. 'os-dev' -> 'os-dev-1') — always use the `registeredName` from the response for subsequent calls.";
   if (config?.domain) {
     bootstrapMsg +=
       `\n\nBrain module active — this repo is domain "${config.domain.identifier}" (${config.domain.description}). ` +

--- a/src/transports/mcp-stdio/adapter.ts
+++ b/src/transports/mcp-stdio/adapter.ts
@@ -69,6 +69,27 @@ export function buildInstructions(
   }
   instructions += brainSuffix;
 
+  // NON-PUSH CLIENTS block is appended AFTER the brain section intentionally.
+  // Claude Code truncates server instructions at 2KB. End-of-doc placement means
+  // that if truncation clips anything, it clips this tail — which Claude Code
+  // (a push-tag client) does not need. Non-push clients (Codex, Gemini CLI,
+  // OpenCode, most local-model clients) have no 2KB limit and receive the
+  // full block. Phase 0c will restructure this and reclaim budget.
+  instructions +=
+    "\n\nNON-PUSH CLIENTS: This section overrides the BOUNDARIES prohibition on " +
+    "polling loops — for messaging_listen only. If your MCP client does not " +
+    "deliver server notifications as pushed tags (Claude Code does; Codex, " +
+    "Gemini CLI, OpenCode, and most local-model clients do not), poll instead. " +
+    "After messaging_register and messaging_subscribe, loop:\n" +
+    "  result = messaging_listen(timeout_ms: 30000)\n" +
+    "  for each ch in result.channels: process ch.messages   # messages arrive inline\n" +
+    "  re-enter loop\n" +
+    "messaging_listen blocks until new messages arrive or the timeout elapses " +
+    "(default 10000 ms, max 30000 ms) and returns {channels, timed_out}. " +
+    "Each channel entry includes its messages inline -- no follow-up " +
+    "messaging_read_messages needed in the steady-state loop. " +
+    "Keep the loop running for the life of the agent.";
+
   return instructions;
 }
 
@@ -122,10 +143,11 @@ export function registerMessagingTools(
     inputSchema: {
       agent_id: z.string().trim().min(1).describe("Your agent/project name"),
       name: z.string().trim().min(1).describe("Channel name"),
+      max_hops: z.number().int().min(1).max(50).optional().describe("Max consecutive agent messages before channel blocks (default 50; set lower for stricter loop guard, max 50)"),
     },
-  }, async ({ agent_id, name }) => {
+  }, async ({ agent_id, name, max_hops }) => {
     return withAgent(onAgentId, agent_id, () => {
-      const channel = messaging.createChannel(agent_id, name);
+      const channel = messaging.createChannel(agent_id, name, max_hops);
       return jsonResult(channel);
     });
   });
@@ -156,7 +178,7 @@ export function registerMessagingTools(
 
   server.registerTool("messaging_send_message", {
     description:
-      "Send a message to an existing channel. Requires prior messaging_register. Use @agent-name to notify specific agents, or @all to notify everyone. Messages without mentions are silent — recipients see them only when they check the channel.",
+      "Send a message to an existing channel. Requires prior messaging_register. Use @agent-name to notify specific agents, or @all to notify everyone. Messages without mentions are silent -- recipients see them only when they check the channel. Messages are subject to per-channel hop limits; blocked messages are dropped with a system notice.",
     inputSchema: {
       agent_id: z.string().trim().min(1).describe("Your agent/project name"),
       channel: z.string().trim().min(1).describe("Channel name"),
@@ -275,7 +297,7 @@ export function registerMessagingTools(
   });
 
   server.registerTool("messaging_listen", {
-    description: "Block and wait for new messages across all subscribed channels. Returns when messages arrive or timeout is reached. Use this for agent polling loops instead of repeatedly calling messaging_read_messages.",
+    description: "Block and wait for new messages across all subscribed channels. Returns `{channels, timed_out}` where each channel entry includes its messages inline — no follow-up messaging_read_messages needed in the steady-state poll loop. Use this for agent polling loops instead of repeatedly calling messaging_read_messages.",
     inputSchema: {
       agent_id: z.string().trim().min(1).describe("Your registered agent name"),
       timeout_ms: z.number().int().optional().describe("Max wait time in ms (default 10000, max 30000)"),

--- a/src/transports/mcp-stdio/adapter.ts
+++ b/src/transports/mcp-stdio/adapter.ts
@@ -82,7 +82,8 @@ export function registerMessagingTools(
   messaging: MessagingService,
   onAgentId?: (agentId: string) => { commit: (resolvedName?: string) => void },
   onProfile?: (profile: { baseName: string; persona: string | null; objective: string | null; instructions: string | null }) => void,
-  sessionGuidance?: string
+  sessionGuidance?: string,
+  agents?: AgentRepository
 ): void {
   server.registerTool("messaging_register", {
     description:
@@ -272,6 +273,28 @@ export function registerMessagingTools(
       jsonResult(messaging.renameChannel(agent_id, channel, new_name))
     );
   });
+
+  server.registerTool("messaging_listen", {
+    description: "Block and wait for new messages across all subscribed channels. Returns when messages arrive or timeout is reached. Use this for agent polling loops instead of repeatedly calling messaging_read_messages.",
+    inputSchema: {
+      agent_id: z.string().trim().min(1).describe("Your registered agent name"),
+      timeout_ms: z.number().int().optional().describe("Max wait time in ms (default 10000, max 30000)"),
+    },
+  }, async ({ agent_id, timeout_ms }) => {
+    return withAgent(onAgentId, agent_id, async () => {
+      const timeout = Math.max(1000, Math.min(30000, timeout_ms ?? 10000));
+      agents?.heartbeatOrReclaim(agent_id, process.pid);
+      const deadline = Date.now() + timeout;
+      while (Date.now() < deadline) {
+        const result = messaging.readAllUnread(agent_id);
+        if (result.length > 0) {
+          return jsonResult({ channels: result, timed_out: false });
+        }
+        await Bun.sleep(1000);
+      }
+      return jsonResult({ channels: [], timed_out: true });
+    });
+  });
 }
 
 export function registerBrainTools(
@@ -451,7 +474,7 @@ export async function startMcpStdio(opts: McpStdioOpts): Promise<void> {
   const sessionInstructions = buildInstructions(config, brainIndex);
   registerMessagingTools(mcpServer, messaging, onAgentId, (profile) => {
     boundProfile = profile;
-  }, sessionInstructions);
+  }, sessionInstructions, agents);
   registerBrainTools(mcpServer, brain, config, hasBrain, onAgentId);
 
   const transport = new StdioServerTransport();

--- a/src/transports/mcp-stdio/helpers.ts
+++ b/src/transports/mcp-stdio/helpers.ts
@@ -4,7 +4,7 @@ export function jsonResult(data: unknown) {
 }
 
 export function withAgent<T>(
-  onAgentId: ((agentId: string) => { commit: () => void }) | undefined,
+  onAgentId: ((agentId: string) => { commit: (resolvedName?: string) => void }) | undefined,
   agentId: string,
   fn: () => T
 ): T {

--- a/src/transports/repl/app.ts
+++ b/src/transports/repl/app.ts
@@ -119,7 +119,7 @@ export function startApp(opts: AppOptions): () => void {
 
         // Send message
         try {
-          svc.send(agentId, state.activeChannel, text);
+          svc.send(agentId, state.activeChannel, text, { human: true });
           // Local echo
           const formatted = formatMessage(
             { agent_id: agentId, content: text },

--- a/src/transports/repl/commands.ts
+++ b/src/transports/repl/commands.ts
@@ -24,7 +24,7 @@ export interface CommandResult {
 
 export const KNOWN_COMMANDS = new Set([
   "channels", "agents", "join", "create", "history",
-  "send", "members", "help", "quit",
+  "send", "members", "help", "quit", "continue",
 ]);
 
 export function parseCommand(input: string): ParsedCommand | null {
@@ -100,7 +100,7 @@ export function executeCommand(
       const filePath = match[1]!.trim();
       try {
         const content = readFileSync(filePath, "utf-8");
-        svc.send(state.agentId, state.activeChannel, content);
+        svc.send(state.agentId, state.activeChannel, content, { human: true });
         return {
           output: [],
           localEcho: { agent_id: state.agentId, content },
@@ -116,6 +116,13 @@ export function executeCommand(
       return { output: members.map(m => `  ${m.agent_id} ${m.active ? "(active)" : "(inactive)"}`) };
     }
 
+    case "continue": {
+      let amount = parseInt(cmd.args, 10);
+      if (!Number.isFinite(amount) || amount <= 0) amount = 4;
+      const result = svc.continueChannel(state.agentId, state.activeChannel, amount);
+      return { output: [`Bumped ${state.activeChannel}: hop count ${result.hopCount}/${result.maxHops} (+${result.bumped})`] };
+    }
+
     case "help":
       return {
         output: [
@@ -127,6 +134,7 @@ export function executeCommand(
           "  /history [N]     — Show last N messages (default 20)",
           "  /send -f <path>  — Send file contents",
           "  /members         — List channel members",
+          "  /continue [N]    -- Resume hop-limited channel (+N hops, default 4)",
           "  /help            — Show this help",
           "  /quit            — Exit",
         ],

--- a/src/transports/repl/startup.ts
+++ b/src/transports/repl/startup.ts
@@ -1,8 +1,10 @@
 // src/transports/repl/startup.ts
 import type { MessagingService } from "../../core/messaging/service";
 
-export function startupRepl(svc: MessagingService, agentId: string, channel: string): void {
-  svc.register(agentId);
-  svc.createChannel(agentId, channel);
-  svc.subscribe(agentId, channel);
+export function startupRepl(svc: MessagingService, agentId: string, channel: string): string {
+  const result = svc.register(agentId);
+  const name = result.registeredName;
+  svc.createChannel(name, channel);
+  svc.subscribe(name, channel);
+  return name;
 }

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -25,7 +25,8 @@ describe("concurrency", () => {
     const { db: setupDbRef, svc } = setup();
     // Subscribe verifier before workers run so cursor starts at 0 (sees all messages)
     svc.register("verifier");
-    svc.createChannel("verifier", "stress-test");
+    // Use a high maxHops so workers can send many messages without triggering hop limit
+    svc.createChannel("verifier", "stress-test", 1000);
     svc.subscribe("verifier", "stress-test");
     setupDbRef.close();
 

--- a/tests/hex/core/continue-channel-transport-boundary.test.ts
+++ b/tests/hex/core/continue-channel-transport-boundary.test.ts
@@ -1,0 +1,70 @@
+// tests/hex/core/continue-channel-transport-boundary.test.ts
+//
+// Transport-boundary regression guard for `MessagingService.continueChannel()`.
+//
+// `continueChannel()` is human-only by transport-restriction (see JSDoc on the
+// method in src/core/messaging/service.ts). The architectural invariant is
+// that no agent-callable transport (MCP, future RPC, future HTTP) is allowed
+// to invoke this method. Currently REPL `/continue` is the sole surface;
+// future `ocs continue` CLI will be the second.
+//
+// This test scans `src/transports/` for `.continueChannel(` references and
+// fails if any non-REPL transport invokes it. Adding the method to MCP, RPC,
+// or any other agent-driven path will fail here.
+
+import { describe, it, expect } from "bun:test";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "../../..");
+const TRANSPORTS_ROOT = join(REPO_ROOT, "src/transports");
+const ALLOWED_TRANSPORT_PREFIXES = [
+  "src/transports/repl/",
+  // Future: "src/transports/cli/" once `ocs continue` ships
+];
+
+function walkTsFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      walkTsFiles(full, acc);
+    } else if (entry.endsWith(".ts")) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+function findContinueChannelInvocations(): Array<{ file: string; lines: number[] }> {
+  const files = walkTsFiles(TRANSPORTS_ROOT);
+  const results: Array<{ file: string; lines: number[] }> = [];
+  for (const file of files) {
+    const content = readFileSync(file, "utf-8");
+    const lines = content.split("\n");
+    const matchedLines: number[] = [];
+    lines.forEach((line, idx) => {
+      if (/\.continueChannel\s*\(/.test(line)) {
+        matchedLines.push(idx + 1);
+      }
+    });
+    if (matchedLines.length > 0) {
+      results.push({ file: relative(REPO_ROOT, file), lines: matchedLines });
+    }
+  }
+  return results;
+}
+
+describe("continueChannel — transport-boundary discipline", () => {
+  it("is invoked only from REPL transport files", () => {
+    const invocations = findContinueChannelInvocations();
+    const violators = invocations.filter(
+      (inv) => !ALLOWED_TRANSPORT_PREFIXES.some((prefix) => inv.file.startsWith(prefix))
+    );
+    expect(violators).toEqual([]);
+  });
+
+  it("at least one transport actually calls continueChannel (sanity)", () => {
+    const invocations = findContinueChannelInvocations();
+    expect(invocations.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/hex/core/listen.test.ts
+++ b/tests/hex/core/listen.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { MessagingService } from "../../../src/core/messaging/service";
+import { createSqliteRepos } from "../../../src/storage/sqlite";
+import { createDb } from "../../../src/storage/sqlite/db";
+import { runMigrations, allMigrations } from "../../../src/storage/sqlite/migrations";
+import { createNotificationDispatcher } from "../../../src/notifications/dispatch/dispatcher";
+import { cleanupDb } from "../../helpers/db";
+
+const TEST_DB = `/tmp/octo-santa-test-hex-listen-${process.pid}.sqlite`;
+
+function setup() {
+  cleanupDb(TEST_DB);
+  const db = createDb(TEST_DB);
+  runMigrations(db, allMigrations);
+  const repos = createSqliteRepos(db);
+  const dispatcher = createNotificationDispatcher();
+  const svc = new MessagingService(
+    repos.agents,
+    repos.channels,
+    repos.messages,
+    repos.cursors,
+    process.pid,
+    dispatcher
+  );
+  return { db, repos, svc };
+}
+
+afterEach(() => cleanupDb(TEST_DB));
+
+describe("readAllUnread()", () => {
+  it("returns empty array when agent has no subscriptions", () => {
+    const { svc } = setup();
+    svc.register("alice");
+
+    const result = svc.readAllUnread("alice");
+    expect(result).toEqual([]);
+  });
+
+  it("returns only channels with unread messages, skips empty ones", () => {
+    const { svc } = setup();
+    svc.register("alice");
+    svc.register("bob");
+
+    svc.createChannel("alice", "active");
+    svc.subscribe("alice", "active");
+    svc.subscribe("bob", "active");
+
+    svc.createChannel("alice", "quiet");
+    svc.subscribe("alice", "quiet");
+
+    svc.send("bob", "active", "hello alice");
+
+    const result = svc.readAllUnread("alice");
+    expect(result.length).toBe(1);
+    expect(result[0]!.channel).toBe("active");
+    expect(result[0]!.messages.length).toBe(1);
+    expect(result[0]!.messages[0]!.content).toBe("hello alice");
+  });
+
+  it("advances cursors so second call returns empty", () => {
+    const { svc } = setup();
+    svc.register("alice");
+    svc.register("bob");
+
+    svc.createChannel("alice", "general");
+    svc.subscribe("alice", "general");
+    svc.subscribe("bob", "general");
+
+    svc.send("bob", "general", "first message");
+
+    const first = svc.readAllUnread("alice");
+    expect(first.length).toBe(1);
+    expect(first[0]!.messages.length).toBe(1);
+
+    const second = svc.readAllUnread("alice");
+    expect(second).toEqual([]);
+  });
+
+  it("marks DM channels with is_dm: true", () => {
+    const { svc } = setup();
+    svc.register("alice");
+    svc.register("bob");
+
+    svc.directMessage("bob", "alice", "hey alice");
+
+    const result = svc.readAllUnread("alice");
+    expect(result.length).toBe(1);
+    expect(result[0]!.channel).toBe("alice,bob");
+    expect(result[0]!.is_dm).toBe(true);
+    expect(result[0]!.messages.length).toBe(1);
+    expect(result[0]!.messages[0]!.content).toBe("hey alice");
+  });
+
+  it("marks regular channels with is_dm: false", () => {
+    const { svc } = setup();
+    svc.register("alice");
+    svc.register("bob");
+
+    svc.createChannel("alice", "general");
+    svc.subscribe("alice", "general");
+    svc.subscribe("bob", "general");
+
+    svc.send("bob", "general", "hello");
+
+    const result = svc.readAllUnread("alice");
+    expect(result.length).toBe(1);
+    expect(result[0]!.is_dm).toBe(false);
+  });
+
+  it("throws if agent is not registered", () => {
+    const { svc } = setup();
+
+    expect(() => svc.readAllUnread("ghost")).toThrow(
+      'Agent "ghost" must call messaging_register before using messaging tools'
+    );
+  });
+});

--- a/tests/hex/core/pool-mentions.test.ts
+++ b/tests/hex/core/pool-mentions.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { MessagingService } from "../../../src/core/messaging/service";
+import { createSqliteRepos } from "../../../src/storage/sqlite";
+import { createDb } from "../../../src/storage/sqlite/db";
+import {
+  runMigrations,
+  allMigrations,
+} from "../../../src/storage/sqlite/migrations";
+import { cleanupDb } from "../../helpers/db";
+import type { ProfileRepository } from "../../../src/core/ports";
+import type { AgentProfile } from "../../../src/core/profiles/types";
+
+const TEST_DB = `/tmp/octo-santa-test-pool-mentions-${process.pid}.sqlite`;
+
+// ── In-memory ProfileRepository ────────────────────────────────────────────
+
+class InMemoryProfileRepo implements ProfileRepository {
+  private profiles = new Map<string, AgentProfile>();
+
+  add(profile: AgentProfile): void {
+    this.profiles.set(profile.name, profile);
+  }
+
+  getProfile(baseName: string): AgentProfile | null {
+    return this.profiles.get(baseName) ?? null;
+  }
+
+  listProfiles(): AgentProfile[] {
+    return [...this.profiles.values()];
+  }
+
+  getBaseNames(): Set<string> {
+    return new Set(this.profiles.keys());
+  }
+}
+
+// ── Captured dispatch helper ───────────────────────────────────────────────
+
+type DispatchCall = {
+  channelName: string;
+  sender: string;
+  content: string;
+  messageId: number;
+  isDm: boolean;
+  targetAgents: string[];
+};
+
+function makeCapturingDispatch() {
+  const dispatched: DispatchCall[] = [];
+  return {
+    dispatched,
+    dispatch(notification: DispatchCall) {
+      dispatched.push({ ...notification });
+    },
+  };
+}
+
+// ── Setup helper ───────────────────────────────────────────────────────────
+
+function setup(profileRepo?: ProfileRepository) {
+  cleanupDb(TEST_DB);
+  const db = createDb(TEST_DB);
+  runMigrations(db, allMigrations);
+  const repos = createSqliteRepos(db);
+  const capturingDispatch = makeCapturingDispatch();
+  const svc = new MessagingService(
+    repos.agents,
+    repos.channels,
+    repos.messages,
+    repos.cursors,
+    process.pid,
+    capturingDispatch,
+    profileRepo
+  );
+  return { db, repos, svc, dispatched: capturingDispatch.dispatched };
+}
+
+afterEach(() => cleanupDb(TEST_DB));
+
+/**
+ * Inserts a live agent directly into the DB with a given base_name and the
+ * current PID so that isAgentActive() returns true.
+ * Used to simulate a second pool instance from a "different process" that
+ * happens to be alive (same PID — acceptable for unit tests).
+ */
+function insertLiveAgent(
+  db: ReturnType<typeof createDb>,
+  agentId: string,
+  baseName: string
+): void {
+  const now = Date.now();
+  db.run(
+    `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [agentId, now, now, process.pid, now, baseName]
+  );
+}
+
+// ── Pool mention — base name stored, instances notified ───────────────────
+
+describe("pool-wide mention expansion", () => {
+  it("@os-dev mention stores base name and dispatches to subscribed live instances", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: null,
+      objective: null,
+      instructions: null,
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { svc, db, repos, dispatched } = setup(profileRepo);
+
+    // Bootstrap: create channel and an admin
+    svc.register("admin");
+    svc.createChannel("admin", "general");
+
+    // Register first pool instance through the service (os-dev-1)
+    const r1 = svc.register("os-dev");
+    const id1 = r1.registeredName; // "os-dev-1"
+
+    // Insert second instance directly (bypasses same-PID idempotency) so we have two live instances
+    insertLiveAgent(db, "os-dev-2", "os-dev");
+    const id2 = "os-dev-2";
+
+    // Register os-dev-2 as a known agent via repos.agents so subscribe works
+    // (subscribe calls requireRegistered which checks pid = process.pid)
+    // We need to use a separate MessagingService for os-dev-2 that shares the same DB
+    // Instead, let's subscribe os-dev-2 directly via repos
+    const channel = repos.channels.findByName("general")!;
+    repos.channels.addMember(id2, channel.id, 0);
+
+    // Subscribe id1 too
+    svc.subscribe(id1, "general");
+
+    // Admin sends @os-dev (base name mention)
+    const msg = svc.send("admin", "general", `hey @os-dev check this`);
+
+    // The message's stored mentions should contain the raw base name "os-dev"
+    const row = db.query("SELECT mentions FROM messages WHERE id = ?").get(msg.id) as { mentions: string } | null;
+    expect(row).not.toBeNull();
+    const storedMentions = JSON.parse(row!.mentions) as string[];
+    expect(storedMentions).toContain("os-dev");
+
+    // Dispatch should have resolved os-dev → [os-dev-1, os-dev-2]
+    expect(dispatched.length).toBe(1);
+    expect(dispatched[0]!.targetAgents.sort()).toEqual([id1, id2].sort());
+  });
+
+  it("@os-dev-1 as direct mention targets only that instance, not the whole pool", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: null,
+      objective: null,
+      instructions: null,
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { svc, db, repos, dispatched } = setup(profileRepo);
+
+    svc.register("admin");
+    svc.createChannel("admin", "general");
+
+    const r1 = svc.register("os-dev");
+    const id1 = r1.registeredName; // "os-dev-1"
+
+    // Second instance inserted directly
+    insertLiveAgent(db, "os-dev-2", "os-dev");
+    const channel = repos.channels.findByName("general")!;
+    repos.channels.addMember("os-dev-2", channel.id, 0);
+    svc.subscribe(id1, "general");
+
+    // Direct mention by full instance name
+    svc.send("admin", "general", `hey @${id1} only you`);
+
+    expect(dispatched.length).toBe(1);
+    expect(dispatched[0]!.targetAgents).toEqual([id1]);
+  });
+
+  it("membership filter: @os-dev only notifies pool instances subscribed to the channel", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: null,
+      objective: null,
+      instructions: null,
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { svc, db, repos, dispatched } = setup(profileRepo);
+
+    svc.register("admin");
+    svc.createChannel("admin", "general");
+
+    const r1 = svc.register("os-dev"); // os-dev-1
+    const id1 = r1.registeredName;
+
+    // os-dev-2 is live but NOT subscribed to the channel
+    insertLiveAgent(db, "os-dev-2", "os-dev");
+    const id2 = "os-dev-2";
+
+    // Only os-dev-1 subscribes; os-dev-2 does NOT
+    svc.subscribe(id1, "general");
+    // id2 exists and is active (same PID) but is NOT a channel member
+
+    svc.send("admin", "general", "@os-dev all instances should see this");
+
+    expect(dispatched.length).toBe(1);
+    // Only id1 is a member — id2 must NOT be in targets
+    expect(dispatched[0]!.targetAgents).toEqual([id1]);
+    expect(dispatched[0]!.targetAgents).not.toContain(id2);
+  });
+
+  it("no dispatch when pool instances are live but none subscribed to channel", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: null,
+      objective: null,
+      instructions: null,
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { svc, db, dispatched } = setup(profileRepo);
+
+    svc.register("admin");
+    svc.createChannel("admin", "general");
+
+    // Insert live instances but don't subscribe any to general
+    insertLiveAgent(db, "os-dev-1", "os-dev");
+    insertLiveAgent(db, "os-dev-2", "os-dev");
+
+    svc.send("admin", "general", "@os-dev nobody is subscribed");
+
+    // No subscribed pool members → no dispatch
+    expect(dispatched.length).toBe(0);
+  });
+
+  it("deduplicates when same agent is targeted by base name AND direct mention", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: null,
+      objective: null,
+      instructions: null,
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { svc, dispatched } = setup(profileRepo);
+
+    svc.register("admin");
+    svc.createChannel("admin", "general");
+
+    const r1 = svc.register("os-dev"); // os-dev-1
+    const id1 = r1.registeredName;
+    svc.subscribe(id1, "general");
+
+    // Mention both the base name (@os-dev) and the specific instance (@os-dev-1)
+    svc.send("admin", "general", `@os-dev and @${id1} check this`);
+
+    expect(dispatched.length).toBe(1);
+    // id1 should appear only once in targetAgents
+    const targets = dispatched[0]!.targetAgents;
+    expect(targets.filter((t) => t === id1).length).toBe(1);
+  });
+});

--- a/tests/hex/core/profile-concurrency.test.ts
+++ b/tests/hex/core/profile-concurrency.test.ts
@@ -1,0 +1,310 @@
+// tests/hex/core/profile-concurrency.test.ts
+//
+// Cross-process concurrency tests for profile-aware registration.
+// Uses Bun.spawn worker pattern to simulate multiple processes racing
+// for profile pool slots via SQLite EXCLUSIVE transactions.
+
+import { describe, it, expect, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { cleanupDb } from "../../helpers/db";
+import { createDb } from "../../../src/storage/sqlite/db";
+import { runMigrations, allMigrations } from "../../../src/storage/sqlite/migrations";
+import { createSqliteRepos } from "../../../src/storage/sqlite";
+import { MessagingService } from "../../../src/core/messaging/service";
+import { YamlProfileStore } from "../../../src/storage/yaml-profiles/store";
+import { SqliteNotificationQueryRepo } from "../../../src/storage/sqlite/notification-query-repo";
+import { createNotificationPoller } from "../../../src/notifications/poller/poller";
+import type { NotificationPort } from "../../../src/core/ports";
+
+const projectRoot = process.cwd();
+
+// Use a fixed (non-PID-suffixed) path so workers can share the same DB.
+const TEST_DB = `/tmp/octo-santa-test-profile-concurrency.sqlite`;
+
+let tempProfileDirs: string[] = [];
+
+afterEach(() => {
+  cleanupDb(TEST_DB);
+  for (const dir of tempProfileDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+  tempProfileDirs = [];
+});
+
+function makeTempProfileDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "octo-santa-profiles-"));
+  tempProfileDirs.push(dir);
+  return dir;
+}
+
+function writeProfileYaml(dir: string, name: string, maxInstances: number): void {
+  const content = `name: ${name}\nmaxInstances: ${maxInstances}\n`;
+  writeFileSync(join(dir, `${name}.yaml`), content, "utf-8");
+}
+
+// Worker script template — runs from /tmp so all imports use absolute paths.
+function makeWorkerScript(profileDir: string, agentName: string): string {
+  return `
+import { createDb } from "${projectRoot}/src/storage/sqlite/db";
+import { runMigrations, allMigrations } from "${projectRoot}/src/storage/sqlite/migrations";
+import { createSqliteRepos } from "${projectRoot}/src/storage/sqlite";
+import { MessagingService } from "${projectRoot}/src/core/messaging/service";
+import { YamlProfileStore } from "${projectRoot}/src/storage/yaml-profiles/store";
+
+const db = createDb("${TEST_DB}");
+runMigrations(db, allMigrations);
+const repos = createSqliteRepos(db);
+const profiles = new YamlProfileStore("${profileDir}");
+const svc = new MessagingService(
+  repos.agents,
+  repos.channels,
+  repos.messages,
+  repos.cursors,
+  process.pid,
+  undefined,
+  profiles
+);
+
+try {
+  const result = svc.register("${agentName}");
+  console.log(JSON.stringify({ ok: true, registeredName: result.registeredName }));
+  db.close();
+} catch (err) {
+  console.error(err.message);
+  db.close();
+  process.exit(1);
+}
+`;
+}
+
+describe("cross-process profile registration concurrency", () => {
+  it("(a) singleton race: 2 workers racing for maxInstances=1 — exactly 1 succeeds", async () => {
+    const profileDir = makeTempProfileDir();
+    writeProfileYaml(profileDir, "os-pm", 1);
+
+    // Set up the DB on disk first (workers will call runMigrations themselves,
+    // but we need the file to exist for cleanupDb to work in afterEach).
+    const setupDb = createDb(TEST_DB);
+    runMigrations(setupDb, allMigrations);
+    setupDb.close();
+
+    const workerScript = makeWorkerScript(profileDir, "os-pm");
+    const workerPath = "/tmp/octo-santa-profile-concurrency-singleton-worker.ts";
+    await Bun.write(workerPath, workerScript);
+
+    // Spawn 2 workers simultaneously
+    const workers = [0, 1].map(() =>
+      Bun.spawn(["bun", "run", workerPath], {
+        cwd: projectRoot,
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+    );
+
+    const exitCodes = await Promise.all(workers.map((w) => w.exited));
+
+    // Gather output for diagnostics
+    const outputs = await Promise.all(
+      workers.map(async (w, i) => ({
+        idx: i,
+        code: exitCodes[i],
+        stdout: await new Response(w.stdout).text(),
+        stderr: await new Response(w.stderr).text(),
+      }))
+    );
+
+    const succeeded = outputs.filter((o) => o.code === 0);
+    const failed = outputs.filter((o) => o.code !== 0);
+
+    if (succeeded.length !== 1) {
+      console.error("Unexpected results:", JSON.stringify(outputs, null, 2));
+    }
+
+    // Exactly 1 worker should have succeeded
+    expect(succeeded).toHaveLength(1);
+    expect(failed).toHaveLength(1);
+
+    // The failed worker should have reported already-active or at-capacity error
+    const failedStderr = failed[0]!.stderr;
+    const isExpectedError =
+      failedStderr.includes("already active") ||
+      failedStderr.includes("at capacity");
+    expect(isExpectedError).toBe(true);
+
+    // Verify DB has exactly 1 agent row for os-pm
+    const db = createDb(TEST_DB);
+    const rows = db.query("SELECT id FROM agents WHERE id = 'os-pm' OR base_name = 'os-pm'").all() as { id: string }[];
+    db.close();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.id).toBe("os-pm");
+  });
+
+  it("(b) pool race: 3 workers racing for 3 slots — all succeed with unique names", async () => {
+    const profileDir = makeTempProfileDir();
+    writeProfileYaml(profileDir, "os-dev", 3);
+
+    // Set up the DB on disk first
+    const setupDb = createDb(TEST_DB);
+    runMigrations(setupDb, allMigrations);
+    setupDb.close();
+
+    const workerScript = makeWorkerScript(profileDir, "os-dev");
+    const workerPath = "/tmp/octo-santa-profile-concurrency-pool-worker.ts";
+    await Bun.write(workerPath, workerScript);
+
+    // Spawn 3 workers simultaneously
+    const workers = [0, 1, 2].map(() =>
+      Bun.spawn(["bun", "run", workerPath], {
+        cwd: projectRoot,
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+    );
+
+    const exitCodes = await Promise.all(workers.map((w) => w.exited));
+
+    const outputs = await Promise.all(
+      workers.map(async (w, i) => ({
+        idx: i,
+        code: exitCodes[i],
+        stdout: await new Response(w.stdout).text(),
+        stderr: await new Response(w.stderr).text(),
+      }))
+    );
+
+    const succeeded = outputs.filter((o) => o.code === 0);
+    const failed = outputs.filter((o) => o.code !== 0);
+
+    if (succeeded.length !== 3) {
+      console.error("Unexpected results:", JSON.stringify(outputs, null, 2));
+    }
+
+    // All 3 workers should succeed
+    expect(succeeded).toHaveLength(3);
+    expect(failed).toHaveLength(0);
+
+    // Parse registered names from stdout
+    const registeredNames = succeeded.map((o) => {
+      const parsed = JSON.parse(o.stdout.trim()) as { ok: boolean; registeredName: string };
+      return parsed.registeredName;
+    });
+
+    // All names should be unique
+    const uniqueNames = new Set(registeredNames);
+    expect(uniqueNames.size).toBe(3);
+
+    // All names should match os-dev-1, os-dev-2, os-dev-3 (in any order)
+    const expected = new Set(["os-dev-1", "os-dev-2", "os-dev-3"]);
+    for (const name of registeredNames) {
+      expect(expected.has(name)).toBe(true);
+    }
+
+    // Verify DB has exactly 3 agent rows with base_name = 'os-dev'
+    const db = createDb(TEST_DB);
+    const rows = db
+      .query("SELECT id FROM agents WHERE base_name = 'os-dev' ORDER BY id")
+      .all() as { id: string }[];
+    db.close();
+
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.id)).toEqual(["os-dev-1", "os-dev-2", "os-dev-3"]);
+  });
+
+  it("(c) cross-process: pool base-name mention triggers poller notification", async () => {
+    const profileDir = makeTempProfileDir();
+    writeProfileYaml(profileDir, "os-dev", 3);
+
+    // Set up DB and register os-dev → os-dev-1, create + subscribe to channel
+    const db = createDb(TEST_DB);
+    runMigrations(db, allMigrations);
+    const repos = createSqliteRepos(db);
+    const profiles = new YamlProfileStore(profileDir);
+    const svc = new MessagingService(
+      repos.agents,
+      repos.channels,
+      repos.messages,
+      repos.cursors,
+      process.pid,
+      undefined,
+      profiles
+    );
+
+    const result = svc.register("os-dev");
+    expect(result.registeredName).toBe("os-dev-1");
+
+    svc.createChannel("os-dev-1", "work");
+    svc.subscribe("os-dev-1", "work");
+    db.close();
+
+    // Spawn worker: registers as "sender", subscribes to "work", sends @os-dev mention.
+    // Must pass the YamlProfileStore so extractMentions recognises "os-dev" as a pool base name.
+    const workerScript = `
+import { createDb } from "${projectRoot}/src/storage/sqlite/db";
+import { runMigrations, allMigrations } from "${projectRoot}/src/storage/sqlite/migrations";
+import { createSqliteRepos } from "${projectRoot}/src/storage/sqlite";
+import { MessagingService } from "${projectRoot}/src/core/messaging/service";
+import { YamlProfileStore } from "${projectRoot}/src/storage/yaml-profiles/store";
+
+const db = createDb("${TEST_DB}");
+runMigrations(db, allMigrations);
+const repos = createSqliteRepos(db);
+const profiles = new YamlProfileStore("${profileDir}");
+const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid, undefined, profiles);
+
+svc.register("sender");
+svc.subscribe("sender", "work");
+svc.send("sender", "work", "Hey @os-dev please review");
+db.close();
+`;
+
+    const tmpWorker = "/tmp/octo-santa-poller-mention-worker.ts";
+    await Bun.write(tmpWorker, workerScript);
+    const proc = Bun.spawn(["bun", "run", tmpWorker], {
+      cwd: projectRoot,
+      stderr: "pipe",
+    });
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text();
+      throw new Error(`Worker failed: ${stderr}`);
+    }
+
+    // Open a fresh DB connection for the poller
+    const db2 = createDb(TEST_DB);
+    const notificationQueries = new SqliteNotificationQueryRepo(db2);
+
+    const notifications: Array<{ content: string; meta: Record<string, string> }> = [];
+    const port: NotificationPort = {
+      notify: async (content, meta) => {
+        notifications.push({ content, meta });
+      },
+    };
+
+    const poller = createNotificationPoller({
+      getNewMessagesForAgent: notificationQueries.getNewMessagesForAgent.bind(notificationQueries),
+      getMaxMessageId: notificationQueries.getMaxMessageId.bind(notificationQueries),
+      port,
+      agentId: "os-dev-1",
+      baseName: "os-dev", // Pool base-name match — this is what we're testing
+    });
+
+    // Manually tick; hwm starts at 0 so all messages since beginning are picked up
+    await poller._tick();
+
+    db2.close();
+
+    // The worker's @os-dev message should have triggered a notification
+    expect(notifications.length).toBeGreaterThan(0);
+    const mentionNotification = notifications.find((n) => n.content.includes("@os-dev"));
+    expect(mentionNotification).toBeDefined();
+    expect(mentionNotification!.meta.sender).toBe("sender");
+    expect(mentionNotification!.meta.channel_name).toBe("work");
+  });
+});

--- a/tests/hex/core/profile-integration.test.ts
+++ b/tests/hex/core/profile-integration.test.ts
@@ -1,0 +1,312 @@
+// tests/hex/core/profile-integration.test.ts
+//
+// Full lifecycle integration test: real YAML profiles on disk + real SQLite.
+// Exercises: register singleton/pool → auto-join → @base-name mention → read →
+// list_agents with persona/objective → agent without profile has null fields.
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  unlinkSync,
+  existsSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createDb } from "../../../src/storage/sqlite/db";
+import { runMigrations, allMigrations } from "../../../src/storage/sqlite/migrations";
+import { createSqliteRepos } from "../../../src/storage/sqlite";
+import { MessagingService } from "../../../src/core/messaging/service";
+import { YamlProfileStore } from "../../../src/storage/yaml-profiles/store";
+
+// ── Captured dispatch helper ───────────────────────────────────────────────
+
+type DispatchCall = {
+  channelName: string;
+  sender: string;
+  content: string;
+  messageId: number;
+  isDm: boolean;
+  targetAgents: string[];
+};
+
+function makeCapturingDispatch() {
+  const dispatched: DispatchCall[] = [];
+  return {
+    dispatched,
+    dispatch(notification: DispatchCall) {
+      dispatched.push({ ...notification });
+    },
+  };
+}
+
+// ── Test fixture ──────────────────────────────────────────────────────────
+
+describe("Profile Integration — Full Lifecycle", () => {
+  let profileDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    profileDir = mkdtempSync(join(tmpdir(), "profiles-integration-"));
+    dbPath = join(tmpdir(), `octo-santa-integration-${Date.now()}-${process.pid}.db`);
+  });
+
+  afterEach(() => {
+    rmSync(profileDir, { recursive: true, force: true });
+    for (const ext of ["", "-wal", "-shm"]) {
+      const f = dbPath + ext;
+      if (existsSync(f)) unlinkSync(f);
+    }
+  });
+
+  it("full lifecycle: profiles → register → auto-join → mention → read → list", () => {
+    // ── Step 1: Write profile YAML files ────────────────────────────────
+
+    writeFileSync(
+      join(profileDir, "os-pm.yaml"),
+      [
+        "name: os-pm",
+        'persona: "Product manager"',
+        'objective: "Drive roadmap"',
+        "maxInstances: 1",
+        "autoJoinChannels:",
+        "  - coordination",
+        'instructions: "When you receive a proposal, evaluate against priorities and provide a clear decision."',
+      ].join("\n")
+    );
+
+    writeFileSync(
+      join(profileDir, "os-dev.yaml"),
+      [
+        "name: os-dev",
+        'persona: "Developer"',
+        'objective: "Ship code"',
+        "maxInstances: 3",
+        "autoJoinChannels:",
+        "  - coordination",
+      ].join("\n")
+    );
+
+    // ── Step 2: Wire up real storage + profile store ─────────────────────
+
+    const profiles = new YamlProfileStore(profileDir);
+    const db = createDb(dbPath);
+    runMigrations(db, allMigrations);
+    const repos = createSqliteRepos(db);
+
+    // ── Step 3: Create coordination channel before registration ──────────
+    // Use an admin MessagingService (no profiles) to create the channel so
+    // auto-join can find it.
+
+    const adminSvc = new MessagingService(
+      repos.agents,
+      repos.channels,
+      repos.messages,
+      repos.cursors,
+      process.pid
+    );
+    adminSvc.register("admin");
+    adminSvc.createChannel("admin", "coordination");
+
+    // ── Step 4: Create profile-aware service with capturing dispatch ──────
+
+    const capturing = makeCapturingDispatch();
+    const svc = new MessagingService(
+      repos.agents,
+      repos.channels,
+      repos.messages,
+      repos.cursors,
+      process.pid,
+      capturing,
+      profiles
+    );
+
+    // ── Step 5a: Register singleton (os-pm, maxInstances=1) ──────────────
+
+    const pmResult = svc.register("os-pm");
+
+    expect(pmResult.registeredName).toBe("os-pm");
+    expect(pmResult.baseName).toBe("os-pm");
+    expect(pmResult.instanceNumber).toBeNull(); // singleton → null
+    expect(pmResult.profile).not.toBeNull();
+    expect(pmResult.profile!.persona).toBe("Product manager");
+    expect(pmResult.autoJoined).not.toBeNull();
+    expect(pmResult.autoJoined!.succeeded).toContain("coordination");
+    expect(pmResult.autoJoined!.failed).toEqual([]);
+    expect(pmResult.profile!.instructions).toBe(
+      "When you receive a proposal, evaluate against priorities and provide a clear decision."
+    );
+
+    // ── Step 5b: Register pool agent (os-dev, maxInstances=3) ─────────────
+
+    const devResult = svc.register("os-dev");
+
+    expect(devResult.registeredName).toBe("os-dev-1");
+    expect(devResult.baseName).toBe("os-dev");
+    expect(devResult.instanceNumber).toBe(1);
+    expect(devResult.profile).not.toBeNull();
+    expect(devResult.profile!.maxInstances).toBe(3);
+    expect(devResult.autoJoined).not.toBeNull();
+    expect(devResult.autoJoined!.succeeded).toContain("coordination");
+    expect(devResult.autoJoined!.failed).toEqual([]);
+
+    // ── Step 6: Send with @base-name ──────────────────────────────────────
+    // os-pm sends "@os-dev" — should expand to os-dev-1 in dispatch
+
+    const msg = svc.send("os-pm", "coordination", "Hey @os-dev, review this");
+    expect(msg.agent_id).toBe("os-pm");
+
+    // The stored mentions should contain the raw base name "os-dev"
+    const msgRow = db
+      .query("SELECT mentions FROM messages WHERE id = ?")
+      .get(msg.id) as { mentions: string } | null;
+    expect(msgRow).not.toBeNull();
+    const storedMentions = JSON.parse(msgRow!.mentions) as string[];
+    expect(storedMentions).toContain("os-dev");
+
+    // Dispatch targets should include "os-dev-1" (expanded from base name)
+    expect(capturing.dispatched.length).toBeGreaterThanOrEqual(1);
+    const dispatchCall = capturing.dispatched.find(
+      (d) => d.messageId === msg.id
+    );
+    expect(dispatchCall).toBeDefined();
+    expect(dispatchCall!.targetAgents).toContain("os-dev-1");
+
+    // ── Step 7: Read messages ─────────────────────────────────────────────
+
+    const messages = svc.read("os-dev-1", "coordination");
+    expect(messages.length).toBeGreaterThanOrEqual(1);
+    const found = messages.find((m) => m.id === msg.id);
+    expect(found).toBeDefined();
+    expect(found!.content).toBe("Hey @os-dev, review this");
+
+    // ── Step 8: listAgents with persona/objective ─────────────────────────
+
+    const agents = svc.listAgents(true); // include stale to see all
+
+    const pmAgent = agents.find((a) => a.id === "os-pm");
+    expect(pmAgent).toBeDefined();
+    expect(pmAgent!.persona).toBe("Product manager");
+    expect(pmAgent!.objective).toBe("Drive roadmap");
+    expect(pmAgent!.instructions).toBe(
+      "When you receive a proposal, evaluate against priorities and provide a clear decision."
+    );
+
+    // Verify DB persistence directly via raw SQL
+    const row = db.query("SELECT instructions FROM agents WHERE id = ?").get("os-pm") as { instructions: string } | null;
+    expect(row).not.toBeNull();
+    expect(row!.instructions).toBe(
+      "When you receive a proposal, evaluate against priorities and provide a clear decision."
+    );
+
+    const devAgent = agents.find((a) => a.id === "os-dev-1");
+    expect(devAgent).toBeDefined();
+    expect(devAgent!.persona).toBe("Developer");
+    expect(devAgent!.objective).toBe("Ship code");
+
+    // ── Step 9: Agent without profile has null fields ─────────────────────
+
+    const botResult = svc.register("random-bot");
+    expect(botResult.registeredName).toBe("random-bot");
+    expect(botResult.baseName).toBeNull();
+    expect(botResult.profile).toBeNull();
+    expect(botResult.autoJoined).toBeNull();
+
+    const botAgent = svc.listAgents(true).find((a) => a.id === "random-bot");
+    expect(botAgent).toBeDefined();
+    expect(botAgent!.persona).toBeNull();
+    expect(botAgent!.objective).toBeNull();
+    expect(botAgent!.base_name).toBeNull();
+    expect(botAgent!.instructions).toBeNull();
+
+    db.close();
+  });
+
+  it("getInstructions returns profile instructions for registered agent", () => {
+    writeFileSync(
+      join(profileDir, "os-pm.yaml"),
+      [
+        "name: os-pm",
+        'persona: "Product manager"',
+        'objective: "Drive roadmap"',
+        'instructions: "Evaluate proposals against priorities."',
+      ].join("\n")
+    );
+
+    const profiles = new YamlProfileStore(profileDir);
+    const db = createDb(dbPath);
+    runMigrations(db, allMigrations);
+    const repos = createSqliteRepos(db);
+    const svc = new MessagingService(
+      repos.agents, repos.channels, repos.messages, repos.cursors,
+      process.pid, undefined, profiles
+    );
+
+    svc.register("os-pm");
+    const result = svc.getInstructions("os-pm");
+    expect(result.profile).not.toBeNull();
+    expect(result.profile!.instructions).toBe("Evaluate proposals against priorities.");
+    expect(result.profile!.persona).toBe("Product manager");
+
+    db.close();
+  });
+
+  it("getInstructions returns null profile for agent without profile", () => {
+    const db = createDb(dbPath);
+    runMigrations(db, allMigrations);
+    const repos = createSqliteRepos(db);
+    const svc = new MessagingService(
+      repos.agents, repos.channels, repos.messages, repos.cursors,
+      process.pid
+    );
+
+    svc.register("random-bot");
+    const result = svc.getInstructions("random-bot");
+    expect(result.profile).toBeNull();
+
+    db.close();
+  });
+
+  it("getInstructions throws for unregistered agent", () => {
+    const db = createDb(dbPath);
+    runMigrations(db, allMigrations);
+    const repos = createSqliteRepos(db);
+    const svc = new MessagingService(
+      repos.agents, repos.channels, repos.messages, repos.cursors,
+      process.pid
+    );
+
+    expect(() => svc.getInstructions("nobody")).toThrow(/messaging_register/);
+
+    db.close();
+  });
+
+  it("getInstructions returns universal as null (transport layer populates it)", () => {
+    writeFileSync(
+      join(profileDir, "os-pm.yaml"),
+      [
+        "name: os-pm",
+        'persona: "Product manager"',
+        'instructions: "Evaluate proposals."',
+      ].join("\n")
+    );
+
+    const profiles = new YamlProfileStore(profileDir);
+    const db = createDb(dbPath);
+    runMigrations(db, allMigrations);
+    const repos = createSqliteRepos(db);
+    const svc = new MessagingService(
+      repos.agents, repos.channels, repos.messages, repos.cursors,
+      process.pid, undefined, profiles
+    );
+
+    svc.register("os-pm");
+    const result = svc.getInstructions("os-pm");
+    expect(result.universal).toBeNull();
+    expect(result.profile).not.toBeNull();
+    expect(result.profile!.instructions).toBe("Evaluate proposals.");
+
+    db.close();
+  });
+});

--- a/tests/hex/core/profile-registration.test.ts
+++ b/tests/hex/core/profile-registration.test.ts
@@ -1,0 +1,487 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { MessagingService } from "../../../src/core/messaging/service";
+import { createSqliteRepos } from "../../../src/storage/sqlite";
+import { createDb } from "../../../src/storage/sqlite/db";
+import { runMigrations, allMigrations } from "../../../src/storage/sqlite/migrations";
+import { cleanupDb } from "../../helpers/db";
+import type { ProfileRepository } from "../../../src/core/ports";
+import type { AgentProfile } from "../../../src/core/profiles/types";
+
+const TEST_DB = `/tmp/octo-santa-test-hex-profile-reg-${process.pid}.sqlite`;
+
+// ── In-memory ProfileRepository for tests ─────────────────────────────────
+
+class InMemoryProfileRepo implements ProfileRepository {
+  private profiles = new Map<string, AgentProfile>();
+
+  add(profile: AgentProfile): void {
+    this.profiles.set(profile.name, profile);
+  }
+
+  getProfile(baseName: string): AgentProfile | null {
+    return this.profiles.get(baseName) ?? null;
+  }
+
+  listProfiles(): AgentProfile[] {
+    return [...this.profiles.values()];
+  }
+
+  getBaseNames(): Set<string> {
+    return new Set(this.profiles.keys());
+  }
+}
+
+// ── Setup helpers ──────────────────────────────────────────────────────────
+
+function setup(profileRepo?: ProfileRepository) {
+  cleanupDb(TEST_DB);
+  const db = createDb(TEST_DB);
+  runMigrations(db, allMigrations);
+  const repos = createSqliteRepos(db);
+  const svc = new MessagingService(
+    repos.agents,
+    repos.channels,
+    repos.messages,
+    repos.cursors,
+    process.pid,
+    undefined, // dispatch
+    profileRepo
+  );
+  return { db, repos, svc };
+}
+
+afterEach(() => cleanupDb(TEST_DB));
+
+// ── Singleton profile registration ────────────────────────────────────────
+
+describe("singleton profile registration", () => {
+  it("registers agent under profile and returns RegisterResult with profile fields", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: "Senior developer",
+      objective: "Write clean code",
+      instructions: null,
+      maxInstances: 1,
+      autoJoinChannels: [],
+    });
+
+    const { svc } = setup(profileRepo);
+    const result = svc.register("os-dev");
+
+    // Core Agent fields
+    expect(result.id).toBe("os-dev");
+    expect(result.pid).toBe(process.pid);
+
+    // RegisterResult fields
+    expect(result.registeredName).toBe("os-dev");
+    expect(result.baseName).toBe("os-dev");
+    expect(result.instanceNumber).toBeNull(); // singleton → null
+    expect(result.profile).not.toBeNull();
+    expect(result.profile!.persona).toBe("Senior developer");
+    expect(result.profile!.objective).toBe("Write clean code");
+    expect(result.profile!.maxInstances).toBe(1);
+    expect(result.autoJoined).not.toBeNull();
+    expect(result.autoJoined!.succeeded).toEqual([]);
+    expect(result.autoJoined!.failed).toEqual([]);
+  });
+
+  it("stores base_name, persona, objective in DB for singleton", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: "Senior developer",
+      objective: "Write clean code",
+      instructions: null,
+      maxInstances: 1,
+      autoJoinChannels: [],
+    });
+
+    const { svc, db } = setup(profileRepo);
+    svc.register("os-dev");
+
+    const row = db.query("SELECT * FROM agents WHERE id = ?").get("os-dev") as {
+      base_name: string | null;
+      persona: string | null;
+      objective: string | null;
+    };
+    expect(row).not.toBeNull();
+    expect(row.base_name).toBe("os-dev");
+    expect(row.persona).toBe("Senior developer");
+    expect(row.objective).toBe("Write clean code");
+  });
+});
+
+// ── Pool profile registration (multiple instances) ─────────────────────────
+
+describe("pool profile registration", () => {
+  it("assigns instance-1 to first pool member", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "worker",
+      persona: null,
+      objective: "Process tasks",
+      instructions: null,
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { svc } = setup(profileRepo);
+    const result = svc.register("worker");
+
+    expect(result.registeredName).toBe("worker-1");
+    expect(result.baseName).toBe("worker");
+    expect(result.instanceNumber).toBe(1);
+    expect(result.profile!.maxInstances).toBe(3);
+  });
+
+  it("same-PID re-registration is idempotent for singleton", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-pm",
+      persona: "Product manager",
+      objective: null,
+      instructions: null,
+      maxInstances: 1,
+      autoJoinChannels: [],
+    });
+
+    const { svc } = setup(profileRepo);
+    const first = svc.register("os-pm");
+    const second = svc.register("os-pm");
+    expect(second.registeredName).toBe(first.registeredName);
+    expect(second.registeredName).toBe("os-pm");
+  });
+
+  it("same-PID re-registration is idempotent for pool", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "worker",
+      persona: null,
+      objective: "Process tasks",
+      instructions: null,
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { svc } = setup(profileRepo);
+    const first = svc.register("worker");
+    const second = svc.register("worker");
+
+    // Same PID → same slot returned
+    expect(second.registeredName).toBe(first.registeredName);
+    expect(second.instanceNumber).toBe(first.instanceNumber);
+  });
+
+  it("reclaims dead slot when all slots are taken but one is dead", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "worker",
+      persona: null,
+      objective: "Process tasks",
+      instructions: null,
+      maxInstances: 2,
+      autoJoinChannels: [],
+    });
+
+    cleanupDb(TEST_DB);
+    const db = createDb(TEST_DB);
+    runMigrations(db, allMigrations);
+    const repos = createSqliteRepos(db);
+
+    // Manually insert two dead workers
+    const now = Date.now();
+    db.run(
+      "INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name) VALUES (?, ?, ?, ?, ?, ?)",
+      ["worker-1", now, now - 1, 999999, now - 1, "worker"]  // dead PID
+    );
+    db.run(
+      "INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name) VALUES (?, ?, ?, ?, ?, ?)",
+      ["worker-2", now, now - 1, 999998, now - 1, "worker"]  // dead PID
+    );
+
+    const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid, undefined, profileRepo);
+    const result = svc.register("worker");
+
+    // Should reclaim slot 1 (lowest dead slot)
+    expect(result.instanceNumber).toBe(1);
+    expect(result.registeredName).toBe("worker-1");
+    expect(result.pid).toBe(process.pid);
+  });
+});
+
+// ── Backward compatibility — no profile, no profile repo ───────────────────
+
+describe("backward compatibility — no profile", () => {
+  it("registers normally without profile repo (undefined)", () => {
+    const { svc } = setup(undefined); // no profileRepo
+    const result = svc.register("alice");
+
+    expect(result.id).toBe("alice");
+    expect(result.registeredName).toBe("alice");
+    expect(result.baseName).toBeNull();
+    expect(result.instanceNumber).toBeNull();
+    expect(result.profile).toBeNull();
+    expect(result.autoJoined).toBeNull();
+  });
+
+  it("registers normally with profile repo but no matching profile", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    // No profiles added for "alice"
+
+    const { svc } = setup(profileRepo);
+    const result = svc.register("alice");
+
+    expect(result.registeredName).toBe("alice");
+    expect(result.baseName).toBeNull();
+    expect(result.profile).toBeNull();
+    expect(result.autoJoined).toBeNull();
+  });
+
+  it("still allows register() return value to be used as Agent (structural compat)", () => {
+    const { svc } = setup(undefined);
+    const result = svc.register("alice");
+
+    // All Agent fields must be accessible
+    expect(typeof result.id).toBe("string");
+    expect(typeof result.created_at).toBe("number");
+    expect(typeof result.last_seen_at).toBe("number");
+    // pid is number or null (number when just registered)
+    expect(result.pid).toBe(process.pid);
+  });
+});
+
+// ── Suffixed namespace reservation (Decision #14) ──────────────────────────
+
+describe("suffixed namespace reservation", () => {
+  it("rejects registering as 'os-dev-2' when 'os-dev' profile exists", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: null,
+      objective: null,
+      instructions: null,
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { svc } = setup(profileRepo);
+
+    expect(() => svc.register("os-dev-2")).toThrow(
+      `Name "os-dev-2" is reserved by pool profile "os-dev". Register as "os-dev" to join the pool.`
+    );
+  });
+
+  it("rejects 'worker-10' when 'worker' profile exists", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "worker",
+      persona: null,
+      objective: null,
+      instructions: null,
+      maxInstances: 5,
+      autoJoinChannels: [],
+    });
+
+    const { svc } = setup(profileRepo);
+
+    expect(() => svc.register("worker-10")).toThrow(
+      `Name "worker-10" is reserved by pool profile "worker".`
+    );
+  });
+
+  it("allows registering 'os-dev-2' when no profile exists for 'os-dev'", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    // No profile for "os-dev"
+
+    const { svc } = setup(profileRepo);
+
+    // Should not throw — no profile reservation applies
+    expect(() => svc.register("os-dev-2")).not.toThrow();
+    const result = svc.register("os-dev-2"); // second call — idempotent
+    expect(result.registeredName).toBe("os-dev-2");
+  });
+
+  it("allows registering 'os-dev-2' when profileRepo is absent", () => {
+    const { svc } = setup(undefined); // no profile repo
+
+    expect(() => svc.register("os-dev-2")).not.toThrow();
+    const result = svc.register("os-dev-2");
+    expect(result.registeredName).toBe("os-dev-2");
+  });
+
+  it("only blocks numeric suffixes — 'os-dev-extra' is not rejected", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: null,
+      objective: null,
+      instructions: null,
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { svc } = setup(profileRepo);
+
+    // "os-dev-extra" does not match {base}-\d+ pattern → allowed
+    expect(() => svc.register("os-dev-extra")).not.toThrow();
+  });
+});
+
+// ── Auto-join channels ─────────────────────────────────────────────────────
+
+describe("auto-join channels", () => {
+  it("auto-joins existing channels listed in profile", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: null,
+      objective: null,
+      instructions: null,
+      maxInstances: 1,
+      autoJoinChannels: ["general", "dev"],
+    });
+
+    cleanupDb(TEST_DB);
+    const db = createDb(TEST_DB);
+    runMigrations(db, allMigrations);
+    const repos = createSqliteRepos(db);
+
+    // Pre-create channels using a bootstrap agent
+    const bootstrap = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid);
+    bootstrap.register("admin");
+    bootstrap.createChannel("admin", "general");
+    bootstrap.createChannel("admin", "dev");
+
+    const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid, undefined, profileRepo);
+    const result = svc.register("os-dev");
+
+    expect(result.autoJoined).not.toBeNull();
+    expect(result.autoJoined!.succeeded.sort()).toEqual(["dev", "general"]);
+    expect(result.autoJoined!.failed).toEqual([]);
+
+    // Verify agent is actually a member
+    const members = bootstrap.listMembers("general");
+    const member = members.find((m) => m.agent_id === "os-dev");
+    expect(member).toBeDefined();
+  });
+
+  it("records failure in autoJoined.failed for non-existent channels", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: null,
+      objective: null,
+      instructions: null,
+      maxInstances: 1,
+      autoJoinChannels: ["nonexistent-channel"],
+    });
+
+    const { svc } = setup(profileRepo);
+    const result = svc.register("os-dev");
+
+    expect(result.autoJoined!.succeeded).toEqual([]);
+    expect(result.autoJoined!.failed.length).toBe(1);
+    expect(result.autoJoined!.failed[0]!.channel).toBe("nonexistent-channel");
+  });
+
+  it("partially succeeds: joins existing channels, records failure for missing ones", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: null,
+      objective: null,
+      instructions: null,
+      maxInstances: 1,
+      autoJoinChannels: ["general", "missing-channel"],
+    });
+
+    cleanupDb(TEST_DB);
+    const db = createDb(TEST_DB);
+    runMigrations(db, allMigrations);
+    const repos = createSqliteRepos(db);
+
+    const bootstrap = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid);
+    bootstrap.register("admin");
+    bootstrap.createChannel("admin", "general");
+
+    const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid, undefined, profileRepo);
+    const result = svc.register("os-dev");
+
+    expect(result.autoJoined!.succeeded).toEqual(["general"]);
+    expect(result.autoJoined!.failed.length).toBe(1);
+    expect(result.autoJoined!.failed[0]!.channel).toBe("missing-channel");
+  });
+
+  it("auto-join does not throw for pool profile — uses registeredName for channel membership", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "worker",
+      persona: null,
+      objective: null,
+      instructions: null,
+      maxInstances: 3,
+      autoJoinChannels: ["tasks"],
+    });
+
+    cleanupDb(TEST_DB);
+    const db = createDb(TEST_DB);
+    runMigrations(db, allMigrations);
+    const repos = createSqliteRepos(db);
+
+    const bootstrap = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid);
+    bootstrap.register("admin");
+    bootstrap.createChannel("admin", "tasks");
+
+    const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid, undefined, profileRepo);
+    const result = svc.register("worker");
+
+    expect(result.registeredName).toBe("worker-1");
+    expect(result.autoJoined!.succeeded).toEqual(["tasks"]);
+
+    // Verify worker-1 is a member of tasks
+    const members = bootstrap.listMembers("tasks");
+    expect(members.find((m) => m.agent_id === "worker-1")).toBeDefined();
+  });
+});
+
+// ── RegisterResult type compatibility ─────────────────────────────────────
+
+describe("RegisterResult type shape", () => {
+  it("register() returns all required fields in all paths", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: "dev",
+      objective: "code",
+      instructions: null,
+      maxInstances: 1,
+      autoJoinChannels: [],
+    });
+
+    cleanupDb(TEST_DB);
+    const db = createDb(TEST_DB);
+    runMigrations(db, allMigrations);
+    const repos = createSqliteRepos(db);
+    const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid, undefined, profileRepo);
+
+    const withProfile = svc.register("os-dev");
+    expect(withProfile).toHaveProperty("registeredName");
+    expect(withProfile).toHaveProperty("baseName");
+    expect(withProfile).toHaveProperty("instanceNumber");
+    expect(withProfile).toHaveProperty("profile");
+    expect(withProfile).toHaveProperty("autoJoined");
+
+    // Register a plain agent (no profile) from same service
+    const svc2 = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid);
+    const noProfile = svc2.register("plain-agent");
+    expect(noProfile).toHaveProperty("registeredName");
+    expect(noProfile).toHaveProperty("baseName");
+    expect(noProfile).toHaveProperty("instanceNumber");
+    expect(noProfile).toHaveProperty("profile");
+    expect(noProfile).toHaveProperty("autoJoined");
+    expect(noProfile.baseName).toBeNull();
+    expect(noProfile.profile).toBeNull();
+    expect(noProfile.autoJoined).toBeNull();
+  });
+});

--- a/tests/hex/core/safety-rails-cross-process.test.ts
+++ b/tests/hex/core/safety-rails-cross-process.test.ts
@@ -1,0 +1,142 @@
+// tests/hex/core/safety-rails-cross-process.test.ts
+import { describe, it, expect, afterEach } from "bun:test";
+import { cleanupDb } from "../../helpers/db";
+import { createDb } from "../../../src/storage/sqlite/db";
+import { runMigrations, allMigrations } from "../../../src/storage/sqlite/migrations";
+import { createSqliteRepos } from "../../../src/storage/sqlite";
+import { MessagingService } from "../../../src/core/messaging/service";
+import { existsSync, unlinkSync } from "fs";
+
+const projectRoot = process.cwd();
+const TEST_DB = `/tmp/octo-santa-test-safety-rails-cross-process-${process.pid}.sqlite`;
+
+afterEach(() => {
+  cleanupDb(TEST_DB);
+});
+
+describe("hop counter atomicity across processes", () => {
+  it("two worker processes share hop counter via SQLite -- total messages capped at explicit max_hops=4", async () => {
+    // ── Setup: create channel with explicit max_hops=4 in main process ─────
+    {
+      const db = createDb(TEST_DB);
+      runMigrations(db, allMigrations);
+      const repos = createSqliteRepos(db);
+      const svc = new MessagingService(
+        repos.agents,
+        repos.channels,
+        repos.messages,
+        repos.cursors,
+        process.pid
+      );
+
+      svc.register("worker-a");
+      svc.register("worker-b");
+      svc.createChannel("worker-a", "hop-test", 4); // explicit max_hops=4 for this test
+      svc.subscribe("worker-a", "hop-test");
+      svc.subscribe("worker-b", "hop-test");
+
+      // Unregister so workers can re-register under their own PIDs
+      svc.unregister("worker-a");
+      svc.unregister("worker-b");
+      db.close();
+    }
+
+    // ── Worker script: tries to send 3 messages, handles hop limit gracefully ──
+    const makeWorkerScript = (agentId: string) => `
+      import { createDb } from "${projectRoot}/src/storage/sqlite/db";
+      import { runMigrations, allMigrations } from "${projectRoot}/src/storage/sqlite/migrations";
+      import { createSqliteRepos } from "${projectRoot}/src/storage/sqlite";
+      import { MessagingService } from "${projectRoot}/src/core/messaging/service";
+
+      const db = createDb("${TEST_DB}");
+      runMigrations(db, allMigrations);
+      const repos = createSqliteRepos(db);
+      const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid);
+
+      svc.register("${agentId}");
+
+      let sent = 0;
+      for (let i = 0; i < 3; i++) {
+        try {
+          svc.send("${agentId}", "hop-test", "msg-${agentId}-" + i);
+          sent++;
+        } catch (e) {
+          // Hop limit reached -- expected
+          break;
+        }
+      }
+
+      db.close();
+      process.exit(0);
+    `;
+
+    const workerPathA = "/tmp/octo-santa-hop-worker-a.ts";
+    const workerPathB = "/tmp/octo-santa-hop-worker-b.ts";
+    await Bun.write(workerPathA, makeWorkerScript("worker-a"));
+    await Bun.write(workerPathB, makeWorkerScript("worker-b"));
+
+    // ── Spawn both workers concurrently ────────────────────────────────────
+    const workerA = Bun.spawn(["bun", "run", workerPathA], {
+      cwd: process.cwd(),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const workerB = Bun.spawn(["bun", "run", workerPathB], {
+      cwd: process.cwd(),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [exitA, exitB] = await Promise.all([workerA.exited, workerB.exited]);
+
+    if (exitA !== 0) {
+      const stderr = await new Response(workerA.stderr).text();
+      console.error(`Worker A failed (code ${exitA}): ${stderr}`);
+    }
+    if (exitB !== 0) {
+      const stderr = await new Response(workerB.stderr).text();
+      console.error(`Worker B failed (code ${exitB}): ${stderr}`);
+    }
+
+    expect(exitA).toBe(0);
+    expect(exitB).toBe(0);
+
+    // ── Verify: exactly 4 non-system messages and hop_count=4 ──────────────
+    const db2 = createDb(TEST_DB);
+    runMigrations(db2, allMigrations);
+
+    const channelRow = db2
+      .query<{ id: number; hop_count: number }, [string]>(
+        "SELECT id, hop_count FROM channels WHERE name = ?"
+      )
+      .get("hop-test");
+
+    expect(channelRow).not.toBeNull();
+    const channelId = channelRow!.id;
+
+    const userMessages = db2
+      .query<{ id: number; content: string; agent_id: string }, [number]>(
+        "SELECT id, content, agent_id FROM messages WHERE channel_id = ? AND agent_id != '_system' ORDER BY id"
+      )
+      .all(channelId);
+
+    // Exactly 4 messages got through (hop counter shared atomically)
+    expect(userMessages.length).toBe(4);
+
+    // hop_count is exactly 4 (at the limit)
+    expect(channelRow!.hop_count).toBe(4);
+
+    // Both workers contributed at least 1 message (not one process monopolised all 4)
+    const fromA = userMessages.filter((m) => m.agent_id === "worker-a").length;
+    const fromB = userMessages.filter((m) => m.agent_id === "worker-b").length;
+    expect(fromA).toBeGreaterThanOrEqual(1);
+    expect(fromB).toBeGreaterThanOrEqual(1);
+
+    db2.close();
+
+    // Cleanup temp worker files
+    for (const p of [workerPathA, workerPathB]) {
+      if (existsSync(p)) unlinkSync(p);
+    }
+  });
+});

--- a/tests/hex/core/safety-rails-integration.test.ts
+++ b/tests/hex/core/safety-rails-integration.test.ts
@@ -1,0 +1,231 @@
+// tests/hex/core/safety-rails-integration.test.ts
+//
+// Full lifecycle integration tests for safety rails: hop counter and
+// self-mention guard running against real SQLite.
+
+import { describe, it, expect, afterEach } from "bun:test";
+import { MessagingService } from "../../../src/core/messaging/service";
+import { createSqliteRepos } from "../../../src/storage/sqlite";
+import { createDb } from "../../../src/storage/sqlite/db";
+import { runMigrations, allMigrations } from "../../../src/storage/sqlite/migrations";
+import { cleanupDb } from "../../helpers/db";
+import type { Database } from "bun:sqlite";
+
+const TEST_DB = `/tmp/octo-santa-test-safety-integration-${process.pid}.sqlite`;
+
+function setup() {
+  cleanupDb(TEST_DB);
+  const db = createDb(TEST_DB);
+  runMigrations(db, allMigrations);
+  const repos = createSqliteRepos(db);
+  const svc = new MessagingService(
+    repos.agents,
+    repos.channels,
+    repos.messages,
+    repos.cursors,
+    process.pid
+  );
+  return { db, repos, svc };
+}
+
+afterEach(() => cleanupDb(TEST_DB));
+
+// ── Verification helpers ───────────────────────────────────────────────────
+
+function getHopCount(db: Database, channelName: string): number {
+  const row = db
+    .query<{ hop_count: number }, [string]>(
+      "SELECT hop_count FROM channels WHERE name = ?"
+    )
+    .get(channelName);
+  return row?.hop_count ?? -1;
+}
+
+function getMessages(db: Database, channelName: string) {
+  return db
+    .query<{ id: number; agent_id: string; content: string }, [string]>(
+      "SELECT m.id, m.agent_id, m.content FROM messages m JOIN channels c ON m.channel_id = c.id WHERE c.name = ? ORDER BY m.id"
+    )
+    .all(channelName);
+}
+
+// ── Test 1: Ping-pong full lifecycle ──────────────────────────────────────
+
+describe("safety rails integration - ping-pong lifecycle", () => {
+  it("two agents ping-pong until hop limit, /continue, then human reset", () => {
+    const { db, svc } = setup();
+
+    // Step 1: Create channel with explicit max_hops=4 (test the hop limit mechanism at a low value)
+    svc.register("agent-a");
+    svc.register("agent-b");
+    const channel = svc.createChannel("agent-a", "test-channel", 4);
+    svc.subscribe("agent-b", "test-channel");
+
+    // Step 2: Ping-pong to hop=4
+    svc.send("agent-a", "test-channel", "hop 1"); // hop 1
+    svc.send("agent-b", "test-channel", "hop 2"); // hop 2
+    svc.send("agent-a", "test-channel", "hop 3"); // hop 3
+    svc.send("agent-b", "test-channel", "hop 4"); // hop 4
+
+    expect(getHopCount(db, "test-channel")).toBe(4);
+
+    // Step 3: Agent A tries to send (hop 5) — blocked
+    expect(() => svc.send("agent-a", "test-channel", "hop 5 - should fail")).toThrow(
+      "Hop limit reached (4/4) in #test-channel. Message dropped. Only a human can /continue."
+    );
+
+    // Step 4: Verify _system message exists with hop limit text
+    const messages = getMessages(db, "test-channel");
+    const systemMsgs = messages.filter((m) => m.agent_id === "_system");
+    expect(systemMsgs.length).toBe(1);
+    expect(systemMsgs[0]!.content).toBe(
+      "hop limit reached (4/4) in #test-channel -- message from @agent-a blocked. Waiting for human input."
+    );
+
+    // Step 5: /continue +4 — hop_count decremented by 4
+    const continueResult = svc.continueChannel("agent-a", "test-channel", 4);
+    expect(continueResult.hopCount).toBe(0);
+    expect(continueResult.maxHops).toBe(4);
+    expect(continueResult.bumped).toBe(4);
+    expect(getHopCount(db, "test-channel")).toBe(0);
+
+    // Step 6: Agent A can send again after /continue
+    expect(() => svc.send("agent-a", "test-channel", "back in action")).not.toThrow();
+    expect(getHopCount(db, "test-channel")).toBe(1);
+
+    // Step 7: Human sends { human: true } → hop_count reset to 0
+    svc.send("agent-a", "test-channel", "a human speaks", { human: true });
+    expect(getHopCount(db, "test-channel")).toBe(0);
+
+    // Step 8: Verify all messages in correct order (hop1..hop4, _system, back-in-action, human)
+    const allMsgs = getMessages(db, "test-channel");
+    const agentMsgs = allMsgs.filter((m) => m.agent_id !== "_system");
+    expect(agentMsgs[0]!.content).toBe("hop 1");
+    expect(agentMsgs[0]!.agent_id).toBe("agent-a");
+    expect(agentMsgs[1]!.content).toBe("hop 2");
+    expect(agentMsgs[1]!.agent_id).toBe("agent-b");
+    expect(agentMsgs[2]!.content).toBe("hop 3");
+    expect(agentMsgs[2]!.agent_id).toBe("agent-a");
+    expect(agentMsgs[3]!.content).toBe("hop 4");
+    expect(agentMsgs[3]!.agent_id).toBe("agent-b");
+    expect(agentMsgs[4]!.content).toBe("back in action");
+    expect(agentMsgs[4]!.agent_id).toBe("agent-a");
+    expect(agentMsgs[5]!.content).toBe("a human speaks");
+    expect(agentMsgs[5]!.agent_id).toBe("agent-a");
+
+    // _system notice appears after hop 4 messages
+    const systemIdx = allMsgs.findIndex((m) => m.agent_id === "_system");
+    const hop4Idx = allMsgs.findIndex((m) => m.content === "hop 4");
+    const backIdx = allMsgs.findIndex((m) => m.content === "back in action");
+    expect(systemIdx).toBeGreaterThan(hop4Idx);
+    expect(backIdx).toBeGreaterThan(systemIdx);
+  });
+});
+
+// ── Test 2: Custom max_hops on channel creation ───────────────────────────
+
+describe("safety rails integration - custom max_hops", () => {
+  it("channel with maxHops=2 blocks on third send", () => {
+    const { db, svc } = setup();
+
+    // Step 1: Create channel with maxHops=2
+    svc.register("agent-a");
+    svc.createChannel("agent-a", "tight-channel", 2);
+
+    // Step 2: Agent sends twice — succeeds
+    expect(() => svc.send("agent-a", "tight-channel", "send 1")).not.toThrow();
+    expect(() => svc.send("agent-a", "tight-channel", "send 2")).not.toThrow();
+    expect(getHopCount(db, "tight-channel")).toBe(2);
+
+    // Step 3: Third send — blocked
+    expect(() => svc.send("agent-a", "tight-channel", "send 3")).toThrow(
+      "Hop limit reached (2/2) in #tight-channel. Message dropped. Only a human can /continue."
+    );
+
+    // Verify blocked message was NOT inserted
+    const msgs = getMessages(db, "tight-channel");
+    const agentMsgs = msgs.filter((m) => m.agent_id === "agent-a");
+    expect(agentMsgs.length).toBe(2);
+    expect(agentMsgs.some((m) => m.content === "send 3")).toBe(false);
+
+    // Verify _system notice was posted
+    const systemMsgs = msgs.filter((m) => m.agent_id === "_system");
+    expect(systemMsgs.length).toBe(1);
+    expect(systemMsgs[0]!.content).toBe(
+      "hop limit reached (2/2) in #tight-channel -- message from @agent-a blocked. Waiting for human input."
+    );
+  });
+});
+
+// ── Test 3: Self-mention blocked ──────────────────────────────────────────
+
+describe("safety rails integration - self-mention blocked", () => {
+  it("agent sends message containing @self - error thrown, no message inserted", () => {
+    const { db, svc } = setup();
+
+    // Step 1: Register agent and create channel
+    svc.register("agent-x");
+    svc.createChannel("agent-x", "self-mention-channel");
+
+    // Step 2: Agent sends message containing @self — error thrown
+    expect(() =>
+      svc.send("agent-x", "self-mention-channel", "hey @agent-x look at this")
+    ).toThrow("Cannot @mention yourself in a message");
+
+    // Step 3: Verify no message was inserted
+    const msgs = getMessages(db, "self-mention-channel");
+    expect(msgs.length).toBe(0);
+
+    // Hop count should also remain at 0 (self-mention check happens before hop increment)
+    expect(getHopCount(db, "self-mention-channel")).toBe(0);
+  });
+});
+
+// ── Test 4: DM hop counter ────────────────────────────────────────────────
+
+describe("safety rails integration - DM hop counter", () => {
+  it("two agents DM back and forth and hit explicit limit (channel pre-created with max_hops=4)", () => {
+    const { db, svc } = setup();
+
+    // Step 1: Register two agents
+    svc.register("dm-alice");
+    svc.register("dm-bob");
+
+    const dmName = ["dm-alice", "dm-bob"].sort().join(",");
+
+    // Pre-create DM channel with explicit max_hops=4 so the hop-limit mechanism
+    // can be exercised without sending 50 DMs. directMessage() will find this
+    // channel via ON CONFLICT DO NOTHING and use its existing limit.
+    svc.createChannel("dm-alice", dmName, 4);
+
+    // Step 2: Send 4 DMs alternating — should succeed
+    svc.directMessage("dm-alice", "dm-bob", "hello bob");   // hop 1
+    svc.directMessage("dm-bob", "dm-alice", "hello alice"); // hop 2
+    svc.directMessage("dm-alice", "dm-bob", "how are you"); // hop 3
+    svc.directMessage("dm-bob", "dm-alice", "doing well");  // hop 4
+
+    expect(getHopCount(db, dmName)).toBe(4);
+
+    // Step 3: Fifth DM hits the configured limit (4)
+    expect(() => svc.directMessage("dm-alice", "dm-bob", "one more")).toThrow(
+      `Hop limit reached (4/4) in #${dmName}. Message dropped. Only a human can /continue.`
+    );
+
+    // Verify _system notice was posted in the DM channel
+    const msgs = getMessages(db, dmName);
+    const systemMsgs = msgs.filter((m) => m.agent_id === "_system");
+    expect(systemMsgs.length).toBe(1);
+    expect(systemMsgs[0]!.content).toContain("hop limit reached (4/4)");
+    expect(systemMsgs[0]!.content).toContain("Waiting for human input.");
+
+    // Hop count stays at 4
+    expect(getHopCount(db, dmName)).toBe(4);
+
+    // /continue allows more DMs
+    svc.continueChannel("dm-alice", dmName, 4);
+    expect(getHopCount(db, dmName)).toBe(0);
+
+    expect(() => svc.directMessage("dm-alice", "dm-bob", "resumed")).not.toThrow();
+    expect(getHopCount(db, dmName)).toBe(1);
+  });
+});

--- a/tests/hex/core/safety-rails.test.ts
+++ b/tests/hex/core/safety-rails.test.ts
@@ -1,0 +1,478 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { MessagingService } from "../../../src/core/messaging/service";
+import { createSqliteRepos } from "../../../src/storage/sqlite";
+import { createDb } from "../../../src/storage/sqlite/db";
+import {
+  runMigrations,
+  allMigrations,
+} from "../../../src/storage/sqlite/migrations";
+import { cleanupDb } from "../../helpers/db";
+import type { ProfileRepository } from "../../../src/core/ports";
+import type { AgentProfile } from "../../../src/core/profiles/types";
+import type { Database } from "bun:sqlite";
+
+const TEST_DB = `/tmp/octo-santa-test-safety-rails-${process.pid}.sqlite`;
+
+// ── In-memory ProfileRepository ────────────────────────────────────────────
+
+class InMemoryProfileRepo implements ProfileRepository {
+  private profiles = new Map<string, AgentProfile>();
+
+  add(profile: AgentProfile): void {
+    this.profiles.set(profile.name, profile);
+  }
+
+  getProfile(baseName: string): AgentProfile | null {
+    return this.profiles.get(baseName) ?? null;
+  }
+
+  listProfiles(): AgentProfile[] {
+    return [...this.profiles.values()];
+  }
+
+  getBaseNames(): Set<string> {
+    return new Set(this.profiles.keys());
+  }
+}
+
+// ── Setup helper ───────────────────────────────────────────────────────────
+
+function setup(profileRepo?: ProfileRepository) {
+  cleanupDb(TEST_DB);
+  const db = createDb(TEST_DB);
+  runMigrations(db, allMigrations);
+  const repos = createSqliteRepos(db);
+  const svc = new MessagingService(
+    repos.agents,
+    repos.channels,
+    repos.messages,
+    repos.cursors,
+    process.pid,
+    undefined,
+    profileRepo
+  );
+  return { db, repos, svc };
+}
+
+afterEach(() => cleanupDb(TEST_DB));
+
+// ── Self-mention guard ─────────────────────────────────────────────────────
+
+describe("self-mention guard", () => {
+  it("send() with @self mention throws 'Cannot @mention yourself in a message'", () => {
+    const { svc } = setup();
+
+    svc.register("alice");
+    svc.createChannel("alice", "general");
+
+    expect(() => svc.send("alice", "general", "hey @alice check this out")).toThrow(
+      "Cannot @mention yourself in a message"
+    );
+  });
+
+  it("send() with @other-agent mention succeeds (not a self-mention)", () => {
+    const { svc } = setup();
+
+    svc.register("alice");
+    svc.register("bob");
+    svc.createChannel("alice", "general");
+
+    expect(() => svc.send("alice", "general", "hey @bob check this out")).not.toThrow();
+  });
+
+  it("send() with @pool-base-name mention by pool instance is NOT a self-mention", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: null,
+      objective: null,
+      instructions: null,
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { svc } = setup(profileRepo);
+
+    svc.register("admin");
+    svc.createChannel("admin", "general");
+
+    // Register pool instance (os-dev -> os-dev-1)
+    const r1 = svc.register("os-dev");
+    const instanceId = r1.registeredName; // "os-dev-1"
+    svc.subscribe(instanceId, "general");
+
+    // os-dev-1 sends @os-dev (pool base name) - should NOT be a self-mention
+    // because extractMentions stores "os-dev" (base name), not "os-dev-1" (instance)
+    expect(() =>
+      svc.send(instanceId, "general", "hey @os-dev all instances check this")
+    ).not.toThrow();
+  });
+
+  it("directMessage() with @self mention throws 'Cannot @mention yourself in a message'", () => {
+    const { svc } = setup();
+
+    svc.register("alice");
+    svc.register("bob");
+
+    expect(() =>
+      svc.directMessage("alice", "bob", "hey @alice I am talking to myself")
+    ).toThrow("Cannot @mention yourself in a message");
+  });
+});
+
+// ── Hop counter ────────────────────────────────────────────────────────────
+
+function getHopCount(db: Database, channelName: string): number {
+  const row = db
+    .query<{ hop_count: number }, [string]>(
+      "SELECT hop_count FROM channels WHERE name = ?"
+    )
+    .get(channelName);
+  return row?.hop_count ?? -1;
+}
+
+function countMessages(db: Database, channelId: number): number {
+  const row = db
+    .query<{ cnt: number }, [number]>(
+      "SELECT COUNT(*) as cnt FROM messages WHERE channel_id = ?"
+    )
+    .get(channelId);
+  return row?.cnt ?? 0;
+}
+
+function getSystemMessages(db: Database, channelId: number) {
+  return db
+    .query<{ id: number; content: string }, [number]>(
+      "SELECT id, content FROM messages WHERE channel_id = ? AND agent_id = '_system'"
+    )
+    .all(channelId);
+}
+
+describe("hop counter", () => {
+  it("agent message increments hop counter from 0 to 1", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    const channel = svc.createChannel("alice", "general");
+
+    expect(getHopCount(db, "general")).toBe(0);
+
+    svc.send("alice", "general", "hello");
+
+    expect(getHopCount(db, "general")).toBe(1);
+  });
+
+  it("agent message at limit (4/4) throws hop limit error and message NOT inserted", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    // Create channel with maxHops=4
+    const channel = svc.createChannel("alice", "general", 4);
+    // Send 4 messages to hit the limit
+    svc.send("alice", "general", "msg 1");
+    svc.send("alice", "general", "msg 2");
+    svc.send("alice", "general", "msg 3");
+    svc.send("alice", "general", "msg 4");
+
+    expect(getHopCount(db, "general")).toBe(4);
+
+    // The 5th send should be blocked
+    expect(() => svc.send("alice", "general", "msg 5")).toThrow(
+      "Hop limit reached (4/4) in #general. Message dropped. Only a human can /continue."
+    );
+
+    // Blocked message was NOT inserted
+    const rows = db
+      .query<{ content: string }, [number]>(
+        "SELECT content FROM messages WHERE channel_id = ? AND agent_id = 'alice'"
+      )
+      .all(channel.id);
+    expect(rows.some((r) => r.content === "msg 5")).toBe(false);
+  });
+
+  it("agent message at limit posts _system notice with blocked message info", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    const channel = svc.createChannel("alice", "general", 4);
+    svc.send("alice", "general", "msg 1");
+    svc.send("alice", "general", "msg 2");
+    svc.send("alice", "general", "msg 3");
+    svc.send("alice", "general", "msg 4");
+
+    expect(() => svc.send("alice", "general", "msg 5")).toThrow();
+
+    const notices = getSystemMessages(db, channel.id);
+    expect(notices.length).toBe(1);
+    expect(notices[0]!.content).toBe(
+      "hop limit reached (4/4) in #general -- message from @alice blocked. Waiting for human input."
+    );
+  });
+
+  it("human message resets hop counter to 0", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    svc.createChannel("alice", "general", 4);
+    svc.send("alice", "general", "msg 1");
+    svc.send("alice", "general", "msg 2");
+
+    expect(getHopCount(db, "general")).toBe(2);
+
+    // Human send resets counter
+    svc.send("alice", "general", "human says hi", { human: true });
+
+    expect(getHopCount(db, "general")).toBe(0);
+  });
+
+  it("human message after limit resets and succeeds", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    const channel = svc.createChannel("alice", "general", 2);
+    svc.send("alice", "general", "msg 1");
+    svc.send("alice", "general", "msg 2");
+
+    // Now blocked
+    expect(() => svc.send("alice", "general", "blocked")).toThrow();
+
+    // Human resets
+    expect(() =>
+      svc.send("alice", "general", "human resets", { human: true })
+    ).not.toThrow();
+
+    expect(getHopCount(db, "general")).toBe(0);
+
+    // Agent can send again
+    expect(() => svc.send("alice", "general", "back in action")).not.toThrow();
+    expect(getHopCount(db, "general")).toBe(1);
+  });
+
+  it("multiple agent messages increment counter correctly 0->1->2->3->4->blocked", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    const channel = svc.createChannel("alice", "general", 4);
+
+    for (let i = 1; i <= 4; i++) {
+      svc.send("alice", "general", `msg ${i}`);
+      expect(getHopCount(db, "general")).toBe(i);
+    }
+
+    expect(() => svc.send("alice", "general", "msg 5")).toThrow(
+      "Hop limit reached (4/4)"
+    );
+    // Counter stays at 4 (not incremented on blocked message)
+    expect(getHopCount(db, "general")).toBe(4);
+  });
+
+  it("_system notices do NOT increment hop counter", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    const channel = svc.createChannel("alice", "general", 4);
+    svc.send("alice", "general", "msg 1");
+    svc.send("alice", "general", "msg 2");
+    svc.send("alice", "general", "msg 3");
+    svc.send("alice", "general", "msg 4");
+
+    expect(getHopCount(db, "general")).toBe(4);
+
+    // Trigger blocked send which posts _system notice
+    expect(() => svc.send("alice", "general", "blocked")).toThrow();
+
+    // Hop count stays at 4, not incremented by _system notice
+    expect(getHopCount(db, "general")).toBe(4);
+  });
+
+  it("DM hop counter: two agents DMing increment DM channel hop counter", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    svc.register("bob");
+
+    // alice DMs bob - creates DM channel
+    svc.directMessage("alice", "bob", "hello bob");
+
+    // Determine the DM channel name
+    const dmName = ["alice", "bob"].sort().join(",");
+    expect(getHopCount(db, dmName)).toBe(1);
+
+    // bob DMs alice - uses same channel
+    svc.directMessage("bob", "alice", "hello alice");
+    expect(getHopCount(db, dmName)).toBe(2);
+  });
+});
+
+// ── continueChannel ────────────────────────────────────────────────────────
+
+describe("continueChannel", () => {
+  it("continueChannel at hop_count=4 with amount=4 decrements to 0 and returns correct result", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    svc.createChannel("alice", "test-channel", 4);
+    svc.send("alice", "test-channel", "msg 1");
+    svc.send("alice", "test-channel", "msg 2");
+    svc.send("alice", "test-channel", "msg 3");
+    svc.send("alice", "test-channel", "msg 4");
+
+    expect(getHopCount(db, "test-channel")).toBe(4);
+
+    const result = svc.continueChannel("alice", "test-channel", 4);
+
+    expect(result).toEqual({ channel: "test-channel", hopCount: 0, maxHops: 4, bumped: 4 });
+    expect(getHopCount(db, "test-channel")).toBe(0);
+  });
+
+  it("continueChannel at hop_count=4 with amount=2 decrements to 2", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    svc.createChannel("alice", "test-channel", 4);
+    svc.send("alice", "test-channel", "msg 1");
+    svc.send("alice", "test-channel", "msg 2");
+    svc.send("alice", "test-channel", "msg 3");
+    svc.send("alice", "test-channel", "msg 4");
+
+    const result = svc.continueChannel("alice", "test-channel", 2);
+
+    expect(result.hopCount).toBe(2);
+    expect(result.bumped).toBe(2);
+    expect(getHopCount(db, "test-channel")).toBe(2);
+  });
+
+  it("continueChannel with no amount uses default of 4", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    svc.createChannel("alice", "test-channel", 4);
+    svc.send("alice", "test-channel", "msg 1");
+    svc.send("alice", "test-channel", "msg 2");
+    svc.send("alice", "test-channel", "msg 3");
+    svc.send("alice", "test-channel", "msg 4");
+
+    const result = svc.continueChannel("alice", "test-channel");
+
+    expect(result.bumped).toBe(4);
+    expect(result.hopCount).toBe(0);
+    expect(getHopCount(db, "test-channel")).toBe(0);
+  });
+
+  it("continueChannel on nonexistent channel throws channel not found", () => {
+    const { svc } = setup();
+
+    svc.register("alice");
+    expect(() => svc.continueChannel("alice", "nonexistent")).toThrow(
+      'Channel "nonexistent" not found'
+    );
+  });
+
+  it("after continueChannel, agents can send again until new limit", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    svc.createChannel("alice", "test-channel", 4);
+    svc.send("alice", "test-channel", "msg 1");
+    svc.send("alice", "test-channel", "msg 2");
+    svc.send("alice", "test-channel", "msg 3");
+    svc.send("alice", "test-channel", "msg 4");
+
+    // Channel is now blocked
+    expect(() => svc.send("alice", "test-channel", "blocked")).toThrow("Hop limit reached");
+
+    // /continue gives 4 more hops
+    svc.continueChannel("alice", "test-channel", 4);
+
+    // Agent can send again
+    expect(() => svc.send("alice", "test-channel", "back in action")).not.toThrow();
+    expect(getHopCount(db, "test-channel")).toBe(1);
+  });
+
+  it("continueChannel on non-blocked channel (hop_count=1) decrements to 0, giving extra headroom", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    svc.createChannel("alice", "test-channel", 4);
+    svc.send("alice", "test-channel", "msg 1");
+
+    expect(getHopCount(db, "test-channel")).toBe(1);
+
+    const result = svc.continueChannel("alice", "test-channel", 4);
+
+    // hop_count decrements from 1 to 0 (clamped at 0, not negative)
+    expect(result.hopCount).toBe(0);
+    expect(getHopCount(db, "test-channel")).toBe(0);
+  });
+
+  it("continueChannel throws for unregistered agent", () => {
+    const { svc } = setup();
+
+    svc.register("alice");
+    svc.createChannel("alice", "test-channel");
+
+    expect(() => svc.continueChannel("nobody", "test-channel")).toThrow(
+      'Agent "nobody" must call messaging_register'
+    );
+  });
+
+  it("continueChannel rejects amount < 1", () => {
+    const { svc } = setup();
+
+    svc.register("alice");
+    svc.createChannel("alice", "test-channel");
+
+    expect(() => svc.continueChannel("alice", "test-channel", 0)).toThrow(
+      "amount must be at least 1"
+    );
+    expect(() => svc.continueChannel("alice", "test-channel", -1)).toThrow(
+      "amount must be at least 1"
+    );
+  });
+});
+
+describe("validation", () => {
+  it("createChannel rejects maxHops < 1", () => {
+    const { svc } = setup();
+
+    svc.register("alice");
+
+    expect(() => svc.createChannel("alice", "blocked-ch", 0)).toThrow(
+      "maxHops must be at least 1"
+    );
+    expect(() => svc.createChannel("alice", "blocked-ch", -1)).toThrow(
+      "maxHops must be at least 1"
+    );
+  });
+
+  it("createChannel allows maxHops > 50 (upper bound enforced at transport)", () => {
+    const { svc } = setup();
+
+    svc.register("alice");
+
+    const ch = svc.createChannel("alice", "stress-ch", 100);
+    expect(ch.max_hops).toBe(100);
+  });
+});
+
+describe("_system notice deduplication", () => {
+  it("repeated blocked sends emit only one _system notice", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    svc.createChannel("alice", "test-channel", 2);
+    svc.subscribe("alice", "test-channel");
+
+    svc.send("alice", "test-channel", "msg 1");
+    svc.send("alice", "test-channel", "msg 2");
+
+    // Three blocked attempts
+    expect(() => svc.send("alice", "test-channel", "blocked 1")).toThrow("Hop limit reached");
+    expect(() => svc.send("alice", "test-channel", "blocked 2")).toThrow("Hop limit reached");
+    expect(() => svc.send("alice", "test-channel", "blocked 3")).toThrow("Hop limit reached");
+
+    // Only one _system notice should exist
+    const allMsgs = db.query("SELECT * FROM messages WHERE channel_id = (SELECT id FROM channels WHERE name = 'test-channel') AND agent_id = '_system'").all();
+    expect(allMsgs.length).toBe(1);
+  });
+});

--- a/tests/hex/notifications/cross-process-poller.test.ts
+++ b/tests/hex/notifications/cross-process-poller.test.ts
@@ -136,12 +136,12 @@ describe("cross-process poller integration", () => {
 
     poller.start();
 
-    // agent-b sends a message that mentions themselves
-    svc.send("agent-b", "general", "@agent-b this is a self-message");
+    // agent-b sends a message mentioning agent-a (not itself)
+    svc.send("agent-b", "general", "@agent-a this is agent-b speaking");
 
     await poller._tick();
 
-    // agent-b should NOT be notified about their own messages
+    // agent-b should NOT be notified about their own messages (sender is excluded)
     expect(calls.length).toBe(0);
 
     poller.stop();

--- a/tests/hex/notifications/poller.test.ts
+++ b/tests/hex/notifications/poller.test.ts
@@ -235,6 +235,59 @@ describe("createNotificationPoller", () => {
       expect(calls.length).toBe(0);
     });
 
+    it("notifies pool instance when pool base-name is mentioned", async () => {
+      // os-dev-1 is bound with baseName "os-dev"; message mentions "os-dev"
+      const msg = makeMessage({
+        id: 1,
+        channel_name: "general",
+        agent_id: "agent-b",
+        content: "hey @os-dev",
+        mentions: '["os-dev"]',
+      });
+
+      const queryFns = makeQueryFns([msg], 0);
+      const { port, calls } = makeNotificationPort();
+      const poller = createNotificationPoller({
+        ...queryFns,
+        port,
+        agentId: "os-dev-1",
+        baseName: "os-dev",
+      });
+
+      poller.start();
+      await poller._tick();
+      poller.stop();
+
+      expect(calls.length).toBe(1);
+      expect(calls[0]!.content).toBe("hey @os-dev");
+    });
+
+    it("does not notify pool instance when base-name is not provided and only pool mention is used", async () => {
+      // os-dev-1 without baseName — @os-dev mention should not match
+      const msg = makeMessage({
+        id: 1,
+        channel_name: "general",
+        agent_id: "agent-b",
+        content: "hey @os-dev",
+        mentions: '["os-dev"]',
+      });
+
+      const queryFns = makeQueryFns([msg], 0);
+      const { port, calls } = makeNotificationPort();
+      const poller = createNotificationPoller({
+        ...queryFns,
+        port,
+        agentId: "os-dev-1",
+        // no baseName
+      });
+
+      poller.start();
+      await poller._tick();
+      poller.stop();
+
+      expect(calls.length).toBe(0);
+    });
+
     it("skips messages with malformed mentions JSON in regular channels", async () => {
       const msg = makeMessage({
         id: 1,

--- a/tests/hex/storage/agent-repo.test.ts
+++ b/tests/hex/storage/agent-repo.test.ts
@@ -49,6 +49,48 @@ describe("SqliteAgentRepo", () => {
     db.close();
   });
 
+  it("register with profileFields stores base_name, persona, objective", () => {
+    const { db, repo } = setup();
+    const agent = repo.register("researcher-1", process.pid, {
+      baseName: "researcher",
+      persona: "You are a diligent researcher.",
+      objective: "Gather and summarize information.",
+      instructions: null,
+    });
+    expect(agent.id).toBe("researcher-1");
+    expect(agent.base_name).toBe("researcher");
+    expect(agent.persona).toBe("You are a diligent researcher.");
+    expect(agent.objective).toBe("Gather and summarize information.");
+    db.close();
+  });
+
+  it("register without profileFields stores null for base_name, persona, objective", () => {
+    const { db, repo } = setup();
+    const agent = repo.register("plain-agent", process.pid);
+    expect(agent.base_name).toBeNull();
+    expect(agent.persona).toBeNull();
+    expect(agent.objective).toBeNull();
+    db.close();
+  });
+
+  it("register clears stale profile when called without profileFields", () => {
+    const { db, repo } = setup();
+    // First register with profile
+    repo.register("agent-x", process.pid, {
+      baseName: "agent-x",
+      persona: "Old persona",
+      objective: "Old objective",
+      instructions: null,
+    });
+    // Re-register without profile — should clear profile fields
+    db.run("UPDATE agents SET pid = 999999 WHERE id = ?", ["agent-x"]);
+    const updated = repo.register("agent-x", process.pid);
+    expect(updated.base_name).toBeNull();
+    expect(updated.persona).toBeNull();
+    expect(updated.objective).toBeNull();
+    db.close();
+  });
+
   it("findById returns agent or null", () => {
     const { db, repo } = setup();
     expect(repo.findById("nonexistent")).toBeNull();
@@ -57,12 +99,53 @@ describe("SqliteAgentRepo", () => {
     db.close();
   });
 
-  it("listAll returns all agents", () => {
+  it("findByBaseName returns agents with matching base_name", () => {
     const { db, repo } = setup();
-    repo.register("agent-a", process.pid);
+    const now = Date.now();
+    // Insert worker-1 and worker-2 directly with base_name set
+    db.run(
+      `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
+       VALUES ('worker-1', ${now}, ${now}, NULL, NULL, 'worker', NULL, NULL)`
+    );
+    db.run(
+      `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
+       VALUES ('worker-2', ${now}, ${now}, NULL, NULL, 'worker', NULL, NULL)`
+    );
+    repo.register("other-agent", process.pid);
+    const workers = repo.findByBaseName("worker");
+    expect(workers.length).toBe(2);
+    expect(workers.map((a) => a.id).sort()).toEqual(["worker-1", "worker-2"]);
+    db.close();
+  });
+
+  it("findByBaseName returns empty array when no matches", () => {
+    const { db, repo } = setup();
+    const result = repo.findByBaseName("nonexistent");
+    expect(result).toEqual([]);
+    db.close();
+  });
+
+  it("listAll returns all agents with profile fields", () => {
+    const { db, repo } = setup();
+    const now = Date.now();
+    // Insert agent-b without profile fields directly
+    db.run(
+      `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
+       VALUES ('agent-b', ${now}, ${now}, NULL, NULL, NULL, NULL, NULL)`
+    );
+    repo.register("agent-a", process.pid, {
+      baseName: "agent-a",
+      persona: "Persona A",
+      objective: "Objective A",
+      instructions: null,
+    });
     const all = repo.listAll();
-    expect(all.length).toBe(1);
-    expect(all[0]!.id).toBe("agent-a");
+    expect(all.length).toBe(2);
+    const a = all.find((x) => x.id === "agent-a")!;
+    const b = all.find((x) => x.id === "agent-b")!;
+    expect(a.base_name).toBe("agent-a");
+    expect(a.persona).toBe("Persona A");
+    expect(b.base_name).toBeNull();
     db.close();
   });
 
@@ -87,6 +170,189 @@ describe("SqliteAgentRepo", () => {
     repo.register("test-agent", process.pid);
     db.run("UPDATE agents SET pid = 1 WHERE id = ?", ["test-agent"]);
     expect(repo.heartbeatOrReclaim("test-agent", process.pid)).toBe("lost");
+    db.close();
+  });
+});
+
+describe("SqliteAgentRepo - registerWithProfile", () => {
+  it("singleton: registers with base name, instanceNumber null", () => {
+    const { db, repo } = setup();
+    const result = repo.registerWithProfile("researcher", process.pid, 1, {
+      persona: "Researcher persona",
+      objective: "Research things",
+      instructions: null,
+    });
+    expect(result.registeredName).toBe("researcher");
+    expect(result.instanceNumber).toBeNull();
+    expect(result.agent.id).toBe("researcher");
+    expect(result.agent.base_name).toBe("researcher");
+    expect(result.agent.persona).toBe("Researcher persona");
+    expect(result.agent.objective).toBe("Research things");
+    db.close();
+  });
+
+  it("pool: first instance gets slot 1 (name: base-1)", () => {
+    const { db, repo } = setup();
+    const result = repo.registerWithProfile("worker", process.pid, 3, {
+      persona: null,
+      objective: null,
+      instructions: null,
+    });
+    expect(result.registeredName).toBe("worker-1");
+    expect(result.instanceNumber).toBe(1);
+    expect(result.agent.id).toBe("worker-1");
+    expect(result.agent.base_name).toBe("worker");
+    db.close();
+  });
+
+  it("pool: new process reclaims dead slot (reclaim before new slot)", () => {
+    const { db, repo } = setup();
+    // Seed slot 1 as dead (stale pid + old last_seen_at)
+    db.run(
+      `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
+       VALUES ('worker-1', 1, 1, 999991, 1, 'worker', NULL, NULL)`
+    );
+    const result = repo.registerWithProfile("worker", process.pid, 3, {
+      persona: null,
+      objective: null,
+      instructions: null,
+    });
+    // Slot 1 is dead → reclaimed
+    expect(result.registeredName).toBe("worker-1");
+    expect(result.instanceNumber).toBe(1);
+    expect(result.agent.base_name).toBe("worker");
+    db.close();
+  });
+
+  it("pool: slots fill in ascending order", () => {
+    const { db, repo } = setup();
+    // Seed worker-1 as alive by using the current process PID
+    // We cannot use process.pid twice for slot 1 and slot 2, so we seed slot 1 alive
+    // using a fake but considered-alive PID (PID 1 = init, always alive)
+    db.run(
+      `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
+       VALUES ('worker-1', 1, ${Date.now()}, 1, 1, 'worker', NULL, NULL)`
+    );
+    const result = repo.registerWithProfile("worker", process.pid, 3, {
+      persona: null,
+      objective: null,
+      instructions: null,
+    });
+    expect(result.registeredName).toBe("worker-2");
+    expect(result.instanceNumber).toBe(2);
+    db.close();
+  });
+
+  it("pool: third slot after two live slots", () => {
+    const { db, repo } = setup();
+    const now = Date.now();
+    // Seed two live slots using PID 1 (init, always alive)
+    db.run(
+      `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
+       VALUES ('worker-1', 1, ${now}, 1, 1, 'worker', NULL, NULL)`
+    );
+    db.run(
+      `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
+       VALUES ('worker-2', 1, ${now}, 1, 1, 'worker', NULL, NULL)`
+    );
+    const result = repo.registerWithProfile("worker", process.pid, 5, {
+      persona: null,
+      objective: null,
+      instructions: null,
+    });
+    expect(result.registeredName).toBe("worker-3");
+    expect(result.instanceNumber).toBe(3);
+    db.close();
+  });
+
+  it("idempotent: same PID re-registering returns existing slot", () => {
+    const { db, repo } = setup();
+    const first = repo.registerWithProfile("worker", process.pid, 3, {
+      persona: null,
+      objective: null,
+      instructions: null,
+    });
+    const second = repo.registerWithProfile("worker", process.pid, 3, {
+      persona: null,
+      objective: null,
+      instructions: null,
+    });
+    expect(second.registeredName).toBe(first.registeredName);
+    expect(second.instanceNumber).toBe(first.instanceNumber);
+    db.close();
+  });
+
+  it("reclaim: dead slot gets reassigned to new PID", () => {
+    const { db, repo } = setup();
+    const now = Date.now();
+    // Seed two workers: slot 1 owned by current PID, slot 2 owned by PID 1 (init, always alive)
+    repo.registerWithProfile("worker", process.pid, 3, { persona: null, objective: null, instructions: null });
+    db.run(
+      `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
+       VALUES ('worker-2', 1, ${now}, 1, 1, 'worker', NULL, NULL)`
+    );
+    // Kill slot 1 by setting dead pid
+    db.run("UPDATE agents SET pid = 999999, last_seen_at = 0 WHERE id = ?", ["worker-1"]);
+    // New process should reclaim slot 1 (lowest dead slot)
+    const result = repo.registerWithProfile("worker", process.pid + 100, 3, {
+      persona: null,
+      objective: null,
+      instructions: null,
+    });
+    expect(result.registeredName).toBe("worker-1");
+    expect(result.instanceNumber).toBe(1);
+    expect(result.agent.pid).toBe(process.pid + 100);
+    db.close();
+  });
+
+  it("capacity: throws when all slots are alive", () => {
+    const { db, repo } = setup();
+    const now = Date.now();
+    // Seed two slots as alive using PID 1 (init, always alive)
+    db.run(
+      `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
+       VALUES ('worker-1', 1, ${now}, 1, 1, 'worker', NULL, NULL)`
+    );
+    db.run(
+      `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
+       VALUES ('worker-2', 1, ${now}, 1, 1, 'worker', NULL, NULL)`
+    );
+    // Both slots are alive — a third process should fail
+    expect(() =>
+      repo.registerWithProfile("worker", process.pid, 2, { persona: null, objective: null, instructions: null })
+    ).toThrow(/capacity/i);
+    db.close();
+  });
+
+  it("singleton idempotent: same PID re-registering singleton returns same result", () => {
+    const { db, repo } = setup();
+    const first = repo.registerWithProfile("unique-bot", process.pid, 1, {
+      persona: "Bot persona",
+      objective: null,
+      instructions: null,
+    });
+    const second = repo.registerWithProfile("unique-bot", process.pid, 1, {
+      persona: "Bot persona",
+      objective: null,
+      instructions: null,
+    });
+    expect(second.registeredName).toBe("unique-bot");
+    expect(second.instanceNumber).toBeNull();
+    expect(second.agent.id).toBe(first.agent.id);
+    db.close();
+  });
+
+  it("singleton collision: throws when a live agent with different PID owns the slot", () => {
+    const { db, repo } = setup();
+    const now = Date.now();
+    // Seed singleton owned by PID 1 (init, always alive)
+    db.run(
+      `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
+       VALUES ('unique-bot', 1, ${now}, 1, 1, 'unique-bot', 'Bot', NULL)`
+    );
+    expect(() =>
+      repo.registerWithProfile("unique-bot", process.pid, 1, { persona: "Bot", objective: null, instructions: null })
+    ).toThrow(/already active/i);
     db.close();
   });
 });

--- a/tests/hex/storage/channel-repo.test.ts
+++ b/tests/hex/storage/channel-repo.test.ts
@@ -75,4 +75,106 @@ describe("SqliteChannelRepo", () => {
     expect(msgs[0]!.mentions).toBe('["*"]');
     db.close();
   });
+
+  it("create with default maxHops returns channel with max_hops = 50", () => {
+    const { db, channels } = setup();
+    const ch = channels.create("test-channel", "agent-a");
+    expect(ch.max_hops).toBe(50);
+    expect(ch.hop_count).toBe(0);
+    db.close();
+  });
+
+  it("create with custom maxHops stores the provided value", () => {
+    const { db, channels } = setup();
+    const ch = channels.create("test-channel", "agent-a", 10);
+    expect(ch.max_hops).toBe(10);
+    expect(ch.hop_count).toBe(0);
+    db.close();
+  });
+
+  it("checkAndIncrementHop - allowed at 0/4", () => {
+    const { db, channels } = setup();
+    const ch = channels.create("hop-channel", "agent-a", 4);
+    const result = channels.checkAndIncrementHop(ch.id);
+    expect(result.allowed).toBe(true);
+    expect(result.hopCount).toBe(1);
+    expect(result.maxHops).toBe(4);
+    db.close();
+  });
+
+  it("checkAndIncrementHop - allowed at 3/4", () => {
+    const { db, channels } = setup();
+    const ch = channels.create("hop-channel", "agent-a", 4);
+    // Manually set hop_count to 3
+    db.run("UPDATE channels SET hop_count = 3 WHERE id = ?", [ch.id]);
+    const result = channels.checkAndIncrementHop(ch.id);
+    expect(result.allowed).toBe(true);
+    expect(result.hopCount).toBe(4);
+    expect(result.maxHops).toBe(4);
+    db.close();
+  });
+
+  it("checkAndIncrementHop - blocked at 4/4", () => {
+    const { db, channels } = setup();
+    const ch = channels.create("hop-channel", "agent-a", 4);
+    // Manually set hop_count to 4 (at limit)
+    db.run("UPDATE channels SET hop_count = 4 WHERE id = ?", [ch.id]);
+    const result = channels.checkAndIncrementHop(ch.id);
+    expect(result.allowed).toBe(false);
+    expect(result.hopCount).toBe(4);
+    expect(result.maxHops).toBe(4);
+    db.close();
+  });
+
+  it("checkAndIncrementHop - counter not incremented when blocked", () => {
+    const { db, channels } = setup();
+    const ch = channels.create("hop-channel", "agent-a", 4);
+    db.run("UPDATE channels SET hop_count = 4 WHERE id = ?", [ch.id]);
+    channels.checkAndIncrementHop(ch.id);
+    const row = db.query("SELECT hop_count FROM channels WHERE id = ?").get(ch.id) as { hop_count: number };
+    expect(row.hop_count).toBe(4);
+    db.close();
+  });
+
+  it("resetHopCount resets hop_count to 0", () => {
+    const { db, channels } = setup();
+    const ch = channels.create("hop-channel", "agent-a", 4);
+    db.run("UPDATE channels SET hop_count = 3 WHERE id = ?", [ch.id]);
+    channels.resetHopCount(ch.id);
+    const row = db.query("SELECT hop_count FROM channels WHERE id = ?").get(ch.id) as { hop_count: number };
+    expect(row.hop_count).toBe(0);
+    db.close();
+  });
+
+  it("bumpHopAllowance decrements hop_count by N", () => {
+    const { db, channels } = setup();
+    const ch = channels.create("hop-channel", "agent-a", 4);
+    db.run("UPDATE channels SET hop_count = 3 WHERE id = ?", [ch.id]);
+    const result = channels.bumpHopAllowance(ch.id, 2);
+    expect(result.hopCount).toBe(1);
+    expect(result.maxHops).toBe(4);
+    expect(result.allowed).toBe(true);
+    db.close();
+  });
+
+  it("bumpHopAllowance clamps hop_count to 0, not negative", () => {
+    const { db, channels } = setup();
+    const ch = channels.create("hop-channel", "agent-a", 4);
+    db.run("UPDATE channels SET hop_count = 2 WHERE id = ?", [ch.id]);
+    const result = channels.bumpHopAllowance(ch.id, 10);
+    expect(result.hopCount).toBe(0);
+    expect(result.allowed).toBe(true);
+    db.close();
+  });
+
+  it("bumpHopAllowance returns new state after decrement", () => {
+    const { db, channels } = setup();
+    const ch = channels.create("hop-channel", "agent-a", 5);
+    db.run("UPDATE channels SET hop_count = 5 WHERE id = ?", [ch.id]);
+    const result = channels.bumpHopAllowance(ch.id, 1);
+    expect(result.hopCount).toBe(4);
+    expect(result.maxHops).toBe(5);
+    expect(result.allowed).toBe(true);
+    db.close();
+  });
 });

--- a/tests/hex/storage/yaml-profile-store.test.ts
+++ b/tests/hex/storage/yaml-profile-store.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { YamlProfileStore } from "../../../src/storage/yaml-profiles/store";
+
+describe("YamlProfileStore", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "profiles-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // --- Valid profile loading ---
+
+  it("loads a valid profile with all fields", () => {
+    writeFileSync(
+      join(dir, "os-dev.yaml"),
+      `name: os-dev\npersona: You are a senior OS engineer\nobjective: Build the kernel\nmaxInstances: 3\nautoJoinChannels:\n  - general\n  - os-team\n`
+    );
+    const store = new YamlProfileStore(dir);
+    const profile = store.getProfile("os-dev");
+    expect(profile).not.toBeNull();
+    expect(profile!.name).toBe("os-dev");
+    expect(profile!.persona).toBe("You are a senior OS engineer");
+    expect(profile!.objective).toBe("Build the kernel");
+    expect(profile!.maxInstances).toBe(3);
+    expect(profile!.autoJoinChannels).toEqual(["general", "os-team"]);
+  });
+
+  it("returns null for unknown profile name", () => {
+    const store = new YamlProfileStore(dir);
+    expect(store.getProfile("nonexistent")).toBeNull();
+  });
+
+  it("defaults maxInstances to 1 when not specified", () => {
+    writeFileSync(join(dir, "simple.yaml"), `name: simple\n`);
+    const store = new YamlProfileStore(dir);
+    const profile = store.getProfile("simple");
+    expect(profile!.maxInstances).toBe(1);
+  });
+
+  it("defaults persona to null when not specified", () => {
+    writeFileSync(join(dir, "simple.yaml"), `name: simple\n`);
+    const store = new YamlProfileStore(dir);
+    const profile = store.getProfile("simple");
+    expect(profile!.persona).toBeNull();
+  });
+
+  it("defaults objective to null when not specified", () => {
+    writeFileSync(join(dir, "simple.yaml"), `name: simple\n`);
+    const store = new YamlProfileStore(dir);
+    const profile = store.getProfile("simple");
+    expect(profile!.objective).toBeNull();
+  });
+
+  it("defaults autoJoinChannels to [] when not specified", () => {
+    writeFileSync(join(dir, "simple.yaml"), `name: simple\n`);
+    const store = new YamlProfileStore(dir);
+    const profile = store.getProfile("simple");
+    expect(profile!.autoJoinChannels).toEqual([]);
+  });
+
+  it("defaults instructions to null when not specified", () => {
+    writeFileSync(join(dir, "simple.yaml"), `name: simple\n`);
+    const store = new YamlProfileStore(dir);
+    const profile = store.getProfile("simple");
+    expect(profile!.instructions).toBeNull();
+  });
+
+  it("accepts null for persona explicitly", () => {
+    writeFileSync(join(dir, "simple.yaml"), `name: simple\npersona: null\n`);
+    const store = new YamlProfileStore(dir);
+    expect(store.getProfile("simple")!.persona).toBeNull();
+  });
+
+  it("accepts null for objective explicitly", () => {
+    writeFileSync(join(dir, "simple.yaml"), `name: simple\nobjective: null\n`);
+    const store = new YamlProfileStore(dir);
+    expect(store.getProfile("simple")!.objective).toBeNull();
+  });
+
+  it("loads instructions from profile YAML", () => {
+    writeFileSync(
+      join(dir, "os-pm.yaml"),
+      `name: os-pm\ninstructions: "When you receive a proposal, evaluate it against priorities."\n`
+    );
+    const store = new YamlProfileStore(dir);
+    const profile = store.getProfile("os-pm");
+    expect(profile!.instructions).toBe(
+      "When you receive a proposal, evaluate it against priorities."
+    );
+  });
+
+  it("accepts null for instructions explicitly", () => {
+    writeFileSync(join(dir, "simple.yaml"), `name: simple\ninstructions: null\n`);
+    const store = new YamlProfileStore(dir);
+    expect(store.getProfile("simple")!.instructions).toBeNull();
+  });
+
+  it("rejects non-string instructions (number)", () => {
+    writeFileSync(join(dir, "bad.yaml"), `name: bad\ninstructions: 42\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow(/instructions/i);
+  });
+
+  it("rejects non-string instructions (boolean)", () => {
+    writeFileSync(join(dir, "bad.yaml"), `name: bad\ninstructions: true\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow(/instructions/i);
+  });
+
+  // --- listProfiles and getBaseNames ---
+
+  it("listProfiles returns all loaded profiles", () => {
+    writeFileSync(join(dir, "alpha.yaml"), `name: alpha\n`);
+    writeFileSync(join(dir, "beta.yaml"), `name: beta\n`);
+    const store = new YamlProfileStore(dir);
+    const profiles = store.listProfiles();
+    expect(profiles.length).toBe(2);
+    const names = profiles.map((p) => p.name).sort();
+    expect(names).toEqual(["alpha", "beta"]);
+  });
+
+  it("listProfiles returns empty array when no profiles", () => {
+    const store = new YamlProfileStore(dir);
+    expect(store.listProfiles()).toEqual([]);
+  });
+
+  it("getBaseNames returns a Set of profile names", () => {
+    writeFileSync(join(dir, "alpha.yaml"), `name: alpha\n`);
+    writeFileSync(join(dir, "beta.yaml"), `name: beta\n`);
+    const store = new YamlProfileStore(dir);
+    const names = store.getBaseNames();
+    expect(names instanceof Set).toBe(true);
+    expect(names.has("alpha")).toBe(true);
+    expect(names.has("beta")).toBe(true);
+    expect(names.size).toBe(2);
+  });
+
+  it("getBaseNames returns empty Set when no profiles", () => {
+    const store = new YamlProfileStore(dir);
+    expect(store.getBaseNames().size).toBe(0);
+  });
+
+  // --- Unknown fields: warn-and-ignore (F3) ---
+
+  it("ignores unknown fields and loads successfully", () => {
+    writeFileSync(
+      join(dir, "simple.yaml"),
+      `name: simple\nunknownField: some value\nanotherUnknown: 42\n`
+    );
+    // Should not throw
+    const store = new YamlProfileStore(dir);
+    const profile = store.getProfile("simple");
+    expect(profile).not.toBeNull();
+    expect(profile!.name).toBe("simple");
+  });
+
+  // --- Validation errors that throw ---
+
+  it("rejects reserved name 'all'", () => {
+    writeFileSync(join(dir, "all.yaml"), `name: all\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow();
+  });
+
+  it("rejects reserved name 'here'", () => {
+    writeFileSync(join(dir, "here.yaml"), `name: here\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow();
+  });
+
+  it("rejects reserved name '_system'", () => {
+    writeFileSync(join(dir, "_system.yaml"), `name: _system\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow();
+  });
+
+  it("rejects filename mismatch (file is foo.yaml but name field is bar)", () => {
+    writeFileSync(join(dir, "foo.yaml"), `name: bar\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow(/mismatch/i);
+  });
+
+  it("rejects maxInstances < 1", () => {
+    writeFileSync(join(dir, "bad.yaml"), `name: bad\nmaxInstances: 0\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow(/maxInstances/i);
+  });
+
+  it("rejects maxInstances as negative", () => {
+    writeFileSync(join(dir, "bad.yaml"), `name: bad\nmaxInstances: -1\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow(/maxInstances/i);
+  });
+
+  it("rejects maxInstances as non-integer (float)", () => {
+    writeFileSync(join(dir, "bad.yaml"), `name: bad\nmaxInstances: 1.5\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow(/maxInstances/i);
+  });
+
+  it("loads a single profile into store", () => {
+    // Note: duplicate name detection exists as a defensive guard but is structurally
+    // unreachable — filename-must-match-name + filesystem unique filenames prevents it.
+    writeFileSync(join(dir, "alpha.yaml"), `name: alpha\n`);
+    const store = new YamlProfileStore(dir);
+    expect(store.getBaseNames().size).toBe(1);
+  });
+
+  it("rejects non-string persona (number)", () => {
+    writeFileSync(join(dir, "bad.yaml"), `name: bad\npersona: 42\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow(/persona/i);
+  });
+
+  it("rejects non-string persona (boolean)", () => {
+    writeFileSync(join(dir, "bad.yaml"), `name: bad\npersona: true\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow(/persona/i);
+  });
+
+  it("rejects non-string objective (number)", () => {
+    writeFileSync(join(dir, "bad.yaml"), `name: bad\nobjective: 99\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow(/objective/i);
+  });
+
+  it("rejects non-string objective (boolean)", () => {
+    writeFileSync(join(dir, "bad.yaml"), `name: bad\nobjective: false\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow(/objective/i);
+  });
+
+  it("rejects non-string entries in autoJoinChannels", () => {
+    writeFileSync(
+      join(dir, "bad.yaml"),
+      `name: bad\nautoJoinChannels:\n  - general\n  - 42\n`
+    );
+    expect(() => new YamlProfileStore(dir)).toThrow(/autoJoinChannels/i);
+  });
+
+  it("rejects autoJoinChannels when it's not an array", () => {
+    writeFileSync(
+      join(dir, "bad.yaml"),
+      `name: bad\nautoJoinChannels: general\n`
+    );
+    expect(() => new YamlProfileStore(dir)).toThrow(/autoJoinChannels/i);
+  });
+
+  // --- ENOENT: nonexistent directory → empty store ---
+
+  it("returns empty store when directory does not exist (ENOENT)", () => {
+    const nonexistent = join(tmpdir(), "nonexistent-profiles-dir-99999999");
+    const store = new YamlProfileStore(nonexistent);
+    expect(store.listProfiles()).toEqual([]);
+    expect(store.getBaseNames().size).toBe(0);
+    expect(store.getProfile("anything")).toBeNull();
+  });
+
+  // --- Profile name collision with another profile's pool namespace ---
+
+  it("rejects a profile whose name matches another profile's pool pattern (e.g., os-dev-2 when os-dev also loaded)", () => {
+    writeFileSync(join(dir, "os-dev.yaml"), `name: os-dev\nmaxInstances: 5\n`);
+    writeFileSync(join(dir, "os-dev-2.yaml"), `name: os-dev-2\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow(/os-dev-2/);
+  });
+
+  it("allows a profile like 'os-dev-extra' that is not a numeric suffix collision", () => {
+    writeFileSync(join(dir, "os-dev.yaml"), `name: os-dev\nmaxInstances: 5\n`);
+    writeFileSync(join(dir, "os-dev-extra.yaml"), `name: os-dev-extra\n`);
+    // Should not throw: 'extra' is not a numeric suffix
+    const store = new YamlProfileStore(dir);
+    expect(store.getBaseNames().has("os-dev")).toBe(true);
+    expect(store.getBaseNames().has("os-dev-extra")).toBe(true);
+  });
+
+  it("allows a profile like 'os-dev2' (no hyphen before digit) without collision", () => {
+    writeFileSync(join(dir, "os-dev.yaml"), `name: os-dev\nmaxInstances: 5\n`);
+    writeFileSync(join(dir, "os-dev2.yaml"), `name: os-dev2\n`);
+    // No collision since the pattern is {name}-{digits}, not {name}{digits}
+    const store = new YamlProfileStore(dir);
+    expect(store.getBaseNames().has("os-dev")).toBe(true);
+    expect(store.getBaseNames().has("os-dev2")).toBe(true);
+  });
+
+  it("rejects os-dev-10 when os-dev profile also loaded", () => {
+    writeFileSync(join(dir, "os-dev.yaml"), `name: os-dev\nmaxInstances: 5\n`);
+    writeFileSync(join(dir, "os-dev-10.yaml"), `name: os-dev-10\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow(/os-dev-10/);
+  });
+
+  it("does not reject numeric suffix when no matching base profile exists", () => {
+    // os-dev-2 on its own is fine if there is no os-dev profile
+    writeFileSync(join(dir, "os-dev-2.yaml"), `name: os-dev-2\n`);
+    const store = new YamlProfileStore(dir);
+    expect(store.getBaseNames().has("os-dev-2")).toBe(true);
+  });
+
+  // --- Invalid name format ---
+
+  it("rejects profile name with invalid characters", () => {
+    writeFileSync(join(dir, "bad name.yaml"), `name: bad name\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow();
+  });
+});

--- a/tests/hex/transports/mcp-instructions.test.ts
+++ b/tests/hex/transports/mcp-instructions.test.ts
@@ -2,26 +2,54 @@ import { describe, it, expect } from "bun:test";
 import { buildInstructions, UNIVERSAL_GUIDANCE } from "../../../src/transports/mcp-stdio/adapter";
 
 describe("buildInstructions", () => {
-  // Claude Code truncates server instructions at 2KB (2048 bytes).
-  // The BRAIN section adds ~50 bytes with domain. If the base text exceeds budget,
-  // trim SENDING and DISCOVERY first -- REACTING TO MESSAGES and BOUNDARIES
-  // are highest priority for weak models.
+  // Claude Code truncates server instructions at 2KB (2048 bytes). Everything
+  // up through the BRAIN section must fit inside that window. The NON-PUSH
+  // CLIENTS block is appended AFTER BRAIN intentionally: end-of-doc placement
+  // means Claude Code's truncation clips the tail the push-client doesn't
+  // need, while non-push clients (Codex, Gemini CLI, OpenCode) have no 2KB
+  // limit and receive the full text. The 2900-byte ceiling below accommodates
+  // the sacrificial tail. Phase 0c will restructure the whole block and
+  // reclaim budget.
 
-  it("stays under 2KB without brain config", () => {
+  it("pre-NON-PUSH section stays under 2KB without brain config", () => {
     const text = buildInstructions(null);
-    const bytes = Buffer.byteLength(text, "utf-8");
-    console.log(`buildInstructions(null): ${bytes} bytes`);
+    const preTail = text.split("\n\nNON-PUSH CLIENTS:")[0]!;
+    const bytes = Buffer.byteLength(preTail, "utf-8");
+    console.log(`buildInstructions(null) pre-NON-PUSH: ${bytes} bytes`);
     expect(bytes).toBeLessThan(2048);
   });
 
-  it("stays under 2KB with brain config", () => {
+  it("pre-NON-PUSH section stays under 2KB with brain config", () => {
     const text = buildInstructions({
       domain: { identifier: "test-domain", tags: ["test"], description: "A test domain" },
       brain: { dirs: ["docs"], files: [] },
     });
-    const bytes = Buffer.byteLength(text, "utf-8");
-    console.log(`buildInstructions(with brain): ${bytes} bytes`);
+    const preTail = text.split("\n\nNON-PUSH CLIENTS:")[0]!;
+    const bytes = Buffer.byteLength(preTail, "utf-8");
+    console.log(`buildInstructions(with brain) pre-NON-PUSH: ${bytes} bytes`);
     expect(bytes).toBeLessThan(2048);
+  });
+
+  it("full instructions stay under the non-push ceiling", () => {
+    const none = Buffer.byteLength(buildInstructions(null), "utf-8");
+    const withBrain = Buffer.byteLength(
+      buildInstructions({
+        domain: { identifier: "test-domain", tags: ["test"], description: "A test domain" },
+        brain: { dirs: ["docs"], files: [] },
+      }),
+      "utf-8"
+    );
+    console.log(`full: none=${none}, withBrain=${withBrain}`);
+    expect(none).toBeLessThan(2900);
+    expect(withBrain).toBeLessThan(2900);
+  });
+
+  it("includes NON-PUSH CLIENTS section at end of document", () => {
+    const text = buildInstructions(null);
+    expect(text).toContain("NON-PUSH CLIENTS:");
+    expect(text).toContain("messaging_listen(timeout_ms");
+    expect(text).toContain("messages arrive inline");
+    expect(text.indexOf("NON-PUSH CLIENTS:")).toBeGreaterThan(text.indexOf("BRAIN:"));
   });
 
   it("includes REACTING TO MESSAGES section with anti-polling guidance", () => {

--- a/tests/hex/transports/mcp-instructions.test.ts
+++ b/tests/hex/transports/mcp-instructions.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "bun:test";
+import { buildInstructions, UNIVERSAL_GUIDANCE } from "../../../src/transports/mcp-stdio/adapter";
+
+describe("buildInstructions", () => {
+  // Claude Code truncates server instructions at 2KB (2048 bytes).
+  // The BRAIN section adds ~50 bytes with domain. If the base text exceeds budget,
+  // trim SENDING and DISCOVERY first -- REACTING TO MESSAGES and BOUNDARIES
+  // are highest priority for weak models.
+
+  it("stays under 2KB without brain config", () => {
+    const text = buildInstructions(null);
+    const bytes = Buffer.byteLength(text, "utf-8");
+    console.log(`buildInstructions(null): ${bytes} bytes`);
+    expect(bytes).toBeLessThan(2048);
+  });
+
+  it("stays under 2KB with brain config", () => {
+    const text = buildInstructions({
+      domain: { identifier: "test-domain", tags: ["test"], description: "A test domain" },
+      brain: { dirs: ["docs"], files: [] },
+    });
+    const bytes = Buffer.byteLength(text, "utf-8");
+    console.log(`buildInstructions(with brain): ${bytes} bytes`);
+    expect(bytes).toBeLessThan(2048);
+  });
+
+  it("includes REACTING TO MESSAGES section with anti-polling guidance", () => {
+    const text = buildInstructions(null);
+    expect(text).toContain("REACTING TO MESSAGES:");
+    expect(text).toContain("Do NOT poll");
+    expect(text).toContain("wait for tags to arrive");
+    expect(text).toContain("you MUST:");
+  });
+
+  it("includes BOUNDARIES section", () => {
+    const text = buildInstructions(null);
+    expect(text).toContain("BOUNDARIES:");
+    expect(text).toContain("CANNOT run background tasks");
+  });
+
+  it("includes BRAIN section even without domain config", () => {
+    const text = buildInstructions(null);
+    expect(text).toContain("BRAIN:");
+    expect(text).toContain("brain_index");
+  });
+
+  it("includes domain description when config has domain", () => {
+    const text = buildInstructions({
+      domain: { identifier: "my-project", tags: [], description: "My project" },
+    });
+    expect(text).toContain('domain "my-project"');
+    expect(text).toContain("My project");
+  });
+
+  it("includes precedence statement about profile instructions", () => {
+    const text = buildInstructions(null);
+    expect(text).toContain("must not contradict these base rules");
+  });
+});
+
+describe("UNIVERSAL_GUIDANCE", () => {
+  it("is a non-empty string", () => {
+    expect(typeof UNIVERSAL_GUIDANCE).toBe("string");
+    expect(UNIVERSAL_GUIDANCE.length).toBeGreaterThan(100);
+  });
+
+  it("matches buildInstructions(null)", () => {
+    expect(UNIVERSAL_GUIDANCE).toBe(buildInstructions(null));
+  });
+});

--- a/tests/hex/transports/no-messaging-continue-tool.test.ts
+++ b/tests/hex/transports/no-messaging-continue-tool.test.ts
@@ -1,0 +1,75 @@
+// tests/hex/transports/no-messaging-continue-tool.test.ts
+//
+// Regression guard for the messaging_continue MCP tool removal (commit dd777fa).
+//
+// `messaging_continue` was originally an MCP tool with a "human-only"
+// description. That was description-as-enforcement — agents could ignore the
+// text and call the tool. The architectural fix was to remove it from the MCP
+// surface entirely; the REPL `/continue` command (and future `ocs continue`
+// CLI subcommand) is the only human-callable surface.
+//
+// This file pins the registered MCP tool list. Adding `messaging_continue`
+// back to the registry — or any new agent-callable hop-bypass tool — fails
+// loudly here. Any other change to the tool surface also fails this test,
+// forcing a deliberate update with reviewer awareness.
+
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ADAPTER_PATH = join(
+  import.meta.dir,
+  "../../../src/transports/mcp-stdio/adapter.ts"
+);
+
+const EXPECTED_MCP_TOOLS = [
+  "brain_claim_domain",
+  "brain_find_expert",
+  "brain_index",
+  "brain_read",
+  "brain_shared_index",
+  "brain_shared_read",
+  "messaging_create_channel",
+  "messaging_direct_message",
+  "messaging_get_instructions",
+  "messaging_list_agents",
+  "messaging_list_channels",
+  "messaging_list_members",
+  "messaging_listen",
+  "messaging_read_messages",
+  "messaging_register",
+  "messaging_rename_channel",
+  "messaging_send_message",
+  "messaging_subscribe",
+];
+
+function extractRegisteredToolNames(): string[] {
+  const source = readFileSync(ADAPTER_PATH, "utf-8");
+  const re = /server\.registerTool\("([^"]+)"/g;
+  const names: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(source)) !== null) {
+    names.push(match[1]!);
+  }
+  return names.sort();
+}
+
+describe("MCP tool registry — pinned surface", () => {
+  it("registered tool names match the expected list exactly", () => {
+    const actual = extractRegisteredToolNames();
+    expect(actual).toEqual(EXPECTED_MCP_TOOLS);
+  });
+
+  it("messaging_continue is NOT registered as an MCP tool (transport-boundary invariant)", () => {
+    const actual = extractRegisteredToolNames();
+    expect(actual).not.toContain("messaging_continue");
+  });
+
+  it("no other agent-callable hop-bypass tool snuck in", () => {
+    const actual = extractRegisteredToolNames();
+    const suspicious = actual.filter((name) =>
+      /continue|reset.*hop|bump.*hop|hop.*reset|hop.*bump|allowance|bypass/i.test(name)
+    );
+    expect(suspicious).toEqual([]);
+  });
+});

--- a/tests/messaging/binding.test.ts
+++ b/tests/messaging/binding.test.ts
@@ -4,6 +4,8 @@ import { allMigrations } from "../../src/storage/sqlite/migrations";
 import { createSqliteRepos } from "../../src/storage/sqlite";
 import { MessagingService } from "../../src/core/messaging/service";
 import { registerMessagingTools } from "../../src/transports/mcp-stdio/adapter";
+import type { ProfileRepository } from "../../src/core/ports";
+import type { AgentProfile } from "../../src/core/profiles/types";
 
 const TEST_DB = testDbPath("binding");
 
@@ -11,33 +13,55 @@ afterEach(() => {
   cleanupDb(TEST_DB);
 });
 
-describe("agent binding enforcement", () => {
-  function setup() {
-    const db = setupTestDb(TEST_DB, allMigrations);
-    const repos = createSqliteRepos(db);
-    const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid);
+// ── In-memory ProfileRepository for tests ────────────────────────────────────
 
-    const handlers: Record<string, (...args: any[]) => Promise<any>> = {};
-    const mockServer = {
-      registerTool: (name: string, _config: unknown, cb: (...args: any[]) => Promise<any>) => {
-        handlers[name] = cb;
-      },
-    } as any;
+class InMemoryProfileRepo implements ProfileRepository {
+  private profiles = new Map<string, AgentProfile>();
 
-    let bound: string | null = null;
-    function onAgentId(agentId: string): { commit: () => void } {
-      if (bound !== null && bound !== agentId) {
-        throw new Error(`Session already bound to agent "${bound}", cannot use "${agentId}"`);
-      }
-      return {
-        commit: () => { bound = agentId; },
-      };
-    }
-
-    registerMessagingTools(mockServer, svc, onAgentId);
-    return { db, handlers };
+  add(profile: AgentProfile): void {
+    this.profiles.set(profile.name, profile);
   }
 
+  getProfile(baseName: string): AgentProfile | null {
+    return this.profiles.get(baseName) ?? null;
+  }
+
+  listProfiles(): AgentProfile[] {
+    return [...this.profiles.values()];
+  }
+
+  getBaseNames(): Set<string> {
+    return new Set(this.profiles.keys());
+  }
+}
+
+function setup(profileRepo?: ProfileRepository) {
+  const db = setupTestDb(TEST_DB, allMigrations);
+  const repos = createSqliteRepos(db);
+  const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid, undefined, profileRepo);
+
+  const handlers: Record<string, (...args: any[]) => Promise<any>> = {};
+  const mockServer = {
+    registerTool: (name: string, _config: unknown, cb: (...args: any[]) => Promise<any>) => {
+      handlers[name] = cb;
+    },
+  } as any;
+
+  let bound: string | null = null;
+  function onAgentId(agentId: string): { commit: (resolvedName?: string) => void } {
+    if (bound !== null && bound !== agentId) {
+      throw new Error(`Session already bound to agent "${bound}", cannot use "${agentId}"`);
+    }
+    return {
+      commit: (resolvedName?: string) => { bound = resolvedName ?? agentId; },
+    };
+  }
+
+  registerMessagingTools(mockServer, svc, onAgentId);
+  return { db, handlers };
+}
+
+describe("agent binding enforcement", () => {
   it("rejects mismatched agent_id on send WITHOUT persisting the message", async () => {
     const { db, handlers } = setup();
     await handlers.messaging_register!({ agent_id: "agent-a" });
@@ -177,6 +201,135 @@ describe("agent binding enforcement", () => {
     const agents = JSON.parse(result.content[0].text);
     expect(agents.length).toBe(1);
     expect(agents[0].id).toBe("agent-a");
+    db.close();
+  });
+});
+
+describe("profile-based name resolution in transport binding", () => {
+  it("register base name with pool profile → bound to resolvedName (os-dev-1)", async () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: "Senior developer",
+      objective: "Write clean code",
+      instructions: null,
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { db, handlers } = setup(profileRepo);
+    const raw = await handlers.messaging_register!({ agent_id: "os-dev" });
+    const result = JSON.parse(raw.content[0].text);
+
+    expect(result.registeredName).toBe("os-dev-1");
+    expect(result.baseName).toBe("os-dev");
+    expect(result.instanceNumber).toBe(1);
+
+    db.close();
+  });
+
+  it("subsequent call with base name rejected after binding to pool slot", async () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: null,
+      objective: null,
+      instructions: null,
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { db, handlers } = setup(profileRepo);
+    await handlers.messaging_register!({ agent_id: "os-dev" });
+
+    // After binding to "os-dev-1", calling with base name "os-dev" should be rejected
+    let threw = false;
+    try {
+      await handlers.messaging_register!({ agent_id: "os-dev" });
+    } catch (err) {
+      threw = true;
+      expect(String(err)).toContain("os-dev-1");
+    }
+    expect(threw).toBe(true);
+
+    db.close();
+  });
+});
+
+describe("messaging_get_instructions tool", () => {
+  it("returns universal guidance and profile instructions for profiled agent", async () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-pm",
+      persona: "Product manager",
+      objective: "Drive roadmap",
+      instructions: "Evaluate proposals against priorities.",
+      maxInstances: 1,
+      autoJoinChannels: [],
+    });
+    const { db, handlers } = setup(profileRepo);
+
+    await handlers.messaging_register!({ agent_id: "os-pm" });
+    const result = await handlers.messaging_get_instructions!({ agent_id: "os-pm", include_universal: true });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.universal).not.toBeNull();
+    expect(parsed.universal.length).toBeGreaterThan(100);
+    expect(parsed.profile).not.toBeNull();
+    expect(parsed.profile.instructions).toBe("Evaluate proposals against priorities.");
+    expect(parsed.profile.persona).toBe("Product manager");
+
+    db.close();
+  });
+
+  it("returns null universal when include_universal is false", async () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-pm",
+      persona: "PM",
+      objective: null,
+      instructions: "Test instructions",
+      maxInstances: 1,
+      autoJoinChannels: [],
+    });
+    const { db, handlers } = setup(profileRepo);
+
+    await handlers.messaging_register!({ agent_id: "os-pm" });
+    const result = await handlers.messaging_get_instructions!({ agent_id: "os-pm", include_universal: false });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.universal).toBeNull();
+    expect(parsed.profile).not.toBeNull();
+    expect(parsed.profile.instructions).toBe("Test instructions");
+
+    db.close();
+  });
+
+  it("returns null profile for unprofiled agent", async () => {
+    const { db, handlers } = setup();
+
+    await handlers.messaging_register!({ agent_id: "random-bot" });
+    const result = await handlers.messaging_get_instructions!({ agent_id: "random-bot", include_universal: true });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.universal).not.toBeNull();
+    expect(parsed.profile).toBeNull();
+
+    db.close();
+  });
+
+  it("rejects mismatched agent_id via withAgent binding", async () => {
+    const { db, handlers } = setup();
+
+    await handlers.messaging_register!({ agent_id: "agent-a" });
+    let threw = false;
+    try {
+      await handlers.messaging_get_instructions!({ agent_id: "agent-b", include_universal: true });
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(true);
+
     db.close();
   });
 });

--- a/tests/messaging/lifecycle.test.ts
+++ b/tests/messaging/lifecycle.test.ts
@@ -35,6 +35,10 @@ describe("isAgentActive", () => {
       last_seen_at: Date.now(),
       pid: null,
       registered_at: null,
+      base_name: null,
+      persona: null,
+      objective: null,
+      instructions: null,
     };
     expect(isAgentActive(agent)).toBe(false);
   });
@@ -46,6 +50,10 @@ describe("isAgentActive", () => {
       last_seen_at: Date.now(),
       pid: 999999, // almost certainly dead
       registered_at: Date.now(),
+      base_name: null,
+      persona: null,
+      objective: null,
+      instructions: null,
     };
     expect(isAgentActive(agent)).toBe(false);
   });
@@ -57,6 +65,10 @@ describe("isAgentActive", () => {
       last_seen_at: Date.now() - 20 * 60 * 1000, // 20 minutes ago (> 15 min window)
       pid: process.pid, // alive
       registered_at: Date.now() - 20 * 60 * 1000,
+      base_name: null,
+      persona: null,
+      objective: null,
+      instructions: null,
     };
     expect(isAgentActive(agent)).toBe(false);
   });

--- a/tests/messaging/listen.test.ts
+++ b/tests/messaging/listen.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { cleanupDb, testDbPath, setupTestDb } from "../helpers/db";
+import { allMigrations } from "../../src/storage/sqlite/migrations";
+import { createSqliteRepos } from "../../src/storage/sqlite";
+import { MessagingService } from "../../src/core/messaging/service";
+import { registerMessagingTools } from "../../src/transports/mcp-stdio/adapter";
+
+const TEST_DB = testDbPath("listen");
+
+afterEach(() => {
+  cleanupDb(TEST_DB);
+});
+
+function setup() {
+  const db = setupTestDb(TEST_DB, allMigrations);
+  const repos = createSqliteRepos(db);
+  const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid);
+
+  const handlers: Record<string, (...args: any[]) => Promise<any>> = {};
+  const mockServer = {
+    registerTool: (name: string, _config: unknown, cb: (...args: any[]) => Promise<any>) => {
+      handlers[name] = cb;
+    },
+  } as any;
+
+  let bound: string | null = null;
+  function onAgentId(agentId: string): { commit: (resolvedName?: string) => void } {
+    if (bound !== null && bound !== agentId) {
+      throw new Error(`Session already bound to agent "${bound}", cannot use "${agentId}"`);
+    }
+    return {
+      commit: (resolvedName?: string) => { bound = resolvedName ?? agentId; },
+    };
+  }
+
+  registerMessagingTools(mockServer, svc, onAgentId, undefined, undefined, repos.agents);
+  return { db, svc, handlers };
+}
+
+describe("messaging_listen", () => {
+  it("returns messages immediately when unread exist", async () => {
+    const { db, svc, handlers } = setup();
+
+    await handlers.messaging_register!({ agent_id: "alice" });
+    svc.register("bob");
+    await handlers.messaging_create_channel!({ agent_id: "alice", name: "general" });
+    await handlers.messaging_subscribe!({ agent_id: "alice", channel: "general" });
+    svc.subscribe("bob", "general");
+    svc.send("bob", "general", "hello alice");
+
+    const result = await handlers.messaging_listen!({ agent_id: "alice", timeout_ms: 5000 });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.timed_out).toBe(false);
+    expect(parsed.channels.length).toBeGreaterThan(0);
+    expect(parsed.channels[0].channel).toBe("general");
+    expect(parsed.channels[0].messages[0].content).toBe("hello alice");
+
+    db.close();
+  }, 10000);
+
+  it("times out when no messages", async () => {
+    const { db, handlers } = setup();
+
+    await handlers.messaging_register!({ agent_id: "alice" });
+    await handlers.messaging_create_channel!({ agent_id: "alice", name: "quiet" });
+    await handlers.messaging_subscribe!({ agent_id: "alice", channel: "quiet" });
+
+    const start = performance.now();
+    const result = await handlers.messaging_listen!({ agent_id: "alice", timeout_ms: 1500 });
+    const elapsed = performance.now() - start;
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.timed_out).toBe(true);
+    expect(parsed.channels).toEqual([]);
+    expect(elapsed).toBeGreaterThanOrEqual(1000);
+
+    db.close();
+  }, 10000);
+
+  it("clamps timeout_ms below 1000 to 1000", async () => {
+    const { db, handlers } = setup();
+
+    await handlers.messaging_register!({ agent_id: "alice" });
+    await handlers.messaging_create_channel!({ agent_id: "alice", name: "quiet2" });
+    await handlers.messaging_subscribe!({ agent_id: "alice", channel: "quiet2" });
+
+    const start = performance.now();
+    const result = await handlers.messaging_listen!({ agent_id: "alice", timeout_ms: 100 });
+    const elapsed = performance.now() - start;
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.timed_out).toBe(true);
+    expect(elapsed).toBeGreaterThanOrEqual(900);
+
+    db.close();
+  }, 10000);
+
+  it("requires agent registration", async () => {
+    const { db, handlers } = setup();
+
+    let threw = false;
+    try {
+      await handlers.messaging_listen!({ agent_id: "unregistered", timeout_ms: 1500 });
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(true);
+    db.close();
+  });
+});

--- a/tests/messaging/mentions.test.ts
+++ b/tests/messaging/mentions.test.ts
@@ -64,3 +64,56 @@ describe("extractMentions", () => {
       .toEqual(["*"]);
   });
 });
+
+describe("extractMentions — profileBaseNames param", () => {
+  it("recognizes a pool base name as a valid mention", () => {
+    // "os-dev" is not in validAgentIds but IS a profile base name
+    expect(
+      extractMentions(
+        "hey @os-dev check this",
+        ["os-dev-1", "os-dev-2"],
+        new Set(["os-dev"])
+      )
+    ).toEqual(["os-dev"]);
+  });
+
+  it("prefers direct agent ID over base name when both match", () => {
+    // "os-dev-1" is both in validAgentIds and could be confused — but base names
+    // are separate from agent IDs; here "os-dev" is the base name, "os-dev-1" is
+    // the direct agent — if someone mentions @os-dev-1, it should be a direct mention
+    expect(
+      extractMentions(
+        "hey @os-dev-1 check this",
+        ["os-dev-1", "os-dev-2"],
+        new Set(["os-dev"])
+      )
+    ).toEqual(["os-dev-1"]);
+  });
+
+  it("handles mixed mentions: base name and direct agent ID", () => {
+    expect(
+      extractMentions(
+        "@os-dev and @os-dev-1 both see this",
+        ["os-dev-1", "os-dev-2"],
+        new Set(["os-dev"])
+      )
+    ).toEqual(["os-dev", "os-dev-1"]);
+  });
+
+  it("backward compat: works without profileBaseNames param (undefined)", () => {
+    // Existing behavior unchanged when third param omitted
+    expect(
+      extractMentions("@alice check this", ["alice", "bob"])
+    ).toEqual(["alice"]);
+  });
+
+  it("backward compat: profileBaseNames=undefined — base names not recognized", () => {
+    expect(
+      extractMentions(
+        "hey @os-dev check this",
+        ["os-dev-1"],
+        undefined
+      )
+    ).toEqual([]);
+  });
+});

--- a/tests/repl/app.test.ts
+++ b/tests/repl/app.test.ts
@@ -116,6 +116,19 @@ describe("REPL integration", () => {
     expect(result.messages!.some(m => m.content === "their msg")).toBe(true);
   });
 
+  it("plain message send uses human flag - resets hop count on hop-limited channel", () => {
+    const { db, svc } = setup();
+    svc.register("jay");
+    // Create channel with maxHops=1: first non-human send uses the 1 hop (hop_count 0->1).
+    // A second non-human send would fail (hop_count 1 >= max_hops 1).
+    // app.ts passes { human: true }, which resets hop_count to 0, allowing the send.
+    svc.createChannel("jay", "planning", 1);
+    svc.send("jay", "planning", "first agent msg"); // exhausts the 1 hop
+    // Simulates what app.ts does — passes { human: true }
+    const msg = svc.send("jay", "planning", "human typed message", { human: true });
+    expect(msg.content).toBe("human typed message");
+  });
+
   it("poll excludes self messages", () => {
     const { db, svc } = setup();
     svc.register("jay");

--- a/tests/repl/commands.test.ts
+++ b/tests/repl/commands.test.ts
@@ -43,6 +43,14 @@ describe("parseCommand", () => {
   it("returns null for empty input", () => {
     expect(parseCommand("")).toBeNull();
   });
+
+  it("parses /continue as a known command with no args", () => {
+    expect(parseCommand("/continue")).toEqual({ name: "continue", args: "" });
+  });
+
+  it("parses /continue 8 with args", () => {
+    expect(parseCommand("/continue 8")).toEqual({ name: "continue", args: "8" });
+  });
 });
 
 describe("executeCommand", () => {
@@ -85,7 +93,7 @@ describe("executeCommand", () => {
   it("/history defaults to 20 for invalid N", () => {
     const { db, svc, channelRepo } = setup();
     svc.register("user");
-    svc.createChannel("user", "test-ch");
+    svc.createChannel("user", "test-ch", 100);
     // Insert 25 messages so the limit is exercised
     for (let i = 0; i < 25; i++) svc.send("user", "test-ch", `msg-${i}`);
     const state = { activeChannel: "test-ch", joinedChannels: new Set(["test-ch"]), cursors: new Map(), agentId: "user" };
@@ -155,7 +163,7 @@ describe("executeCommand", () => {
   it("/history 0 falls back to 20", () => {
     const { db, svc, channelRepo } = setup();
     svc.register("user");
-    svc.createChannel("user", "test-ch");
+    svc.createChannel("user", "test-ch", 100);
     for (let i = 0; i < 25; i++) svc.send("user", "test-ch", `msg-${i}`);
     const state = { activeChannel: "test-ch", joinedChannels: new Set(["test-ch"]), cursors: new Map(), agentId: "user" };
     const result = executeCommand({ name: "history", args: "0" }, svc, channelRepo, state);
@@ -165,7 +173,7 @@ describe("executeCommand", () => {
   it("/history -1 falls back to 20", () => {
     const { db, svc, channelRepo } = setup();
     svc.register("user");
-    svc.createChannel("user", "test-ch");
+    svc.createChannel("user", "test-ch", 100);
     for (let i = 0; i < 25; i++) svc.send("user", "test-ch", `msg-${i}`);
     const state = { activeChannel: "test-ch", joinedChannels: new Set(["test-ch"]), cursors: new Map(), agentId: "user" };
     const result = executeCommand({ name: "history", args: "-1" }, svc, channelRepo, state);
@@ -177,5 +185,65 @@ describe("executeCommand", () => {
     const state = { activeChannel: "ch", joinedChannels: new Set(["ch"]), cursors: new Map(), agentId: "user" };
     const result = executeCommand({ name: "help", args: "" }, svc, channelRepo, state);
     expect(result.output.length).toBeGreaterThan(0);
+  });
+
+  it("/help includes /continue entry", () => {
+    const { db, svc, channelRepo } = setup();
+    const state = { activeChannel: "ch", joinedChannels: new Set(["ch"]), cursors: new Map(), agentId: "user" };
+    const result = executeCommand({ name: "help", args: "" }, svc, channelRepo, state);
+    expect(result.output.some(l => l.includes("/continue"))).toBe(true);
+  });
+
+  it("/continue with no args uses default amount of 4", () => {
+    const { db, svc, channelRepo } = setup();
+    svc.register("user");
+    svc.createChannel("user", "test-ch", 10);
+    const state = { activeChannel: "test-ch", joinedChannels: new Set(["test-ch"]), cursors: new Map(), agentId: "user" };
+    const result = executeCommand({ name: "continue", args: "" }, svc, channelRepo, state);
+    expect(result.output[0]).toContain("+4");
+    expect(result.output[0]).toContain("test-ch");
+  });
+
+  it("/continue 8 passes amount 8", () => {
+    const { db, svc, channelRepo } = setup();
+    svc.register("user");
+    svc.createChannel("user", "test-ch", 10);
+    const state = { activeChannel: "test-ch", joinedChannels: new Set(["test-ch"]), cursors: new Map(), agentId: "user" };
+    const result = executeCommand({ name: "continue", args: "8" }, svc, channelRepo, state);
+    expect(result.output[0]).toContain("+8");
+  });
+
+  it("/continue with invalid arg defaults to 4", () => {
+    const { db, svc, channelRepo } = setup();
+    svc.register("user");
+    svc.createChannel("user", "test-ch", 10);
+    const state = { activeChannel: "test-ch", joinedChannels: new Set(["test-ch"]), cursors: new Map(), agentId: "user" };
+    const result = executeCommand({ name: "continue", args: "abc" }, svc, channelRepo, state);
+    expect(result.output[0]).toContain("+4");
+  });
+
+  it("/continue 0 defaults to 4", () => {
+    const { db, svc, channelRepo } = setup();
+    svc.register("user");
+    svc.createChannel("user", "test-ch", 10);
+    const state = { activeChannel: "test-ch", joinedChannels: new Set(["test-ch"]), cursors: new Map(), agentId: "user" };
+    const result = executeCommand({ name: "continue", args: "0" }, svc, channelRepo, state);
+    expect(result.output[0]).toContain("+4");
+  });
+
+  it("/send -f sends with human flag, allowing send on hop-limited channel", () => {
+    const { db, svc, channelRepo } = setup();
+    svc.register("user");
+    // Create channel with maxHops=1: first non-human send succeeds (hop 0->1),
+    // second would fail. Human flag resets hop count.
+    svc.createChannel("user", "test-ch", 1);
+    svc.send("user", "test-ch", "first agent msg"); // exhausts the 1 hop
+    const tmpFile = "/tmp/octo-santa-test-send-f-human.txt";
+    writeFileSync(tmpFile, "human file content");
+    const state = { activeChannel: "test-ch", joinedChannels: new Set(["test-ch"]), cursors: new Map(), agentId: "user" };
+    // Human flag should reset hop count, so this send succeeds despite exhausted hops
+    const result = executeCommand({ name: "send", args: `-f ${tmpFile}` }, svc, channelRepo, state);
+    expect(result.localEcho?.content).toBe("human file content");
+    unlinkSync(tmpFile);
   });
 });

--- a/tests/repl/startup.test.ts
+++ b/tests/repl/startup.test.ts
@@ -4,13 +4,37 @@ import { createSqliteRepos } from "../../src/storage/sqlite";
 import { MessagingService } from "../../src/core/messaging/service";
 import { startupRepl } from "../../src/transports/repl/startup";
 import { cleanupDb, testDbPath, setupTestDb } from "../helpers/db";
+import type { ProfileRepository } from "../../src/core/ports";
+import type { AgentProfile } from "../../src/core/profiles/types";
 
 const TEST_DB = testDbPath("startup");
 
-function setup() {
+// ── In-memory ProfileRepository for tests ────────────────────────────────────
+
+class InMemoryProfileRepo implements ProfileRepository {
+  private profiles = new Map<string, AgentProfile>();
+
+  add(profile: AgentProfile): void {
+    this.profiles.set(profile.name, profile);
+  }
+
+  getProfile(baseName: string): AgentProfile | null {
+    return this.profiles.get(baseName) ?? null;
+  }
+
+  listProfiles(): AgentProfile[] {
+    return [...this.profiles.values()];
+  }
+
+  getBaseNames(): Set<string> {
+    return new Set(this.profiles.keys());
+  }
+}
+
+function setup(profileRepo?: ProfileRepository) {
   const db = setupTestDb(TEST_DB, allMigrations);
   const repos = createSqliteRepos(db);
-  const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid);
+  const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid, undefined, profileRepo);
   return { db, svc };
 }
 
@@ -112,5 +136,42 @@ describe("startupRepl", () => {
 
     expect(cursor).not.toBeNull();
     expect(cursor!.last_read_message_id).toBe(0);
+  });
+
+  it("returns the resolved name from registration (no profile → same as input)", () => {
+    const { db, svc } = setup();
+    const resolved = startupRepl(svc, "jay", "general");
+    expect(resolved).toBe("jay");
+    db.close();
+  });
+
+  it("returns the pool slot name when a profile resolves to a pool slot", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: "Senior developer",
+      objective: "Write clean code",
+      instructions: null,
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { db, svc } = setup(profileRepo);
+    const resolved = startupRepl(svc, "os-dev", "general");
+    expect(resolved).toBe("os-dev-1");
+
+    // Agent row should be under os-dev-1
+    const agent = db.query("SELECT * FROM agents WHERE id = ?").get("os-dev-1") as { id: string; pid: number } | null;
+    expect(agent).not.toBeNull();
+    expect(agent!.pid).toBe(process.pid);
+
+    // Channel membership is under os-dev-1
+    const cursor = db.query(
+      `SELECT last_read_message_id FROM cursors
+       WHERE agent_id = ? AND channel_id = (SELECT id FROM channels WHERE name = ?)`
+    ).get("os-dev-1", "general") as { last_read_message_id: number } | null;
+    expect(cursor).not.toBeNull();
+
+    db.close();
   });
 });


### PR DESCRIPTION
# Phase 0 (safety rails) + Phase 1 tail (messaging_listen non-push closeout)

Two phases, one merge — Phase 1 tail stacked on Phase 0 because both rewrite the same instruction surface and share the `tests/hex/transports/mcp-instructions.test.ts` anchor contract.

## Phase 0 — Safety Rails

Per-channel message hop counter with configurable limit, human-only `/continue` to bump a blocked channel, self-mention guard, and `_system` notifications for blocked messages.

- **Hop counter:** global default 4, per-channel override via `messaging_create_channel`'s `max_hops` input (bounded 1–50, optional, defaulted in core).
- **Persistence:** SQLite. Survives process restarts.
- **Self-mention guard:** one-line throw in both `MessagingService.send()` and `MessagingService.directMessage()` paths.
- **Blocked messages:** dropped, not queued. `_system` notice posted via `sendSystemNotice` (with `isDm` flag — R1 fix — filters `_system` out of mention targets on DM channels).
- **Human reset:** any message with `SendOptions.human === true` resets the counter to 0.

### Architectural invariant: human-only enforced by the transport boundary

The original design had an MCP tool `messaging_continue` with a "human-only" description. That's description-as-enforcement — a string, not a guardrail. Any agent that ignores the text can invoke it.

**Corrected in review (commit `dd777fa`):** hard enforcement via transport boundary; `messaging_continue` intentionally not an MCP tool; REPL `/continue` is sole human surface (Phase 2's future `ocs continue` CLI subcommand joins it as a second transport-bounded surface). Structural invariant:

- `SendOptions.human` is set at exactly two sites — `src/transports/repl/app.ts:122` and `src/transports/repl/commands.ts:103`. Not in any MCP tool `inputSchema`. Not synthesized by any MCP handler.
- `continueChannel()` core method has exactly one caller: `src/transports/repl/commands.ts:122`.
- Zero references to `messaging_continue` in `src/**` or `tests/**` post-cut.

**Backlog B3 (agent allowlist for `messaging_continue`)** is structurally unnecessary for this vector. Marked likely-closable in `briefings/2026-04-24-backlog-b3-b4-b6-notes.md`; reopen only if the eventual plugin-ecosystem ADR revives a general restriction need.

### Design-accepted risks (documented; not blockers)

- `hasRecentHopNotice()` last-1 read → two concurrent sends can both emit a `_system` notice. Failure mode: harmless duplicate advisory. Counter itself is atomic; notice is informational.
- Hop-increment and `_system` insert span two transactions by port-boundary constraint. Not atomic across both. Verified safe: counter is source of truth; notice is advisory.

### Refactor candidate (non-blocking, post-merge)

- Hop-counter logic duplicated between `send()` and `directMessage()` (~15 lines × 2). Refactor into a shared helper is a low-risk follow-up; not gating this PR.

## Phase 1 — messaging_listen non-push closeout

`MessagingService.readAllUnread(agentId)` core method + `messaging_listen` MCP tool (blocking up to 30s, default 10s, returns `{channels, timed_out}`).

Inline-delivery contract documented for MCP clients that don't surface push as tags (Codex, Gemini CLI, OpenCode, local models). Placed after the brain suffix (rationale at `src/transports/mcp-stdio/adapter.ts:72–77`): `buildInstructions()` output is 2799 bytes (no brain) / 2834 bytes (with brain) — intentionally outside the 2KB budget. Clipping invariant preserved by end-of-doc placement — if Claude Code's 2KB truncation clips anything, it clips this tail, which push-tag clients don't need. Non-push clients have no 2KB limit and receive the full block.

Smoke verified via `scripts/smoke-non-push.ts` — non-Claude stdio client round-trips a listen loop successfully.

## Stats

- **Tests:** 623 pass / 0 fail (1255 expects, 7.06s). Identical count before and after the `messaging_continue` removal.
- **Typecheck:** clean.
- **Review rounds:** Codex R1 + R2 + a targeted transport-boundary review (~25min) that produced `dd777fa` — the R3 equivalent, scope = "verify transport-boundary enforcement is tight + PR body language accurate."
- **Branch:** `feat/safety-rails`, tip `dd777fa`.

## Test plan for reviewer

1. **Transport boundary (primary):** grep `src/**` + `tests/**` for `messaging_continue` → zero hits. `SendOptions.human` set only in REPL source. `continueChannel()` called only from REPL commands.
2. **Hop counter:** two agents mentioning each other hit the limit at hop 4; message dropped; `_system` notice fires.
3. **Self-mention guard:** agent `@os-pm` sending a message mentioning `@os-pm` → rejected at both `send` and `directMessage` paths.
4. **/continue path:** REPL `/continue` bumps counter by +N (default 4); human message (`SendOptions.human = true`) resets to 0.
5. **messaging_listen (non-push):** stdio client without push-tag surfacing receives messages via listen loop within one tick. `scripts/smoke-non-push.ts` is the scripted verification.

## What ships

- Hop counter with per-channel `max_hops` (1–50)
- `/continue` — REPL-only surface
- Self-mention guard (send + DM paths)
- `_system` block notifications with DM-aware filtering
- `messaging_listen` MCP tool + core `readAllUnread`
- NON-PUSH CLIENTS instruction block (end-of-doc placement, truncation-aware)
- `scripts/smoke-non-push.ts` verification script

## What does NOT ship (by design)

- `messaging_continue` MCP tool — removed in review. Transport-boundary enforcement per above.
- Token-based limits — character/hop is simpler, proven (roadmap §5 Deferred).
- Cross-channel hop correlation — complex, not needed for v1 (roadmap §3 Phase 0 Out of Scope).
- Per-agent hop limits — channel-level is sufficient for v1.
