### PR TITLE
feat: persistent agent profiles (F2 substrate)

### DIFF
--- a/src/bin/repl.ts
+++ b/src/bin/repl.ts
@@ -5,6 +5,7 @@ import { createSqliteRepos } from "../storage/sqlite";
 import { MessagingService } from "../core/messaging/service";
 import { startApp } from "../transports/repl/app";
 import { startupRepl } from "../transports/repl/startup";
+import { YamlProfileStore } from "../storage/yaml-profiles/store";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -31,13 +32,15 @@ const dbPath = expandHome(process.env.OCTO_SANTA_DB ?? join(homedir(), ".octo-sa
 const db = createDb(dbPath);
 runMigrations(db, allMigrations);
 const repos = createSqliteRepos(db);
-const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid);
+const profilesDir = expandHome(process.env.OCTO_SANTA_PROFILES_DIR ?? "~/.octo-santa/profiles");
+const profiles = new YamlProfileStore(profilesDir);
+const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid, undefined, profiles);
 
-startupRepl(svc, agentId, channel);
+const resolvedName = startupRepl(svc, agentId, channel);
 
 const pollIntervalMs = Number(process.env.OCTO_SANTA_POLL_INTERVAL_MS) || 1000;
 const kittyTerminals = new Set(["ghostty", "WezTerm", "iTerm2", "kitty"]);
 const termProgram = process.env.TERM_PROGRAM ?? "";
 const kittyEnabled = kittyTerminals.has(termProgram) || process.env.OCTO_SANTA_KITTY === "1";
 
-startApp({ svc, channelRepo: repos.channels, agentId, channel, pollIntervalMs, kittyEnabled });
+startApp({ svc, channelRepo: repos.channels, agentId: resolvedName, channel, pollIntervalMs, kittyEnabled });

--- a/src/core/messaging/service.ts
+++ b/src/core/messaging/service.ts
@@ -72,7 +72,24 @@ export class MessagingService {
 
     const members = this.channels.getMembers(channelId);
     const memberIds = new Set(members.map((m) => m.id));
-    const targetAgents = mentions.filter(
+    const baseNames = this.profiles?.getBaseNames();
+
+    const expandedTargets = new Set<string>();
+    for (const mention of mentions) {
+      if (baseNames?.has(mention)) {
+        // Expand base-name mention to live instances
+        const instances = this.agents.findByBaseName(mention);
+        for (const inst of instances) {
+          if (isAgentActive(inst)) {
+            expandedTargets.add(inst.id);
+          }
+        }
+      } else {
+        expandedTargets.add(mention);
+      }
+    }
+
+    const targetAgents = [...expandedTargets].filter(
       (id) => id !== senderId && memberIds.has(id)
     );
     return { targetAgents, isDm: false };
@@ -187,7 +204,7 @@ export class MessagingService {
     }
     const allAgents = this.agents.listAll();
     const validIds = allAgents.map((a) => a.id);
-    const mentions = extractMentions(content, validIds);
+    const mentions = extractMentions(content, validIds, this.profiles?.getBaseNames());
     const message = this.messages.insertAndJoinSender(
       channel.id,
       agentId,
@@ -274,7 +291,7 @@ export class MessagingService {
 
     const allAgents = this.agents.listAll();
     const validIds = allAgents.map((a) => a.id);
-    const mentions = extractMentions(content, validIds);
+    const mentions = extractMentions(content, validIds, this.profiles?.getBaseNames());
     const message = this.messages.insertAndJoinSender(
       channel.id,
       agentId,

--- a/src/core/messaging/service.ts
+++ b/src/core/messaging/service.ts
@@ -4,6 +4,7 @@ import type {
   MessageRepository,
   CursorRepository,
   NotificationDispatch,
+  ProfileRepository,
 } from "../ports";
 import type {
   Agent,
@@ -11,6 +12,7 @@ import type {
   Message,
   ReadOptions,
 } from "./types";
+import type { RegisterResult, AutoJoinResult } from "../profiles/types";
 import {
   validateAgentName,
   assertDmAccess,
@@ -26,7 +28,8 @@ export class MessagingService {
     private readonly messages: MessageRepository,
     private readonly cursors: CursorRepository,
     private readonly pid: number,
-    private readonly dispatch?: NotificationDispatch
+    private readonly dispatch?: NotificationDispatch,
+    private readonly profiles?: ProfileRepository
   ) {}
 
   private requireRegistered(agentId: string): void {
@@ -87,9 +90,71 @@ export class MessagingService {
     return memberIds.has(match[1]!) && memberIds.has(match[2]!);
   }
 
-  register(agentId: string): Agent {
+  register(agentId: string): RegisterResult {
     validateAgentName(agentId);
-    return this.agents.register(agentId, this.pid);
+
+    // (1) Exact profile match → delegate to agents.registerWithProfile()
+    const profile = this.profiles?.getProfile(agentId) ?? null;
+    if (profile) {
+      const { agent, registeredName, instanceNumber } = this.agents.registerWithProfile(
+        profile.name,
+        this.pid,
+        profile.maxInstances,
+        { persona: profile.persona, objective: profile.objective }
+      );
+      const autoJoined = this.performAutoJoin(registeredName, profile.autoJoinChannels);
+      return {
+        ...agent,
+        registeredName,
+        baseName: profile.name,
+        instanceNumber,
+        profile: {
+          persona: profile.persona,
+          objective: profile.objective,
+          maxInstances: profile.maxInstances,
+        },
+        autoJoined,
+      };
+    }
+
+    // (2) Suffixed namespace reservation: name matches {base}-\d+ for existing profile → reject
+    if (this.profiles) {
+      const match = /^(.+)-(\d+)$/.exec(agentId);
+      if (match) {
+        const baseName = match[1]!;
+        const existingProfile = this.profiles.getProfile(baseName);
+        if (existingProfile) {
+          throw new Error(
+            `Name "${agentId}" is reserved by pool profile "${baseName}". Register as "${baseName}" to join the pool.`
+          );
+        }
+      }
+    }
+
+    // (3) No match → current behavior
+    const agent = this.agents.register(agentId, this.pid);
+    return {
+      ...agent,
+      registeredName: agentId,
+      baseName: null,
+      instanceNumber: null,
+      profile: null,
+      autoJoined: null,
+    };
+  }
+
+  private performAutoJoin(agentId: string, channels: string[]): AutoJoinResult {
+    const succeeded: string[] = [];
+    const failed: Array<{ channel: string; reason: string }> = [];
+    for (const channelName of channels) {
+      try {
+        this.subscribe(agentId, channelName);
+        succeeded.push(channelName);
+      } catch (err) {
+        failed.push({ channel: channelName, reason: String(err) });
+      }
+    }
+    return { succeeded, failed };
   }
 
   unregister(agentId: string): void {

--- a/src/core/messaging/types.ts
+++ b/src/core/messaging/types.ts
@@ -4,6 +4,10 @@ export interface Agent {
   last_seen_at: number;
   pid: number | null;
   registered_at: number | null;
+  // New nullable fields (added for persistent agent profiles)
+  base_name: string | null;
+  persona: string | null;
+  objective: string | null;
 }
 
 export interface Channel {

--- a/src/core/ports.ts
+++ b/src/core/ports.ts
@@ -7,15 +7,31 @@ import type {
   HeartbeatResult,
 } from "./messaging/types";
 import type { BrainDoc, DomainWithClaims } from "./brain/types";
+import type { AgentProfile } from "./profiles/types";
 
 // --- Storage ports (core defines, adapters implement) ---
 
 export interface AgentRepository {
   findById(id: string): Agent | null;
-  register(agentId: string, pid: number): Agent;
+  register(agentId: string, pid: number, profileFields?: {
+    baseName: string; persona: string | null; objective: string | null;
+  }): Agent;
   heartbeatOrReclaim(agentId: string, pid: number): HeartbeatResult;
   listAll(): Agent[];
   clearPid(id: string, expectedPid: number): void;
+  findByBaseName(baseName: string): Agent[];
+  registerWithProfile(
+    baseName: string,
+    pid: number,
+    maxInstances: number,
+    profileFields: { persona: string | null; objective: string | null }
+  ): { agent: Agent; registeredName: string; instanceNumber: number | null };
+}
+
+export interface ProfileRepository {
+  getProfile(baseName: string): AgentProfile | null;
+  listProfiles(): AgentProfile[];
+  getBaseNames(): Set<string>;
 }
 
 export interface ChannelRepository {

--- a/src/core/profiles/types.ts
+++ b/src/core/profiles/types.ts
@@ -1,3 +1,5 @@
+import type { Agent } from "../messaging/types";
+
 export interface AgentProfile {
   name: string;          // base name
   persona: string | null;
@@ -11,17 +13,7 @@ export interface AutoJoinResult {
   failed: Array<{ channel: string; reason: string }>;
 }
 
-export interface RegisterResult {
-  // All Agent fields
-  id: string;
-  created_at: number;
-  last_seen_at: number;
-  pid: number | null;
-  registered_at: number | null;
-  base_name: string | null;
-  persona: string | null;
-  objective: string | null;
-  // Profile-specific
+export interface RegisterResult extends Agent {
   registeredName: string;
   baseName: string | null;
   instanceNumber: number | null;

--- a/src/core/profiles/types.ts
+++ b/src/core/profiles/types.ts
@@ -1,0 +1,34 @@
+export interface AgentProfile {
+  name: string;          // base name
+  persona: string | null;
+  objective: string | null;
+  maxInstances: number;  // >= 1
+  autoJoinChannels: string[];
+}
+
+export interface AutoJoinResult {
+  succeeded: string[];
+  failed: Array<{ channel: string; reason: string }>;
+}
+
+export interface RegisterResult {
+  // All Agent fields
+  id: string;
+  created_at: number;
+  last_seen_at: number;
+  pid: number | null;
+  registered_at: number | null;
+  base_name: string | null;
+  persona: string | null;
+  objective: string | null;
+  // Profile-specific
+  registeredName: string;
+  baseName: string | null;
+  instanceNumber: number | null;
+  profile: {
+    persona: string | null;
+    objective: string | null;
+    maxInstances: number;
+  } | null;
+  autoJoined: AutoJoinResult | null;
+}

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -42,7 +42,8 @@ export function validateAgentName(agentId: string): void {
 
 export function extractMentions(
   content: string,
-  validAgentIds: string[]
+  validAgentIds: string[],
+  profileBaseNames?: Set<string>
 ): string[] {
   const matches = content.matchAll(MENTION_RE);
   const validSet = new Set(validAgentIds);
@@ -54,6 +55,10 @@ export function extractMentions(
     if (name === "all" || name === "here") {
       hasBroadcast = true;
     } else if (validSet.has(name)) {
+      // Direct agent ID — preferred over base name
+      result.add(name);
+    } else if (profileBaseNames?.has(name)) {
+      // Pool base name mention — stored as-is; expanded at dispatch time
       result.add(name);
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,12 +82,13 @@ async function main() {
     registerNotificationHandler: dispatcher.register.bind(dispatcher),
     unregisterNotificationHandler: dispatcher.unregister.bind(dispatcher),
     agents: repos.agents,
-    startPoller: (port, agentId) => {
+    startPoller: (port, agentId, baseName) => {
       const poller = createNotificationPoller({
         getNewMessagesForAgent: notificationQueries.getNewMessagesForAgent.bind(notificationQueries),
         getMaxMessageId: notificationQueries.getMaxMessageId.bind(notificationQueries),
         port,
         agentId,
+        baseName,
       });
       poller.start();
       return poller;

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import { MessagingService } from "./core/messaging/service";
 import { BrainService } from "./core/brain/service";
 import { startMcpStdio } from "./transports/mcp-stdio/adapter";
 import { createNotificationDispatcher } from "./notifications/dispatch/dispatcher";
+import { YamlProfileStore } from "./storage/yaml-profiles/store";
 import { log } from "./log";
 
 function expandHome(p: string): string {
@@ -38,6 +39,12 @@ async function main() {
   // 4. Notification dispatcher
   const dispatcher = createNotificationDispatcher();
 
+  // 4b. Profile store
+  const profilesDir = expandHome(
+    process.env.OCTO_SANTA_PROFILES_DIR ?? "~/.octo-santa/profiles"
+  );
+  const profiles = new YamlProfileStore(profilesDir);
+
   // 5. Services
   const messaging = new MessagingService(
     repos.agents,
@@ -45,7 +52,8 @@ async function main() {
     repos.messages,
     repos.cursors,
     process.pid,
-    dispatcher
+    dispatcher,
+    profiles
   );
 
   const brain = new BrainService(

--- a/src/notifications/poller/poller.ts
+++ b/src/notifications/poller/poller.ts
@@ -14,9 +14,10 @@ export function createNotificationPoller(opts: {
   getMaxMessageId: () => number;
   port: NotificationPort;
   agentId: string;
+  baseName?: string;
   intervalMs?: number;
 }): { start(): void; stop(): void; _tick(): Promise<void> } {
-  const { getNewMessagesForAgent, getMaxMessageId, port, agentId, intervalMs = 2000 } = opts;
+  const { getNewMessagesForAgent, getMaxMessageId, port, agentId, baseName, intervalMs = 2000 } = opts;
   let hwm = 0;
   let timer: ReturnType<typeof setInterval> | null = null;
 
@@ -50,7 +51,7 @@ export function createNotificationPoller(opts: {
     }
     try {
       const mentions: string[] = JSON.parse(mentionsJson);
-      return mentions.includes(agentId) || mentions.includes("*");
+      return mentions.includes(agentId) || (baseName != null && mentions.includes(baseName)) || mentions.includes("*");
     } catch {
       return false;
     }

--- a/src/storage/sqlite/agent-repo.ts
+++ b/src/storage/sqlite/agent-repo.ts
@@ -146,8 +146,12 @@ export class SqliteAgentRepo implements AgentRepository {
         chosenSlot = 1;
         while (liveSlots.has(chosenSlot)) chosenSlot++;
       } else {
+        const activeList = existing
+          .filter((a) => a.pid !== null && isProcessAlive(a.pid) && Date.now() - a.last_seen_at <= PID_STALE_MS)
+          .map((a) => `${a.id} (pid ${a.pid})`)
+          .join(", ");
         throw new Error(
-          `Agent pool "${baseName}" is at capacity (${maxInstances}/${maxInstances} instances active).`
+          `Agent pool "${baseName}" is at capacity (${maxInstances}/${maxInstances} instances). Active instances: ${activeList}`
         );
       }
 

--- a/src/storage/sqlite/agent-repo.ts
+++ b/src/storage/sqlite/agent-repo.ts
@@ -11,9 +11,60 @@ export class SqliteAgentRepo implements AgentRepository {
     return (this.db.query("SELECT * FROM agents WHERE id = ?").get(id) as Agent) ?? null;
   }
 
-  register(agentId: string, pid: number): Agent {
+  findByBaseName(baseName: string): Agent[] {
+    return this.db
+      .query("SELECT * FROM agents WHERE base_name = ? ORDER BY id")
+      .all(baseName) as Agent[];
+  }
+
+  /**
+   * Private helper: performs INSERT/ON CONFLICT upsert without wrapping in its own transaction.
+   * The caller (register or registerWithProfile) must wrap this in an EXCLUSIVE transaction.
+   * When profileFields is omitted, sets base_name/persona/objective to NULL (clears stale data).
+   */
+  private _upsertAgent(
+    agentId: string,
+    pid: number,
+    profileFields?: { baseName: string; persona: string | null; objective: string | null }
+  ): void {
+    const now = Date.now();
+    if (profileFields) {
+      this.db
+        .query(
+          `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(id) DO UPDATE SET
+             last_seen_at = excluded.last_seen_at,
+             pid = excluded.pid,
+             registered_at = excluded.registered_at,
+             base_name = excluded.base_name,
+             persona = excluded.persona,
+             objective = excluded.objective`
+        )
+        .run(agentId, now, now, pid, now, profileFields.baseName, profileFields.persona, profileFields.objective);
+    } else {
+      this.db
+        .query(
+          `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
+           VALUES (?, ?, ?, ?, ?, NULL, NULL, NULL)
+           ON CONFLICT(id) DO UPDATE SET
+             last_seen_at = excluded.last_seen_at,
+             pid = excluded.pid,
+             registered_at = excluded.registered_at,
+             base_name = excluded.base_name,
+             persona = excluded.persona,
+             objective = excluded.objective`
+        )
+        .run(agentId, now, now, pid, now);
+    }
+  }
+
+  register(
+    agentId: string,
+    pid: number,
+    profileFields?: { baseName: string; persona: string | null; objective: string | null }
+  ): Agent {
     const doRegister = this.db.transaction(() => {
-      const now = Date.now();
       const existing = this.findById(agentId);
 
       if (existing && existing.pid !== null && existing.pid !== pid) {
@@ -24,13 +75,86 @@ export class SqliteAgentRepo implements AgentRepository {
         }
       }
 
-      this.db.run(
-        `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at) VALUES (?, ?, ?, ?, ?)
-         ON CONFLICT(id) DO UPDATE SET last_seen_at = excluded.last_seen_at, pid = excluded.pid, registered_at = excluded.registered_at`,
-        [agentId, now, now, pid, now]
-      );
-
+      this._upsertAgent(agentId, pid, profileFields);
       return this.findById(agentId)!;
+    });
+
+    return withRetrySync(() => doRegister.exclusive());
+  }
+
+  registerWithProfile(
+    baseName: string,
+    pid: number,
+    maxInstances: number,
+    profileFields: { persona: string | null; objective: string | null }
+  ): { agent: Agent; registeredName: string; instanceNumber: number | null } {
+    const doRegister = this.db.transaction(() => {
+      const existing = this.findByBaseName(baseName);
+
+      // Same-PID idempotency: if this PID already owns a slot, return it
+      const ownedSlot = existing.find((a) => a.pid === pid);
+      if (ownedSlot) {
+        const instanceNumber =
+          maxInstances === 1 ? null : extractInstanceNumber(ownedSlot.id, baseName);
+        return {
+          agent: ownedSlot,
+          registeredName: ownedSlot.id,
+          instanceNumber,
+        };
+      }
+
+      if (maxInstances === 1) {
+        // Singleton: registered name equals base name
+        const current = existing[0] ?? null;
+        if (current && current.pid !== null && current.pid !== pid) {
+          if (isProcessAlive(current.pid) && Date.now() - current.last_seen_at <= PID_STALE_MS) {
+            throw new Error(
+              `Agent "${baseName}" is already active (pid ${current.pid}). Max instances: 1.`
+            );
+          }
+        }
+        this._upsertAgent(baseName, pid, { baseName, ...profileFields });
+        const agent = this.findById(baseName)!;
+        return { agent, registeredName: baseName, instanceNumber: null };
+      }
+
+      // Pool: scan existing slots to find dead ones or next available
+      const liveSlots = new Set<number>();
+      const deadSlots: Array<{ slot: number; agentId: string }> = [];
+
+      for (const a of existing) {
+        const slot = extractInstanceNumber(a.id, baseName);
+        if (slot === null) continue;
+        const isDead =
+          a.pid === null ||
+          !isProcessAlive(a.pid) ||
+          Date.now() - a.last_seen_at > PID_STALE_MS;
+        if (isDead) {
+          deadSlots.push({ slot, agentId: a.id });
+        } else {
+          liveSlots.add(slot);
+        }
+      }
+
+      // Prefer reclaiming the lowest dead slot; otherwise use next unused slot number
+      deadSlots.sort((a, b) => a.slot - b.slot);
+
+      let chosenSlot: number;
+      if (deadSlots.length > 0) {
+        chosenSlot = deadSlots[0]!.slot;
+      } else if (liveSlots.size < maxInstances) {
+        chosenSlot = 1;
+        while (liveSlots.has(chosenSlot)) chosenSlot++;
+      } else {
+        throw new Error(
+          `Agent pool "${baseName}" is at capacity (${maxInstances}/${maxInstances} instances active).`
+        );
+      }
+
+      const registeredName = `${baseName}-${chosenSlot}`;
+      this._upsertAgent(registeredName, pid, { baseName, ...profileFields });
+      const agent = this.findById(registeredName)!;
+      return { agent, registeredName, instanceNumber: chosenSlot };
     });
 
     return withRetrySync(() => doRegister.exclusive());
@@ -41,14 +165,11 @@ export class SqliteAgentRepo implements AgentRepository {
       const now = Date.now();
 
       // (1) Try UPDATE WHERE pid=? — happy path heartbeat
-      const result = this.db.run(
-        "UPDATE agents SET last_seen_at = ? WHERE id = ? AND pid = ?",
-        [now, agentId, pid]
-      );
+      const result = this.db
+        .query("UPDATE agents SET last_seen_at = ? WHERE id = ? AND pid = ?")
+        .run(now, agentId, pid);
 
-      if (result.changes > 0) {
-        return "ok";
-      }
+      if (result.changes > 0) return "ok";
 
       // (2) 0 rows updated — check current owner
       const current = this.findById(agentId);
@@ -64,10 +185,11 @@ export class SqliteAgentRepo implements AgentRepository {
       }
 
       // (3) Current owner is stale — CAS reclaim
-      const reclaim = this.db.run(
-        "UPDATE agents SET pid = ?, registered_at = ?, last_seen_at = ? WHERE id = ? AND pid = ?",
-        [pid, now, now, agentId, current.pid]
-      );
+      const reclaim = this.db
+        .query(
+          "UPDATE agents SET pid = ?, registered_at = ?, last_seen_at = ? WHERE id = ? AND pid = ?"
+        )
+        .run(pid, now, now, agentId, current.pid);
 
       return reclaim.changes > 0 ? "ok" : "lost";
     });
@@ -76,15 +198,30 @@ export class SqliteAgentRepo implements AgentRepository {
   }
 
   listAll(): Agent[] {
-    return this.db.query("SELECT * FROM agents WHERE id != '_system' ORDER BY id").all() as Agent[];
+    return this.db
+      .query("SELECT * FROM agents WHERE id != '_system' ORDER BY id")
+      .all() as Agent[];
   }
 
   clearPid(id: string, expectedPid: number): void {
     withRetrySync(() => {
-      this.db.run(
-        "UPDATE agents SET pid = NULL, registered_at = NULL WHERE id = ? AND pid = ?",
-        [id, expectedPid]
-      );
+      this.db
+        .query("UPDATE agents SET pid = NULL, registered_at = NULL WHERE id = ? AND pid = ?")
+        .run(id, expectedPid);
     });
   }
+}
+
+/**
+ * Extracts the numeric slot suffix from a pool agent ID.
+ * e.g. extractInstanceNumber("worker-2", "worker") → 2
+ * Returns null if the ID doesn't match the expected pool pattern.
+ */
+function extractInstanceNumber(agentId: string, baseName: string): number | null {
+  const prefix = `${baseName}-`;
+  if (!agentId.startsWith(prefix)) return null;
+  const suffix = agentId.slice(prefix.length);
+  const n = parseInt(suffix, 10);
+  if (isNaN(n) || n <= 0 || String(n) !== suffix) return null;
+  return n;
 }

--- a/src/storage/sqlite/agent-repo.ts
+++ b/src/storage/sqlite/agent-repo.ts
@@ -208,11 +208,12 @@ export class SqliteAgentRepo implements AgentRepository {
   }
 
   clearPid(id: string, expectedPid: number): void {
-    withRetrySync(() => {
+    const doClear = this.db.transaction(() => {
       this.db
         .query("UPDATE agents SET pid = NULL, registered_at = NULL WHERE id = ? AND pid = ?")
         .run(id, expectedPid);
     });
+    withRetrySync(() => doClear.exclusive());
   }
 }
 

--- a/src/storage/sqlite/domain-repo.ts
+++ b/src/storage/sqlite/domain-repo.ts
@@ -48,7 +48,7 @@ export class SqliteDomainRepo implements DomainRepository {
       claims: claims.filter((c) => c.domain_identifier === d.identifier).map((c) => ({
         agent_id: c.agent_id,
         pid: c.pid,
-        agent: { id: c.id, created_at: c.created_at, last_seen_at: c.last_seen_at, pid: c.agent_pid, registered_at: c.registered_at } as Agent,
+        agent: { id: c.id, created_at: c.created_at, last_seen_at: c.last_seen_at, pid: c.agent_pid, registered_at: c.registered_at, base_name: null, persona: null, objective: null } as Agent,
       })),
     }));
   }

--- a/src/storage/sqlite/migrations.ts
+++ b/src/storage/sqlite/migrations.ts
@@ -134,6 +134,15 @@ const messagingMigrations: Migration[] = [
       ALTER TABLE messages ADD COLUMN mentions TEXT NOT NULL DEFAULT '[]';
     `,
   },
+  {
+    name: "messaging_003_agent_profiles",
+    up: `
+      ALTER TABLE agents ADD COLUMN base_name TEXT;
+      ALTER TABLE agents ADD COLUMN persona TEXT;
+      ALTER TABLE agents ADD COLUMN objective TEXT;
+      CREATE INDEX idx_agents_base_name ON agents(base_name);
+    `,
+  },
 ];
 
 const brainMigrations: Migration[] = [

--- a/src/storage/yaml-profiles/store.ts
+++ b/src/storage/yaml-profiles/store.ts
@@ -1,0 +1,186 @@
+// src/storage/yaml-profiles/store.ts
+//
+// YAML filesystem adapter implementing ProfileRepository.
+// Reads all .yaml files from a configured directory on construction.
+// One bad file aborts startup (fail-fast).
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join, basename } from "node:path";
+import type { ProfileRepository } from "../../core/ports";
+import type { AgentProfile } from "../../core/profiles/types";
+import { validateAgentName } from "../../core/utils";
+import { log } from "../../log";
+
+// Known fields — unknown ones trigger a warning
+const KNOWN_FIELDS = new Set([
+  "name",
+  "persona",
+  "objective",
+  "maxInstances",
+  "autoJoinChannels",
+]);
+
+// Pattern: <baseName>-<digits>
+const POOL_SUFFIX_RE = /^(.+)-(\d+)$/;
+
+function parseProfile(filePath: string, content: string): AgentProfile {
+  const fileName = basename(filePath, ".yaml");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const raw: any = Bun.YAML.parse(content);
+
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error(`Profile file "${filePath}" must contain a YAML mapping`);
+  }
+
+  // Warn about unknown fields
+  for (const key of Object.keys(raw)) {
+    if (!KNOWN_FIELDS.has(key)) {
+      log(`Warning: unknown field "${key}" in profile "${filePath}" — ignoring`);
+    }
+  }
+
+  // --- name ---
+  const name: string = raw["name"];
+  if (typeof name !== "string" || !name.trim()) {
+    throw new Error(`Profile file "${filePath}": "name" must be a non-empty string`);
+  }
+  // Validates format ([\w-]+) and reserved names
+  validateAgentName(name);
+
+  // Filename must match name
+  if (fileName !== name) {
+    throw new Error(
+      `Profile filename mismatch: file is "${fileName}.yaml" but name field is "${name}"`
+    );
+  }
+
+  // --- persona ---
+  const rawPersona = raw["persona"];
+  let persona: string | null = null;
+  if (rawPersona !== undefined && rawPersona !== null) {
+    if (typeof rawPersona !== "string") {
+      throw new Error(
+        `Profile "${name}": persona must be a string or null/undefined, got ${typeof rawPersona}`
+      );
+    }
+    persona = rawPersona;
+  }
+
+  // --- objective ---
+  const rawObjective = raw["objective"];
+  let objective: string | null = null;
+  if (rawObjective !== undefined && rawObjective !== null) {
+    if (typeof rawObjective !== "string") {
+      throw new Error(
+        `Profile "${name}": objective must be a string or null/undefined, got ${typeof rawObjective}`
+      );
+    }
+    objective = rawObjective;
+  }
+
+  // --- maxInstances ---
+  const rawMax = raw["maxInstances"];
+  let maxInstances = 1;
+  if (rawMax !== undefined && rawMax !== null) {
+    if (typeof rawMax !== "number" || !Number.isInteger(rawMax) || rawMax < 1) {
+      throw new Error(
+        `Profile "${name}": maxInstances must be a positive integer >= 1, got ${rawMax}`
+      );
+    }
+    maxInstances = rawMax;
+  }
+
+  // --- autoJoinChannels ---
+  const rawChannels = raw["autoJoinChannels"];
+  let autoJoinChannels: string[] = [];
+  if (rawChannels !== undefined && rawChannels !== null) {
+    if (!Array.isArray(rawChannels)) {
+      throw new Error(
+        `Profile "${name}": autoJoinChannels must be an array of strings`
+      );
+    }
+    for (let i = 0; i < rawChannels.length; i++) {
+      if (typeof rawChannels[i] !== "string") {
+        throw new Error(
+          `Profile "${name}": autoJoinChannels[${i}] must be a string, got ${typeof rawChannels[i]}`
+        );
+      }
+    }
+    autoJoinChannels = rawChannels as string[];
+  }
+
+  return { name, persona, objective, maxInstances, autoJoinChannels };
+}
+
+function checkPoolNameCollisions(profiles: AgentProfile[]): void {
+  const nameSet = new Set(profiles.map((p) => p.name));
+  for (const profile of profiles) {
+    const m = POOL_SUFFIX_RE.exec(profile.name);
+    if (m) {
+      const baseName = m[1]!;
+      if (nameSet.has(baseName)) {
+        throw new Error(
+          `Profile name "${profile.name}" collides with pool namespace of profile "${baseName}". ` +
+          `Instance names like "${profile.name}" are reserved for the pool of "${baseName}".`
+        );
+      }
+    }
+  }
+}
+
+export class YamlProfileStore implements ProfileRepository {
+  private readonly profiles: Map<string, AgentProfile>;
+
+  constructor(dirPath: string) {
+    this.profiles = new Map();
+    this.load(dirPath);
+  }
+
+  private load(dirPath: string): void {
+    let files: string[];
+    try {
+      files = readdirSync(dirPath);
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      if (e.code === "ENOENT") {
+        // Directory doesn't exist — silently treat as empty
+        return;
+      }
+      throw err;
+    }
+
+    const yamlFiles = files.filter((f) => f.endsWith(".yaml")).sort();
+    const parsed: AgentProfile[] = [];
+
+    for (const file of yamlFiles) {
+      const filePath = join(dirPath, file);
+      const content = readFileSync(filePath, "utf-8");
+      const profile = parseProfile(filePath, content);
+
+      // Check for duplicate names (defensive; filesystem prevents same basename)
+      if (this.profiles.has(profile.name)) {
+        throw new Error(
+          `Duplicate profile name "${profile.name}" found in directory "${dirPath}"`
+        );
+      }
+
+      parsed.push(profile);
+      this.profiles.set(profile.name, profile);
+    }
+
+    // After all files parsed, check pool namespace collisions
+    checkPoolNameCollisions(parsed);
+  }
+
+  getProfile(baseName: string): AgentProfile | null {
+    return this.profiles.get(baseName) ?? null;
+  }
+
+  listProfiles(): AgentProfile[] {
+    return [...this.profiles.values()];
+  }
+
+  getBaseNames(): Set<string> {
+    return new Set(this.profiles.keys());
+  }
+}

--- a/src/transports/mcp-stdio/adapter.ts
+++ b/src/transports/mcp-stdio/adapter.ts
@@ -332,7 +332,7 @@ export interface McpStdioOpts {
   unregisterNotificationHandler: (agentId: string) => void;
   agents: AgentRepository;
   /** Factory invoked once per session when an agent binds. Returns a handle with stop(). */
-  startPoller: (port: NotificationPort, agentId: string) => { stop(): void };
+  startPoller: (port: NotificationPort, agentId: string, baseName?: string) => { stop(): void };
   heartbeatIntervalMs?: number;
   onDisconnect: (agentId: string, pid: number) => void;
 }
@@ -391,7 +391,7 @@ export async function startMcpStdio(opts: McpStdioOpts): Promise<void> {
             }),
         };
         registerNotificationHandler(effectiveId, port);
-        pollerRef = startPoller(port, effectiveId);
+        pollerRef = startPoller(port, effectiveId, boundProfile?.baseName);
         heartbeatTimer = setInterval(() => {
           const result = agents.heartbeatOrReclaim(effectiveId, process.pid);
           if (result === "lost") {

--- a/src/transports/mcp-stdio/adapter.ts
+++ b/src/transports/mcp-stdio/adapter.ts
@@ -30,9 +30,13 @@ export function buildInstructions(
     "MENTIONS:\n" +
     "- @agent-name → only that agent gets notified\n" +
     "- @all → all channel subscribers get notified\n" +
+    "- @pool-name → all live instances of that pool get notified (e.g. @os-dev reaches os-dev-1, os-dev-2, etc.)\n" +
     "- No mention → message is silent (recipients must read actively)\n\n" +
     "Use @mentions to get attention. Messages without mentions are for " +
     "context/logging — recipients see them when they check the channel.\n\n" +
+    "PROFILES: If your name matches a loaded profile, registration assigns you a pool slot " +
+    "(e.g., registering as 'os-dev' may bind you as 'os-dev-1'). " +
+    "Always use the `registeredName` from the registration response for subsequent calls.\n\n" +
     "NOTIFICATIONS: There are two notification modes:\n" +
     "- DM channels (created via messaging_direct_message): All messages push automatically to both parties. No @mention needed.\n" +
     "- Regular channels (created via messaging_create_channel): Only messages with @mentions trigger push notifications. Unmentioned messages are silent.\n\n" +
@@ -60,11 +64,14 @@ export function buildInstructions(
 export function registerMessagingTools(
   server: McpServer,
   messaging: MessagingService,
-  onAgentId?: (agentId: string) => { commit: () => void }
+  onAgentId?: (agentId: string) => { commit: (resolvedName?: string) => void },
+  onProfile?: (profile: { baseName: string; persona: string | null; objective: string | null }) => void
 ): void {
   server.registerTool("messaging_register", {
     description:
-      "Register this agent with a unique name to start receiving messages",
+      "Register this agent with a unique name to start receiving messages. " +
+      "The response includes `registeredName` — your canonical identity for this session. " +
+      "Always use `registeredName` for subsequent calls.",
     inputSchema: {
       agent_id: z
         .string()
@@ -77,9 +84,13 @@ export function registerMessagingTools(
         .describe("Your agent/project name"),
     },
   }, async ({ agent_id }) => {
-    return withAgent(onAgentId, agent_id, () =>
-      jsonResult(messaging.register(agent_id))
-    );
+    const handle = onAgentId?.(agent_id);
+    const result = messaging.register(agent_id);
+    handle?.commit(result.registeredName);
+    if (result.baseName) {
+      onProfile?.({ baseName: result.baseName, persona: result.profile?.persona ?? null, objective: result.profile?.objective ?? null });
+    }
+    return jsonResult(result);
   });
 
   server.registerTool("messaging_create_channel", {
@@ -224,7 +235,7 @@ export function registerBrainTools(
   brain: BrainService,
   config: OctoSantaConfig | null,
   hasBrain: boolean,
-  onAgentId?: (agentId: string) => { commit: () => void }
+  onAgentId?: (agentId: string) => { commit: (resolvedName?: string) => void }
 ): void {
   server.registerTool("brain_index", {
     description:
@@ -355,8 +366,9 @@ export async function startMcpStdio(opts: McpStdioOpts): Promise<void> {
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   let boundAgentId: string | null = null;
   let pollerRef: { stop(): void } | null = null;
+  let boundProfile: { baseName: string; persona: string | null; objective: string | null } | null = null;
 
-  function onAgentId(agentId: string): { commit: () => void } {
+  function onAgentId(agentId: string): { commit: (resolvedName?: string) => void } {
     if (boundAgentId !== null) {
       if (boundAgentId !== agentId) {
         throw new Error(
@@ -367,9 +379,10 @@ export async function startMcpStdio(opts: McpStdioOpts): Promise<void> {
     }
     // Deferred binding — caller must commit() after successful operation
     return {
-      commit: () => {
+      commit: (resolvedName?: string) => {
         if (boundAgentId !== null) return; // Already bound (concurrent commit)
-        boundAgentId = agentId;
+        const effectiveId = resolvedName ?? agentId;
+        boundAgentId = effectiveId;
         const port: NotificationPort = {
           notify: (content, meta) =>
             mcpServer.server.notification({
@@ -377,10 +390,10 @@ export async function startMcpStdio(opts: McpStdioOpts): Promise<void> {
               params: { content, meta },
             }),
         };
-        registerNotificationHandler(agentId, port);
-        pollerRef = startPoller(port, agentId);
+        registerNotificationHandler(effectiveId, port);
+        pollerRef = startPoller(port, effectiveId);
         heartbeatTimer = setInterval(() => {
-          const result = agents.heartbeatOrReclaim(agentId, process.pid);
+          const result = agents.heartbeatOrReclaim(effectiveId, process.pid);
           if (result === "lost") {
             clearInterval(heartbeatTimer!);
             heartbeatTimer = null;
@@ -391,7 +404,9 @@ export async function startMcpStdio(opts: McpStdioOpts): Promise<void> {
     };
   }
 
-  registerMessagingTools(mcpServer, messaging, onAgentId);
+  registerMessagingTools(mcpServer, messaging, onAgentId, (profile) => {
+    boundProfile = profile;
+  });
   registerBrainTools(mcpServer, brain, config, hasBrain, onAgentId);
 
   const transport = new StdioServerTransport();
@@ -411,7 +426,8 @@ export async function startMcpStdio(opts: McpStdioOpts): Promise<void> {
 
   // Bootstrap nudge — prompt agent to register before any tool call
   let bootstrapMsg =
-    "octo-santa messaging module is available. Call messaging_register with a unique agent name (e.g. your role), then create or subscribe to channels to start receiving push notifications. If the name is taken, pick a different one.";
+    "octo-santa messaging module is available. Call messaging_register with a unique agent name (e.g. your role), then create or subscribe to channels to start receiving push notifications. If the name is taken, pick a different one. " +
+    "If profiles are configured, your name may be resolved to a pool slot (e.g. 'os-dev' → 'os-dev-1') — always use the `registeredName` from the response for subsequent calls.";
   if (config?.domain) {
     bootstrapMsg +=
       `\n\nBrain module active — this repo is domain "${config.domain.identifier}" (${config.domain.description}). ` +

--- a/src/transports/mcp-stdio/helpers.ts
+++ b/src/transports/mcp-stdio/helpers.ts
@@ -4,7 +4,7 @@ export function jsonResult(data: unknown) {
 }
 
 export function withAgent<T>(
-  onAgentId: ((agentId: string) => { commit: () => void }) | undefined,
+  onAgentId: ((agentId: string) => { commit: (resolvedName?: string) => void }) | undefined,
   agentId: string,
   fn: () => T
 ): T {

--- a/src/transports/repl/startup.ts
+++ b/src/transports/repl/startup.ts
@@ -1,8 +1,10 @@
 // src/transports/repl/startup.ts
 import type { MessagingService } from "../../core/messaging/service";
 
-export function startupRepl(svc: MessagingService, agentId: string, channel: string): void {
-  svc.register(agentId);
-  svc.createChannel(agentId, channel);
-  svc.subscribe(agentId, channel);
+export function startupRepl(svc: MessagingService, agentId: string, channel: string): string {
+  const result = svc.register(agentId);
+  const name = result.registeredName;
+  svc.createChannel(name, channel);
+  svc.subscribe(name, channel);
+  return name;
 }

--- a/tests/hex/core/pool-mentions.test.ts
+++ b/tests/hex/core/pool-mentions.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { MessagingService } from "../../../src/core/messaging/service";
+import { createSqliteRepos } from "../../../src/storage/sqlite";
+import { createDb } from "../../../src/storage/sqlite/db";
+import {
+  runMigrations,
+  allMigrations,
+} from "../../../src/storage/sqlite/migrations";
+import { cleanupDb } from "../../helpers/db";
+import type { ProfileRepository } from "../../../src/core/ports";
+import type { AgentProfile } from "../../../src/core/profiles/types";
+
+const TEST_DB = `/tmp/octo-santa-test-pool-mentions-${process.pid}.sqlite`;
+
+// ── In-memory ProfileRepository ────────────────────────────────────────────
+
+class InMemoryProfileRepo implements ProfileRepository {
+  private profiles = new Map<string, AgentProfile>();
+
+  add(profile: AgentProfile): void {
+    this.profiles.set(profile.name, profile);
+  }
+
+  getProfile(baseName: string): AgentProfile | null {
+    return this.profiles.get(baseName) ?? null;
+  }
+
+  listProfiles(): AgentProfile[] {
+    return [...this.profiles.values()];
+  }
+
+  getBaseNames(): Set<string> {
+    return new Set(this.profiles.keys());
+  }
+}
+
+// ── Captured dispatch helper ───────────────────────────────────────────────
+
+type DispatchCall = {
+  channelName: string;
+  sender: string;
+  content: string;
+  messageId: number;
+  isDm: boolean;
+  targetAgents: string[];
+};
+
+function makeCapturingDispatch() {
+  const dispatched: DispatchCall[] = [];
+  return {
+    dispatched,
+    dispatch(notification: DispatchCall) {
+      dispatched.push({ ...notification });
+    },
+  };
+}
+
+// ── Setup helper ───────────────────────────────────────────────────────────
+
+function setup(profileRepo?: ProfileRepository) {
+  cleanupDb(TEST_DB);
+  const db = createDb(TEST_DB);
+  runMigrations(db, allMigrations);
+  const repos = createSqliteRepos(db);
+  const capturingDispatch = makeCapturingDispatch();
+  const svc = new MessagingService(
+    repos.agents,
+    repos.channels,
+    repos.messages,
+    repos.cursors,
+    process.pid,
+    capturingDispatch,
+    profileRepo
+  );
+  return { db, repos, svc, dispatched: capturingDispatch.dispatched };
+}
+
+afterEach(() => cleanupDb(TEST_DB));
+
+/**
+ * Inserts a live agent directly into the DB with a given base_name and the
+ * current PID so that isAgentActive() returns true.
+ * Used to simulate a second pool instance from a "different process" that
+ * happens to be alive (same PID — acceptable for unit tests).
+ */
+function insertLiveAgent(
+  db: ReturnType<typeof createDb>,
+  agentId: string,
+  baseName: string
+): void {
+  const now = Date.now();
+  db.run(
+    `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [agentId, now, now, process.pid, now, baseName]
+  );
+}
+
+// ── Pool mention — base name stored, instances notified ───────────────────
+
+describe("pool-wide mention expansion", () => {
+  it("@os-dev mention stores base name and dispatches to subscribed live instances", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: null,
+      objective: null,
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { svc, db, repos, dispatched } = setup(profileRepo);
+
+    // Bootstrap: create channel and an admin
+    svc.register("admin");
+    svc.createChannel("admin", "general");
+
+    // Register first pool instance through the service (os-dev-1)
+    const r1 = svc.register("os-dev");
+    const id1 = r1.registeredName; // "os-dev-1"
+
+    // Insert second instance directly (bypasses same-PID idempotency) so we have two live instances
+    insertLiveAgent(db, "os-dev-2", "os-dev");
+    const id2 = "os-dev-2";
+
+    // Register os-dev-2 as a known agent via repos.agents so subscribe works
+    // (subscribe calls requireRegistered which checks pid = process.pid)
+    // We need to use a separate MessagingService for os-dev-2 that shares the same DB
+    // Instead, let's subscribe os-dev-2 directly via repos
+    const channel = repos.channels.findByName("general")!;
+    repos.channels.addMember(id2, channel.id, 0);
+
+    // Subscribe id1 too
+    svc.subscribe(id1, "general");
+
+    // Admin sends @os-dev (base name mention)
+    const msg = svc.send("admin", "general", `hey @os-dev check this`);
+
+    // The message's stored mentions should contain the raw base name "os-dev"
+    const row = db.query("SELECT mentions FROM messages WHERE id = ?").get(msg.id) as { mentions: string } | null;
+    expect(row).not.toBeNull();
+    const storedMentions = JSON.parse(row!.mentions) as string[];
+    expect(storedMentions).toContain("os-dev");
+
+    // Dispatch should have resolved os-dev → [os-dev-1, os-dev-2]
+    expect(dispatched.length).toBe(1);
+    expect(dispatched[0]!.targetAgents.sort()).toEqual([id1, id2].sort());
+  });
+
+  it("@os-dev-1 as direct mention targets only that instance, not the whole pool", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: null,
+      objective: null,
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { svc, db, repos, dispatched } = setup(profileRepo);
+
+    svc.register("admin");
+    svc.createChannel("admin", "general");
+
+    const r1 = svc.register("os-dev");
+    const id1 = r1.registeredName; // "os-dev-1"
+
+    // Second instance inserted directly
+    insertLiveAgent(db, "os-dev-2", "os-dev");
+    const channel = repos.channels.findByName("general")!;
+    repos.channels.addMember("os-dev-2", channel.id, 0);
+    svc.subscribe(id1, "general");
+
+    // Direct mention by full instance name
+    svc.send("admin", "general", `hey @${id1} only you`);
+
+    expect(dispatched.length).toBe(1);
+    expect(dispatched[0]!.targetAgents).toEqual([id1]);
+  });
+
+  it("membership filter: @os-dev only notifies pool instances subscribed to the channel", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: null,
+      objective: null,
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { svc, db, repos, dispatched } = setup(profileRepo);
+
+    svc.register("admin");
+    svc.createChannel("admin", "general");
+
+    const r1 = svc.register("os-dev"); // os-dev-1
+    const id1 = r1.registeredName;
+
+    // os-dev-2 is live but NOT subscribed to the channel
+    insertLiveAgent(db, "os-dev-2", "os-dev");
+    const id2 = "os-dev-2";
+
+    // Only os-dev-1 subscribes; os-dev-2 does NOT
+    svc.subscribe(id1, "general");
+    // id2 exists and is active (same PID) but is NOT a channel member
+
+    svc.send("admin", "general", "@os-dev all instances should see this");
+
+    expect(dispatched.length).toBe(1);
+    // Only id1 is a member — id2 must NOT be in targets
+    expect(dispatched[0]!.targetAgents).toEqual([id1]);
+    expect(dispatched[0]!.targetAgents).not.toContain(id2);
+  });
+
+  it("no dispatch when pool instances are live but none subscribed to channel", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: null,
+      objective: null,
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { svc, db, dispatched } = setup(profileRepo);
+
+    svc.register("admin");
+    svc.createChannel("admin", "general");
+
+    // Insert live instances but don't subscribe any to general
+    insertLiveAgent(db, "os-dev-1", "os-dev");
+    insertLiveAgent(db, "os-dev-2", "os-dev");
+
+    svc.send("admin", "general", "@os-dev nobody is subscribed");
+
+    // No subscribed pool members → no dispatch
+    expect(dispatched.length).toBe(0);
+  });
+
+  it("deduplicates when same agent is targeted by base name AND direct mention", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: null,
+      objective: null,
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { svc, dispatched } = setup(profileRepo);
+
+    svc.register("admin");
+    svc.createChannel("admin", "general");
+
+    const r1 = svc.register("os-dev"); // os-dev-1
+    const id1 = r1.registeredName;
+    svc.subscribe(id1, "general");
+
+    // Mention both the base name (@os-dev) and the specific instance (@os-dev-1)
+    svc.send("admin", "general", `@os-dev and @${id1} check this`);
+
+    expect(dispatched.length).toBe(1);
+    // id1 should appear only once in targetAgents
+    const targets = dispatched[0]!.targetAgents;
+    expect(targets.filter((t) => t === id1).length).toBe(1);
+  });
+});

--- a/tests/hex/core/profile-concurrency.test.ts
+++ b/tests/hex/core/profile-concurrency.test.ts
@@ -1,0 +1,213 @@
+// tests/hex/core/profile-concurrency.test.ts
+//
+// Cross-process concurrency tests for profile-aware registration.
+// Uses Bun.spawn worker pattern to simulate multiple processes racing
+// for profile pool slots via SQLite EXCLUSIVE transactions.
+
+import { describe, it, expect, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { cleanupDb } from "../../helpers/db";
+import { createDb } from "../../../src/storage/sqlite/db";
+import { runMigrations, allMigrations } from "../../../src/storage/sqlite/migrations";
+
+const projectRoot = process.cwd();
+
+// Use a fixed (non-PID-suffixed) path so workers can share the same DB.
+const TEST_DB = `/tmp/octo-santa-test-profile-concurrency.sqlite`;
+
+let tempProfileDirs: string[] = [];
+
+afterEach(() => {
+  cleanupDb(TEST_DB);
+  for (const dir of tempProfileDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+  tempProfileDirs = [];
+});
+
+function makeTempProfileDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "octo-santa-profiles-"));
+  tempProfileDirs.push(dir);
+  return dir;
+}
+
+function writeProfileYaml(dir: string, name: string, maxInstances: number): void {
+  const content = `name: ${name}\nmaxInstances: ${maxInstances}\n`;
+  writeFileSync(join(dir, `${name}.yaml`), content, "utf-8");
+}
+
+// Worker script template — runs from /tmp so all imports use absolute paths.
+function makeWorkerScript(profileDir: string, agentName: string): string {
+  return `
+import { createDb } from "${projectRoot}/src/storage/sqlite/db";
+import { runMigrations, allMigrations } from "${projectRoot}/src/storage/sqlite/migrations";
+import { createSqliteRepos } from "${projectRoot}/src/storage/sqlite";
+import { MessagingService } from "${projectRoot}/src/core/messaging/service";
+import { YamlProfileStore } from "${projectRoot}/src/storage/yaml-profiles/store";
+
+const db = createDb("${TEST_DB}");
+runMigrations(db, allMigrations);
+const repos = createSqliteRepos(db);
+const profiles = new YamlProfileStore("${profileDir}");
+const svc = new MessagingService(
+  repos.agents,
+  repos.channels,
+  repos.messages,
+  repos.cursors,
+  process.pid,
+  undefined,
+  profiles
+);
+
+try {
+  const result = svc.register("${agentName}");
+  console.log(JSON.stringify({ ok: true, registeredName: result.registeredName }));
+  db.close();
+} catch (err) {
+  console.error(err.message);
+  db.close();
+  process.exit(1);
+}
+`;
+}
+
+describe("cross-process profile registration concurrency", () => {
+  it("(a) singleton race: 2 workers racing for maxInstances=1 — exactly 1 succeeds", async () => {
+    const profileDir = makeTempProfileDir();
+    writeProfileYaml(profileDir, "os-pm", 1);
+
+    // Set up the DB on disk first (workers will call runMigrations themselves,
+    // but we need the file to exist for cleanupDb to work in afterEach).
+    const setupDb = createDb(TEST_DB);
+    runMigrations(setupDb, allMigrations);
+    setupDb.close();
+
+    const workerScript = makeWorkerScript(profileDir, "os-pm");
+    const workerPath = "/tmp/octo-santa-profile-concurrency-singleton-worker.ts";
+    await Bun.write(workerPath, workerScript);
+
+    // Spawn 2 workers simultaneously
+    const workers = [0, 1].map(() =>
+      Bun.spawn(["bun", "run", workerPath], {
+        cwd: projectRoot,
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+    );
+
+    const exitCodes = await Promise.all(workers.map((w) => w.exited));
+
+    // Gather output for diagnostics
+    const outputs = await Promise.all(
+      workers.map(async (w, i) => ({
+        idx: i,
+        code: exitCodes[i],
+        stdout: await new Response(w.stdout).text(),
+        stderr: await new Response(w.stderr).text(),
+      }))
+    );
+
+    const succeeded = outputs.filter((o) => o.code === 0);
+    const failed = outputs.filter((o) => o.code !== 0);
+
+    if (succeeded.length !== 1) {
+      console.error("Unexpected results:", JSON.stringify(outputs, null, 2));
+    }
+
+    // Exactly 1 worker should have succeeded
+    expect(succeeded).toHaveLength(1);
+    expect(failed).toHaveLength(1);
+
+    // The failed worker should have reported already-active or at-capacity error
+    const failedStderr = failed[0]!.stderr;
+    const isExpectedError =
+      failedStderr.includes("already active") ||
+      failedStderr.includes("at capacity");
+    expect(isExpectedError).toBe(true);
+
+    // Verify DB has exactly 1 agent row for os-pm
+    const db = createDb(TEST_DB);
+    const rows = db.query("SELECT id FROM agents WHERE id = 'os-pm' OR base_name = 'os-pm'").all() as { id: string }[];
+    db.close();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.id).toBe("os-pm");
+  });
+
+  it("(b) pool race: 3 workers racing for 3 slots — all succeed with unique names", async () => {
+    const profileDir = makeTempProfileDir();
+    writeProfileYaml(profileDir, "os-dev", 3);
+
+    // Set up the DB on disk first
+    const setupDb = createDb(TEST_DB);
+    runMigrations(setupDb, allMigrations);
+    setupDb.close();
+
+    const workerScript = makeWorkerScript(profileDir, "os-dev");
+    const workerPath = "/tmp/octo-santa-profile-concurrency-pool-worker.ts";
+    await Bun.write(workerPath, workerScript);
+
+    // Spawn 3 workers simultaneously
+    const workers = [0, 1, 2].map(() =>
+      Bun.spawn(["bun", "run", workerPath], {
+        cwd: projectRoot,
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+    );
+
+    const exitCodes = await Promise.all(workers.map((w) => w.exited));
+
+    const outputs = await Promise.all(
+      workers.map(async (w, i) => ({
+        idx: i,
+        code: exitCodes[i],
+        stdout: await new Response(w.stdout).text(),
+        stderr: await new Response(w.stderr).text(),
+      }))
+    );
+
+    const succeeded = outputs.filter((o) => o.code === 0);
+    const failed = outputs.filter((o) => o.code !== 0);
+
+    if (succeeded.length !== 3) {
+      console.error("Unexpected results:", JSON.stringify(outputs, null, 2));
+    }
+
+    // All 3 workers should succeed
+    expect(succeeded).toHaveLength(3);
+    expect(failed).toHaveLength(0);
+
+    // Parse registered names from stdout
+    const registeredNames = succeeded.map((o) => {
+      const parsed = JSON.parse(o.stdout.trim()) as { ok: boolean; registeredName: string };
+      return parsed.registeredName;
+    });
+
+    // All names should be unique
+    const uniqueNames = new Set(registeredNames);
+    expect(uniqueNames.size).toBe(3);
+
+    // All names should match os-dev-1, os-dev-2, os-dev-3 (in any order)
+    const expected = new Set(["os-dev-1", "os-dev-2", "os-dev-3"]);
+    for (const name of registeredNames) {
+      expect(expected.has(name)).toBe(true);
+    }
+
+    // Verify DB has exactly 3 agent rows with base_name = 'os-dev'
+    const db = createDb(TEST_DB);
+    const rows = db
+      .query("SELECT id FROM agents WHERE base_name = 'os-dev' ORDER BY id")
+      .all() as { id: string }[];
+    db.close();
+
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.id)).toEqual(["os-dev-1", "os-dev-2", "os-dev-3"]);
+  });
+});

--- a/tests/hex/core/profile-concurrency.test.ts
+++ b/tests/hex/core/profile-concurrency.test.ts
@@ -11,6 +11,12 @@ import { tmpdir } from "node:os";
 import { cleanupDb } from "../../helpers/db";
 import { createDb } from "../../../src/storage/sqlite/db";
 import { runMigrations, allMigrations } from "../../../src/storage/sqlite/migrations";
+import { createSqliteRepos } from "../../../src/storage/sqlite";
+import { MessagingService } from "../../../src/core/messaging/service";
+import { YamlProfileStore } from "../../../src/storage/yaml-profiles/store";
+import { SqliteNotificationQueryRepo } from "../../../src/storage/sqlite/notification-query-repo";
+import { createNotificationPoller } from "../../../src/notifications/poller/poller";
+import type { NotificationPort } from "../../../src/core/ports";
 
 const projectRoot = process.cwd();
 
@@ -209,5 +215,96 @@ describe("cross-process profile registration concurrency", () => {
 
     expect(rows).toHaveLength(3);
     expect(rows.map((r) => r.id)).toEqual(["os-dev-1", "os-dev-2", "os-dev-3"]);
+  });
+
+  it("(c) cross-process: pool base-name mention triggers poller notification", async () => {
+    const profileDir = makeTempProfileDir();
+    writeProfileYaml(profileDir, "os-dev", 3);
+
+    // Set up DB and register os-dev → os-dev-1, create + subscribe to channel
+    const db = createDb(TEST_DB);
+    runMigrations(db, allMigrations);
+    const repos = createSqliteRepos(db);
+    const profiles = new YamlProfileStore(profileDir);
+    const svc = new MessagingService(
+      repos.agents,
+      repos.channels,
+      repos.messages,
+      repos.cursors,
+      process.pid,
+      undefined,
+      profiles
+    );
+
+    const result = svc.register("os-dev");
+    expect(result.registeredName).toBe("os-dev-1");
+
+    svc.createChannel("os-dev-1", "work");
+    svc.subscribe("os-dev-1", "work");
+    db.close();
+
+    // Spawn worker: registers as "sender", subscribes to "work", sends @os-dev mention.
+    // Must pass the YamlProfileStore so extractMentions recognises "os-dev" as a pool base name.
+    const workerScript = `
+import { createDb } from "${projectRoot}/src/storage/sqlite/db";
+import { runMigrations, allMigrations } from "${projectRoot}/src/storage/sqlite/migrations";
+import { createSqliteRepos } from "${projectRoot}/src/storage/sqlite";
+import { MessagingService } from "${projectRoot}/src/core/messaging/service";
+import { YamlProfileStore } from "${projectRoot}/src/storage/yaml-profiles/store";
+
+const db = createDb("${TEST_DB}");
+runMigrations(db, allMigrations);
+const repos = createSqliteRepos(db);
+const profiles = new YamlProfileStore("${profileDir}");
+const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid, undefined, profiles);
+
+svc.register("sender");
+svc.subscribe("sender", "work");
+svc.send("sender", "work", "Hey @os-dev please review");
+db.close();
+`;
+
+    const tmpWorker = "/tmp/octo-santa-poller-mention-worker.ts";
+    await Bun.write(tmpWorker, workerScript);
+    const proc = Bun.spawn(["bun", "run", tmpWorker], {
+      cwd: projectRoot,
+      stderr: "pipe",
+    });
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text();
+      throw new Error(`Worker failed: ${stderr}`);
+    }
+
+    // Open a fresh DB connection for the poller
+    const db2 = createDb(TEST_DB);
+    const notificationQueries = new SqliteNotificationQueryRepo(db2);
+
+    const notifications: Array<{ content: string; meta: Record<string, string> }> = [];
+    const port: NotificationPort = {
+      notify: async (content, meta) => {
+        notifications.push({ content, meta });
+      },
+    };
+
+    const poller = createNotificationPoller({
+      getNewMessagesForAgent: notificationQueries.getNewMessagesForAgent.bind(notificationQueries),
+      getMaxMessageId: notificationQueries.getMaxMessageId.bind(notificationQueries),
+      port,
+      agentId: "os-dev-1",
+      baseName: "os-dev", // Pool base-name match — this is what we're testing
+    });
+
+    // Manually tick; hwm starts at 0 so all messages since beginning are picked up
+    await poller._tick();
+
+    db2.close();
+
+    // The worker's @os-dev message should have triggered a notification
+    expect(notifications.length).toBeGreaterThan(0);
+    const mentionNotification = notifications.find((n) => n.content.includes("@os-dev"));
+    expect(mentionNotification).toBeDefined();
+    expect(mentionNotification!.meta.sender).toBe("sender");
+    expect(mentionNotification!.meta.channel_name).toBe("work");
   });
 });

--- a/tests/hex/core/profile-integration.test.ts
+++ b/tests/hex/core/profile-integration.test.ts
@@ -1,0 +1,210 @@
+// tests/hex/core/profile-integration.test.ts
+//
+// Full lifecycle integration test: real YAML profiles on disk + real SQLite.
+// Exercises: register singleton/pool → auto-join → @base-name mention → read →
+// list_agents with persona/objective → agent without profile has null fields.
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  unlinkSync,
+  existsSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createDb } from "../../../src/storage/sqlite/db";
+import { runMigrations, allMigrations } from "../../../src/storage/sqlite/migrations";
+import { createSqliteRepos } from "../../../src/storage/sqlite";
+import { MessagingService } from "../../../src/core/messaging/service";
+import { YamlProfileStore } from "../../../src/storage/yaml-profiles/store";
+
+// ── Captured dispatch helper ───────────────────────────────────────────────
+
+type DispatchCall = {
+  channelName: string;
+  sender: string;
+  content: string;
+  messageId: number;
+  isDm: boolean;
+  targetAgents: string[];
+};
+
+function makeCapturingDispatch() {
+  const dispatched: DispatchCall[] = [];
+  return {
+    dispatched,
+    dispatch(notification: DispatchCall) {
+      dispatched.push({ ...notification });
+    },
+  };
+}
+
+// ── Test fixture ──────────────────────────────────────────────────────────
+
+describe("Profile Integration — Full Lifecycle", () => {
+  let profileDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    profileDir = mkdtempSync(join(tmpdir(), "profiles-integration-"));
+    dbPath = join(tmpdir(), `octo-santa-integration-${Date.now()}-${process.pid}.db`);
+  });
+
+  afterEach(() => {
+    rmSync(profileDir, { recursive: true, force: true });
+    for (const ext of ["", "-wal", "-shm"]) {
+      const f = dbPath + ext;
+      if (existsSync(f)) unlinkSync(f);
+    }
+  });
+
+  it("full lifecycle: profiles → register → auto-join → mention → read → list", () => {
+    // ── Step 1: Write profile YAML files ────────────────────────────────
+
+    writeFileSync(
+      join(profileDir, "os-pm.yaml"),
+      [
+        "name: os-pm",
+        'persona: "Product manager"',
+        'objective: "Drive roadmap"',
+        "maxInstances: 1",
+        "autoJoinChannels:",
+        "  - coordination",
+      ].join("\n")
+    );
+
+    writeFileSync(
+      join(profileDir, "os-dev.yaml"),
+      [
+        "name: os-dev",
+        'persona: "Developer"',
+        'objective: "Ship code"',
+        "maxInstances: 3",
+        "autoJoinChannels:",
+        "  - coordination",
+      ].join("\n")
+    );
+
+    // ── Step 2: Wire up real storage + profile store ─────────────────────
+
+    const profiles = new YamlProfileStore(profileDir);
+    const db = createDb(dbPath);
+    runMigrations(db, allMigrations);
+    const repos = createSqliteRepos(db);
+
+    // ── Step 3: Create coordination channel before registration ──────────
+    // Use an admin MessagingService (no profiles) to create the channel so
+    // auto-join can find it.
+
+    const adminSvc = new MessagingService(
+      repos.agents,
+      repos.channels,
+      repos.messages,
+      repos.cursors,
+      process.pid
+    );
+    adminSvc.register("admin");
+    adminSvc.createChannel("admin", "coordination");
+
+    // ── Step 4: Create profile-aware service with capturing dispatch ──────
+
+    const capturing = makeCapturingDispatch();
+    const svc = new MessagingService(
+      repos.agents,
+      repos.channels,
+      repos.messages,
+      repos.cursors,
+      process.pid,
+      capturing,
+      profiles
+    );
+
+    // ── Step 5a: Register singleton (os-pm, maxInstances=1) ──────────────
+
+    const pmResult = svc.register("os-pm");
+
+    expect(pmResult.registeredName).toBe("os-pm");
+    expect(pmResult.baseName).toBe("os-pm");
+    expect(pmResult.instanceNumber).toBeNull(); // singleton → null
+    expect(pmResult.profile).not.toBeNull();
+    expect(pmResult.profile!.persona).toBe("Product manager");
+    expect(pmResult.autoJoined).not.toBeNull();
+    expect(pmResult.autoJoined!.succeeded).toContain("coordination");
+    expect(pmResult.autoJoined!.failed).toEqual([]);
+
+    // ── Step 5b: Register pool agent (os-dev, maxInstances=3) ─────────────
+
+    const devResult = svc.register("os-dev");
+
+    expect(devResult.registeredName).toBe("os-dev-1");
+    expect(devResult.baseName).toBe("os-dev");
+    expect(devResult.instanceNumber).toBe(1);
+    expect(devResult.profile).not.toBeNull();
+    expect(devResult.profile!.maxInstances).toBe(3);
+    expect(devResult.autoJoined).not.toBeNull();
+    expect(devResult.autoJoined!.succeeded).toContain("coordination");
+    expect(devResult.autoJoined!.failed).toEqual([]);
+
+    // ── Step 6: Send with @base-name ──────────────────────────────────────
+    // os-pm sends "@os-dev" — should expand to os-dev-1 in dispatch
+
+    const msg = svc.send("os-pm", "coordination", "Hey @os-dev, review this");
+    expect(msg.agent_id).toBe("os-pm");
+
+    // The stored mentions should contain the raw base name "os-dev"
+    const msgRow = db
+      .query("SELECT mentions FROM messages WHERE id = ?")
+      .get(msg.id) as { mentions: string } | null;
+    expect(msgRow).not.toBeNull();
+    const storedMentions = JSON.parse(msgRow!.mentions) as string[];
+    expect(storedMentions).toContain("os-dev");
+
+    // Dispatch targets should include "os-dev-1" (expanded from base name)
+    expect(capturing.dispatched.length).toBeGreaterThanOrEqual(1);
+    const dispatchCall = capturing.dispatched.find(
+      (d) => d.messageId === msg.id
+    );
+    expect(dispatchCall).toBeDefined();
+    expect(dispatchCall!.targetAgents).toContain("os-dev-1");
+
+    // ── Step 7: Read messages ─────────────────────────────────────────────
+
+    const messages = svc.read("os-dev-1", "coordination");
+    expect(messages.length).toBeGreaterThanOrEqual(1);
+    const found = messages.find((m) => m.id === msg.id);
+    expect(found).toBeDefined();
+    expect(found!.content).toBe("Hey @os-dev, review this");
+
+    // ── Step 8: listAgents with persona/objective ─────────────────────────
+
+    const agents = svc.listAgents(true); // include stale to see all
+
+    const pmAgent = agents.find((a) => a.id === "os-pm");
+    expect(pmAgent).toBeDefined();
+    expect(pmAgent!.persona).toBe("Product manager");
+    expect(pmAgent!.objective).toBe("Drive roadmap");
+
+    const devAgent = agents.find((a) => a.id === "os-dev-1");
+    expect(devAgent).toBeDefined();
+    expect(devAgent!.persona).toBe("Developer");
+    expect(devAgent!.objective).toBe("Ship code");
+
+    // ── Step 9: Agent without profile has null fields ─────────────────────
+
+    const botResult = svc.register("random-bot");
+    expect(botResult.registeredName).toBe("random-bot");
+    expect(botResult.baseName).toBeNull();
+    expect(botResult.profile).toBeNull();
+    expect(botResult.autoJoined).toBeNull();
+
+    const botAgent = svc.listAgents(true).find((a) => a.id === "random-bot");
+    expect(botAgent).toBeDefined();
+    expect(botAgent!.persona).toBeNull();
+    expect(botAgent!.objective).toBeNull();
+    expect(botAgent!.base_name).toBeNull();
+
+    db.close();
+  });
+});

--- a/tests/hex/core/profile-registration.test.ts
+++ b/tests/hex/core/profile-registration.test.ts
@@ -132,28 +132,21 @@ describe("pool profile registration", () => {
     expect(result.profile!.maxInstances).toBe(3);
   });
 
-  it("assigns sequential slot numbers to pool members", () => {
+  it("same-PID re-registration is idempotent for singleton", () => {
     const profileRepo = new InMemoryProfileRepo();
     profileRepo.add({
-      name: "worker",
-      persona: null,
-      objective: "Process tasks",
-      maxInstances: 3,
+      name: "os-pm",
+      persona: "Product manager",
+      objective: null,
+      maxInstances: 1,
       autoJoinChannels: [],
     });
 
-    cleanupDb(TEST_DB);
-    const db = createDb(TEST_DB);
-    runMigrations(db, allMigrations);
-    const repos = createSqliteRepos(db);
-
-    // First instance at pid 1 (simulate different process — alive to block slot)
-    // We can't easily simulate multi-pid in unit tests, so just test the naming pattern
-    // by registering from same pid (idempotent), then verify the slot
-    const svc1 = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid, undefined, profileRepo);
-    const r1 = svc1.register("worker");
-    expect(r1.instanceNumber).toBe(1);
-    expect(r1.registeredName).toBe("worker-1");
+    const { svc } = setup(profileRepo);
+    const first = svc.register("os-pm");
+    const second = svc.register("os-pm");
+    expect(second.registeredName).toBe(first.registeredName);
+    expect(second.registeredName).toBe("os-pm");
   });
 
   it("same-PID re-registration is idempotent for pool", () => {

--- a/tests/hex/core/profile-registration.test.ts
+++ b/tests/hex/core/profile-registration.test.ts
@@ -1,0 +1,480 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { MessagingService } from "../../../src/core/messaging/service";
+import { createSqliteRepos } from "../../../src/storage/sqlite";
+import { createDb } from "../../../src/storage/sqlite/db";
+import { runMigrations, allMigrations } from "../../../src/storage/sqlite/migrations";
+import { cleanupDb } from "../../helpers/db";
+import type { ProfileRepository } from "../../../src/core/ports";
+import type { AgentProfile } from "../../../src/core/profiles/types";
+
+const TEST_DB = `/tmp/octo-santa-test-hex-profile-reg-${process.pid}.sqlite`;
+
+// ── In-memory ProfileRepository for tests ─────────────────────────────────
+
+class InMemoryProfileRepo implements ProfileRepository {
+  private profiles = new Map<string, AgentProfile>();
+
+  add(profile: AgentProfile): void {
+    this.profiles.set(profile.name, profile);
+  }
+
+  getProfile(baseName: string): AgentProfile | null {
+    return this.profiles.get(baseName) ?? null;
+  }
+
+  listProfiles(): AgentProfile[] {
+    return [...this.profiles.values()];
+  }
+
+  getBaseNames(): Set<string> {
+    return new Set(this.profiles.keys());
+  }
+}
+
+// ── Setup helpers ──────────────────────────────────────────────────────────
+
+function setup(profileRepo?: ProfileRepository) {
+  cleanupDb(TEST_DB);
+  const db = createDb(TEST_DB);
+  runMigrations(db, allMigrations);
+  const repos = createSqliteRepos(db);
+  const svc = new MessagingService(
+    repos.agents,
+    repos.channels,
+    repos.messages,
+    repos.cursors,
+    process.pid,
+    undefined, // dispatch
+    profileRepo
+  );
+  return { db, repos, svc };
+}
+
+afterEach(() => cleanupDb(TEST_DB));
+
+// ── Singleton profile registration ────────────────────────────────────────
+
+describe("singleton profile registration", () => {
+  it("registers agent under profile and returns RegisterResult with profile fields", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: "Senior developer",
+      objective: "Write clean code",
+      maxInstances: 1,
+      autoJoinChannels: [],
+    });
+
+    const { svc } = setup(profileRepo);
+    const result = svc.register("os-dev");
+
+    // Core Agent fields
+    expect(result.id).toBe("os-dev");
+    expect(result.pid).toBe(process.pid);
+
+    // RegisterResult fields
+    expect(result.registeredName).toBe("os-dev");
+    expect(result.baseName).toBe("os-dev");
+    expect(result.instanceNumber).toBeNull(); // singleton → null
+    expect(result.profile).not.toBeNull();
+    expect(result.profile!.persona).toBe("Senior developer");
+    expect(result.profile!.objective).toBe("Write clean code");
+    expect(result.profile!.maxInstances).toBe(1);
+    expect(result.autoJoined).not.toBeNull();
+    expect(result.autoJoined!.succeeded).toEqual([]);
+    expect(result.autoJoined!.failed).toEqual([]);
+  });
+
+  it("stores base_name, persona, objective in DB for singleton", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: "Senior developer",
+      objective: "Write clean code",
+      maxInstances: 1,
+      autoJoinChannels: [],
+    });
+
+    const { svc, db } = setup(profileRepo);
+    svc.register("os-dev");
+
+    const row = db.query("SELECT * FROM agents WHERE id = ?").get("os-dev") as {
+      base_name: string | null;
+      persona: string | null;
+      objective: string | null;
+    };
+    expect(row).not.toBeNull();
+    expect(row.base_name).toBe("os-dev");
+    expect(row.persona).toBe("Senior developer");
+    expect(row.objective).toBe("Write clean code");
+  });
+});
+
+// ── Pool profile registration (multiple instances) ─────────────────────────
+
+describe("pool profile registration", () => {
+  it("assigns instance-1 to first pool member", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "worker",
+      persona: null,
+      objective: "Process tasks",
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { svc } = setup(profileRepo);
+    const result = svc.register("worker");
+
+    expect(result.registeredName).toBe("worker-1");
+    expect(result.baseName).toBe("worker");
+    expect(result.instanceNumber).toBe(1);
+    expect(result.profile!.maxInstances).toBe(3);
+  });
+
+  it("assigns sequential slot numbers to pool members", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "worker",
+      persona: null,
+      objective: "Process tasks",
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    cleanupDb(TEST_DB);
+    const db = createDb(TEST_DB);
+    runMigrations(db, allMigrations);
+    const repos = createSqliteRepos(db);
+
+    // First instance at pid 1 (simulate different process — alive to block slot)
+    // We can't easily simulate multi-pid in unit tests, so just test the naming pattern
+    // by registering from same pid (idempotent), then verify the slot
+    const svc1 = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid, undefined, profileRepo);
+    const r1 = svc1.register("worker");
+    expect(r1.instanceNumber).toBe(1);
+    expect(r1.registeredName).toBe("worker-1");
+  });
+
+  it("same-PID re-registration is idempotent for pool", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "worker",
+      persona: null,
+      objective: "Process tasks",
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { svc } = setup(profileRepo);
+    const first = svc.register("worker");
+    const second = svc.register("worker");
+
+    // Same PID → same slot returned
+    expect(second.registeredName).toBe(first.registeredName);
+    expect(second.instanceNumber).toBe(first.instanceNumber);
+  });
+
+  it("reclaims dead slot when all slots are taken but one is dead", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "worker",
+      persona: null,
+      objective: "Process tasks",
+      maxInstances: 2,
+      autoJoinChannels: [],
+    });
+
+    cleanupDb(TEST_DB);
+    const db = createDb(TEST_DB);
+    runMigrations(db, allMigrations);
+    const repos = createSqliteRepos(db);
+
+    // Manually insert two dead workers
+    const now = Date.now();
+    db.run(
+      "INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name) VALUES (?, ?, ?, ?, ?, ?)",
+      ["worker-1", now, now - 1, 999999, now - 1, "worker"]  // dead PID
+    );
+    db.run(
+      "INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name) VALUES (?, ?, ?, ?, ?, ?)",
+      ["worker-2", now, now - 1, 999998, now - 1, "worker"]  // dead PID
+    );
+
+    const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid, undefined, profileRepo);
+    const result = svc.register("worker");
+
+    // Should reclaim slot 1 (lowest dead slot)
+    expect(result.instanceNumber).toBe(1);
+    expect(result.registeredName).toBe("worker-1");
+    expect(result.pid).toBe(process.pid);
+  });
+});
+
+// ── Backward compatibility — no profile, no profile repo ───────────────────
+
+describe("backward compatibility — no profile", () => {
+  it("registers normally without profile repo (undefined)", () => {
+    const { svc } = setup(undefined); // no profileRepo
+    const result = svc.register("alice");
+
+    expect(result.id).toBe("alice");
+    expect(result.registeredName).toBe("alice");
+    expect(result.baseName).toBeNull();
+    expect(result.instanceNumber).toBeNull();
+    expect(result.profile).toBeNull();
+    expect(result.autoJoined).toBeNull();
+  });
+
+  it("registers normally with profile repo but no matching profile", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    // No profiles added for "alice"
+
+    const { svc } = setup(profileRepo);
+    const result = svc.register("alice");
+
+    expect(result.registeredName).toBe("alice");
+    expect(result.baseName).toBeNull();
+    expect(result.profile).toBeNull();
+    expect(result.autoJoined).toBeNull();
+  });
+
+  it("still allows register() return value to be used as Agent (structural compat)", () => {
+    const { svc } = setup(undefined);
+    const result = svc.register("alice");
+
+    // All Agent fields must be accessible
+    expect(typeof result.id).toBe("string");
+    expect(typeof result.created_at).toBe("number");
+    expect(typeof result.last_seen_at).toBe("number");
+    // pid is number or null (number when just registered)
+    expect(result.pid).toBe(process.pid);
+  });
+});
+
+// ── Suffixed namespace reservation (Decision #14) ──────────────────────────
+
+describe("suffixed namespace reservation", () => {
+  it("rejects registering as 'os-dev-2' when 'os-dev' profile exists", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: null,
+      objective: null,
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { svc } = setup(profileRepo);
+
+    expect(() => svc.register("os-dev-2")).toThrow(
+      `Name "os-dev-2" is reserved by pool profile "os-dev". Register as "os-dev" to join the pool.`
+    );
+  });
+
+  it("rejects 'worker-10' when 'worker' profile exists", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "worker",
+      persona: null,
+      objective: null,
+      maxInstances: 5,
+      autoJoinChannels: [],
+    });
+
+    const { svc } = setup(profileRepo);
+
+    expect(() => svc.register("worker-10")).toThrow(
+      `Name "worker-10" is reserved by pool profile "worker".`
+    );
+  });
+
+  it("allows registering 'os-dev-2' when no profile exists for 'os-dev'", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    // No profile for "os-dev"
+
+    const { svc } = setup(profileRepo);
+
+    // Should not throw — no profile reservation applies
+    expect(() => svc.register("os-dev-2")).not.toThrow();
+    const result = svc.register("os-dev-2"); // second call — idempotent
+    expect(result.registeredName).toBe("os-dev-2");
+  });
+
+  it("allows registering 'os-dev-2' when profileRepo is absent", () => {
+    const { svc } = setup(undefined); // no profile repo
+
+    expect(() => svc.register("os-dev-2")).not.toThrow();
+    const result = svc.register("os-dev-2");
+    expect(result.registeredName).toBe("os-dev-2");
+  });
+
+  it("only blocks numeric suffixes — 'os-dev-extra' is not rejected", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: null,
+      objective: null,
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { svc } = setup(profileRepo);
+
+    // "os-dev-extra" does not match {base}-\d+ pattern → allowed
+    expect(() => svc.register("os-dev-extra")).not.toThrow();
+  });
+});
+
+// ── Auto-join channels ─────────────────────────────────────────────────────
+
+describe("auto-join channels", () => {
+  it("auto-joins existing channels listed in profile", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: null,
+      objective: null,
+      maxInstances: 1,
+      autoJoinChannels: ["general", "dev"],
+    });
+
+    cleanupDb(TEST_DB);
+    const db = createDb(TEST_DB);
+    runMigrations(db, allMigrations);
+    const repos = createSqliteRepos(db);
+
+    // Pre-create channels using a bootstrap agent
+    const bootstrap = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid);
+    bootstrap.register("admin");
+    bootstrap.createChannel("admin", "general");
+    bootstrap.createChannel("admin", "dev");
+
+    const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid, undefined, profileRepo);
+    const result = svc.register("os-dev");
+
+    expect(result.autoJoined).not.toBeNull();
+    expect(result.autoJoined!.succeeded.sort()).toEqual(["dev", "general"]);
+    expect(result.autoJoined!.failed).toEqual([]);
+
+    // Verify agent is actually a member
+    const members = bootstrap.listMembers("general");
+    const member = members.find((m) => m.agent_id === "os-dev");
+    expect(member).toBeDefined();
+  });
+
+  it("records failure in autoJoined.failed for non-existent channels", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: null,
+      objective: null,
+      maxInstances: 1,
+      autoJoinChannels: ["nonexistent-channel"],
+    });
+
+    const { svc } = setup(profileRepo);
+    const result = svc.register("os-dev");
+
+    expect(result.autoJoined!.succeeded).toEqual([]);
+    expect(result.autoJoined!.failed.length).toBe(1);
+    expect(result.autoJoined!.failed[0]!.channel).toBe("nonexistent-channel");
+  });
+
+  it("partially succeeds: joins existing channels, records failure for missing ones", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: null,
+      objective: null,
+      maxInstances: 1,
+      autoJoinChannels: ["general", "missing-channel"],
+    });
+
+    cleanupDb(TEST_DB);
+    const db = createDb(TEST_DB);
+    runMigrations(db, allMigrations);
+    const repos = createSqliteRepos(db);
+
+    const bootstrap = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid);
+    bootstrap.register("admin");
+    bootstrap.createChannel("admin", "general");
+
+    const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid, undefined, profileRepo);
+    const result = svc.register("os-dev");
+
+    expect(result.autoJoined!.succeeded).toEqual(["general"]);
+    expect(result.autoJoined!.failed.length).toBe(1);
+    expect(result.autoJoined!.failed[0]!.channel).toBe("missing-channel");
+  });
+
+  it("auto-join does not throw for pool profile — uses registeredName for channel membership", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "worker",
+      persona: null,
+      objective: null,
+      maxInstances: 3,
+      autoJoinChannels: ["tasks"],
+    });
+
+    cleanupDb(TEST_DB);
+    const db = createDb(TEST_DB);
+    runMigrations(db, allMigrations);
+    const repos = createSqliteRepos(db);
+
+    const bootstrap = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid);
+    bootstrap.register("admin");
+    bootstrap.createChannel("admin", "tasks");
+
+    const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid, undefined, profileRepo);
+    const result = svc.register("worker");
+
+    expect(result.registeredName).toBe("worker-1");
+    expect(result.autoJoined!.succeeded).toEqual(["tasks"]);
+
+    // Verify worker-1 is a member of tasks
+    const members = bootstrap.listMembers("tasks");
+    expect(members.find((m) => m.agent_id === "worker-1")).toBeDefined();
+  });
+});
+
+// ── RegisterResult type compatibility ─────────────────────────────────────
+
+describe("RegisterResult type shape", () => {
+  it("register() returns all required fields in all paths", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: "dev",
+      objective: "code",
+      maxInstances: 1,
+      autoJoinChannels: [],
+    });
+
+    cleanupDb(TEST_DB);
+    const db = createDb(TEST_DB);
+    runMigrations(db, allMigrations);
+    const repos = createSqliteRepos(db);
+    const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid, undefined, profileRepo);
+
+    const withProfile = svc.register("os-dev");
+    expect(withProfile).toHaveProperty("registeredName");
+    expect(withProfile).toHaveProperty("baseName");
+    expect(withProfile).toHaveProperty("instanceNumber");
+    expect(withProfile).toHaveProperty("profile");
+    expect(withProfile).toHaveProperty("autoJoined");
+
+    // Register a plain agent (no profile) from same service
+    const svc2 = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid);
+    const noProfile = svc2.register("plain-agent");
+    expect(noProfile).toHaveProperty("registeredName");
+    expect(noProfile).toHaveProperty("baseName");
+    expect(noProfile).toHaveProperty("instanceNumber");
+    expect(noProfile).toHaveProperty("profile");
+    expect(noProfile).toHaveProperty("autoJoined");
+    expect(noProfile.baseName).toBeNull();
+    expect(noProfile.profile).toBeNull();
+    expect(noProfile.autoJoined).toBeNull();
+  });
+});

--- a/tests/hex/notifications/poller.test.ts
+++ b/tests/hex/notifications/poller.test.ts
@@ -235,6 +235,59 @@ describe("createNotificationPoller", () => {
       expect(calls.length).toBe(0);
     });
 
+    it("notifies pool instance when pool base-name is mentioned", async () => {
+      // os-dev-1 is bound with baseName "os-dev"; message mentions "os-dev"
+      const msg = makeMessage({
+        id: 1,
+        channel_name: "general",
+        agent_id: "agent-b",
+        content: "hey @os-dev",
+        mentions: '["os-dev"]',
+      });
+
+      const queryFns = makeQueryFns([msg], 0);
+      const { port, calls } = makeNotificationPort();
+      const poller = createNotificationPoller({
+        ...queryFns,
+        port,
+        agentId: "os-dev-1",
+        baseName: "os-dev",
+      });
+
+      poller.start();
+      await poller._tick();
+      poller.stop();
+
+      expect(calls.length).toBe(1);
+      expect(calls[0]!.content).toBe("hey @os-dev");
+    });
+
+    it("does not notify pool instance when base-name is not provided and only pool mention is used", async () => {
+      // os-dev-1 without baseName — @os-dev mention should not match
+      const msg = makeMessage({
+        id: 1,
+        channel_name: "general",
+        agent_id: "agent-b",
+        content: "hey @os-dev",
+        mentions: '["os-dev"]',
+      });
+
+      const queryFns = makeQueryFns([msg], 0);
+      const { port, calls } = makeNotificationPort();
+      const poller = createNotificationPoller({
+        ...queryFns,
+        port,
+        agentId: "os-dev-1",
+        // no baseName
+      });
+
+      poller.start();
+      await poller._tick();
+      poller.stop();
+
+      expect(calls.length).toBe(0);
+    });
+
     it("skips messages with malformed mentions JSON in regular channels", async () => {
       const msg = makeMessage({
         id: 1,

--- a/tests/hex/storage/agent-repo.test.ts
+++ b/tests/hex/storage/agent-repo.test.ts
@@ -49,6 +49,46 @@ describe("SqliteAgentRepo", () => {
     db.close();
   });
 
+  it("register with profileFields stores base_name, persona, objective", () => {
+    const { db, repo } = setup();
+    const agent = repo.register("researcher-1", process.pid, {
+      baseName: "researcher",
+      persona: "You are a diligent researcher.",
+      objective: "Gather and summarize information.",
+    });
+    expect(agent.id).toBe("researcher-1");
+    expect(agent.base_name).toBe("researcher");
+    expect(agent.persona).toBe("You are a diligent researcher.");
+    expect(agent.objective).toBe("Gather and summarize information.");
+    db.close();
+  });
+
+  it("register without profileFields stores null for base_name, persona, objective", () => {
+    const { db, repo } = setup();
+    const agent = repo.register("plain-agent", process.pid);
+    expect(agent.base_name).toBeNull();
+    expect(agent.persona).toBeNull();
+    expect(agent.objective).toBeNull();
+    db.close();
+  });
+
+  it("register clears stale profile when called without profileFields", () => {
+    const { db, repo } = setup();
+    // First register with profile
+    repo.register("agent-x", process.pid, {
+      baseName: "agent-x",
+      persona: "Old persona",
+      objective: "Old objective",
+    });
+    // Re-register without profile — should clear profile fields
+    db.run("UPDATE agents SET pid = 999999 WHERE id = ?", ["agent-x"]);
+    const updated = repo.register("agent-x", process.pid);
+    expect(updated.base_name).toBeNull();
+    expect(updated.persona).toBeNull();
+    expect(updated.objective).toBeNull();
+    db.close();
+  });
+
   it("findById returns agent or null", () => {
     const { db, repo } = setup();
     expect(repo.findById("nonexistent")).toBeNull();
@@ -57,12 +97,52 @@ describe("SqliteAgentRepo", () => {
     db.close();
   });
 
-  it("listAll returns all agents", () => {
+  it("findByBaseName returns agents with matching base_name", () => {
     const { db, repo } = setup();
-    repo.register("agent-a", process.pid);
+    const now = Date.now();
+    // Insert worker-1 and worker-2 directly with base_name set
+    db.run(
+      `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
+       VALUES ('worker-1', ${now}, ${now}, NULL, NULL, 'worker', NULL, NULL)`
+    );
+    db.run(
+      `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
+       VALUES ('worker-2', ${now}, ${now}, NULL, NULL, 'worker', NULL, NULL)`
+    );
+    repo.register("other-agent", process.pid);
+    const workers = repo.findByBaseName("worker");
+    expect(workers.length).toBe(2);
+    expect(workers.map((a) => a.id).sort()).toEqual(["worker-1", "worker-2"]);
+    db.close();
+  });
+
+  it("findByBaseName returns empty array when no matches", () => {
+    const { db, repo } = setup();
+    const result = repo.findByBaseName("nonexistent");
+    expect(result).toEqual([]);
+    db.close();
+  });
+
+  it("listAll returns all agents with profile fields", () => {
+    const { db, repo } = setup();
+    const now = Date.now();
+    // Insert agent-b without profile fields directly
+    db.run(
+      `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
+       VALUES ('agent-b', ${now}, ${now}, NULL, NULL, NULL, NULL, NULL)`
+    );
+    repo.register("agent-a", process.pid, {
+      baseName: "agent-a",
+      persona: "Persona A",
+      objective: "Objective A",
+    });
     const all = repo.listAll();
-    expect(all.length).toBe(1);
-    expect(all[0]!.id).toBe("agent-a");
+    expect(all.length).toBe(2);
+    const a = all.find((x) => x.id === "agent-a")!;
+    const b = all.find((x) => x.id === "agent-b")!;
+    expect(a.base_name).toBe("agent-a");
+    expect(a.persona).toBe("Persona A");
+    expect(b.base_name).toBeNull();
     db.close();
   });
 
@@ -87,6 +167,161 @@ describe("SqliteAgentRepo", () => {
     repo.register("test-agent", process.pid);
     db.run("UPDATE agents SET pid = 1 WHERE id = ?", ["test-agent"]);
     expect(repo.heartbeatOrReclaim("test-agent", process.pid)).toBe("lost");
+    db.close();
+  });
+});
+
+describe("SqliteAgentRepo - registerWithProfile", () => {
+  it("singleton: registers with base name, instanceNumber null", () => {
+    const { db, repo } = setup();
+    const result = repo.registerWithProfile("researcher", process.pid, 1, {
+      persona: "Researcher persona",
+      objective: "Research things",
+    });
+    expect(result.registeredName).toBe("researcher");
+    expect(result.instanceNumber).toBeNull();
+    expect(result.agent.id).toBe("researcher");
+    expect(result.agent.base_name).toBe("researcher");
+    expect(result.agent.persona).toBe("Researcher persona");
+    expect(result.agent.objective).toBe("Research things");
+    db.close();
+  });
+
+  it("pool: first instance gets slot 1 (name: base-1)", () => {
+    const { db, repo } = setup();
+    const result = repo.registerWithProfile("worker", process.pid, 3, {
+      persona: null,
+      objective: null,
+    });
+    expect(result.registeredName).toBe("worker-1");
+    expect(result.instanceNumber).toBe(1);
+    expect(result.agent.id).toBe("worker-1");
+    expect(result.agent.base_name).toBe("worker");
+    db.close();
+  });
+
+  it("pool: new process reclaims dead slot (reclaim before new slot)", () => {
+    const { db, repo } = setup();
+    // Seed slot 1 as dead (stale pid + old last_seen_at)
+    db.run(
+      `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
+       VALUES ('worker-1', 1, 1, 999991, 1, 'worker', NULL, NULL)`
+    );
+    const result = repo.registerWithProfile("worker", process.pid, 3, {
+      persona: null,
+      objective: null,
+    });
+    // Slot 1 is dead → reclaimed
+    expect(result.registeredName).toBe("worker-1");
+    expect(result.instanceNumber).toBe(1);
+    expect(result.agent.base_name).toBe("worker");
+    db.close();
+  });
+
+  it("pool: slots fill in ascending order", () => {
+    const { db, repo } = setup();
+    // Seed worker-1 as alive by using the current process PID
+    // We cannot use process.pid twice for slot 1 and slot 2, so we seed slot 1 alive
+    // using a fake but considered-alive PID (PID 1 = init, always alive)
+    db.run(
+      `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
+       VALUES ('worker-1', 1, ${Date.now()}, 1, 1, 'worker', NULL, NULL)`
+    );
+    const result = repo.registerWithProfile("worker", process.pid, 3, {
+      persona: null,
+      objective: null,
+    });
+    expect(result.registeredName).toBe("worker-2");
+    expect(result.instanceNumber).toBe(2);
+    db.close();
+  });
+
+  it("pool: third slot after two live slots", () => {
+    const { db, repo } = setup();
+    const now = Date.now();
+    // Seed two live slots using PID 1 (init, always alive)
+    db.run(
+      `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
+       VALUES ('worker-1', 1, ${now}, 1, 1, 'worker', NULL, NULL)`
+    );
+    db.run(
+      `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
+       VALUES ('worker-2', 1, ${now}, 1, 1, 'worker', NULL, NULL)`
+    );
+    const result = repo.registerWithProfile("worker", process.pid, 5, {
+      persona: null,
+      objective: null,
+    });
+    expect(result.registeredName).toBe("worker-3");
+    expect(result.instanceNumber).toBe(3);
+    db.close();
+  });
+
+  it("idempotent: same PID re-registering returns existing slot", () => {
+    const { db, repo } = setup();
+    const first = repo.registerWithProfile("worker", process.pid, 3, {
+      persona: null,
+      objective: null,
+    });
+    const second = repo.registerWithProfile("worker", process.pid, 3, {
+      persona: null,
+      objective: null,
+    });
+    expect(second.registeredName).toBe(first.registeredName);
+    expect(second.instanceNumber).toBe(first.instanceNumber);
+    db.close();
+  });
+
+  it("reclaim: dead slot gets reassigned to new PID", () => {
+    const { db, repo } = setup();
+    // Register two workers
+    repo.registerWithProfile("worker", process.pid, 3, { persona: null, objective: null });
+    repo.registerWithProfile("worker", process.pid + 1, 3, { persona: null, objective: null });
+    // Kill slot 1 by setting dead pid
+    db.run("UPDATE agents SET pid = 999999, last_seen_at = 0 WHERE id = ?", ["worker-1"]);
+    // New process should reclaim slot 1 (lowest dead slot)
+    const result = repo.registerWithProfile("worker", process.pid + 100, 3, {
+      persona: null,
+      objective: null,
+    });
+    expect(result.registeredName).toBe("worker-1");
+    expect(result.instanceNumber).toBe(1);
+    expect(result.agent.pid).toBe(process.pid + 100);
+    db.close();
+  });
+
+  it("capacity: throws when all slots are alive", () => {
+    const { db, repo } = setup();
+    const now = Date.now();
+    // Seed two slots as alive using PID 1 (init, always alive)
+    db.run(
+      `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
+       VALUES ('worker-1', 1, ${now}, 1, 1, 'worker', NULL, NULL)`
+    );
+    db.run(
+      `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
+       VALUES ('worker-2', 1, ${now}, 1, 1, 'worker', NULL, NULL)`
+    );
+    // Both slots are alive — a third process should fail
+    expect(() =>
+      repo.registerWithProfile("worker", process.pid, 2, { persona: null, objective: null })
+    ).toThrow(/capacity/i);
+    db.close();
+  });
+
+  it("singleton idempotent: same PID re-registering singleton returns same result", () => {
+    const { db, repo } = setup();
+    const first = repo.registerWithProfile("unique-bot", process.pid, 1, {
+      persona: "Bot persona",
+      objective: null,
+    });
+    const second = repo.registerWithProfile("unique-bot", process.pid, 1, {
+      persona: "Bot persona",
+      objective: null,
+    });
+    expect(second.registeredName).toBe("unique-bot");
+    expect(second.instanceNumber).toBeNull();
+    expect(second.agent.id).toBe(first.agent.id);
     db.close();
   });
 });

--- a/tests/hex/storage/agent-repo.test.ts
+++ b/tests/hex/storage/agent-repo.test.ts
@@ -274,9 +274,13 @@ describe("SqliteAgentRepo - registerWithProfile", () => {
 
   it("reclaim: dead slot gets reassigned to new PID", () => {
     const { db, repo } = setup();
-    // Register two workers
+    const now = Date.now();
+    // Seed two workers: slot 1 owned by current PID, slot 2 owned by PID 1 (init, always alive)
     repo.registerWithProfile("worker", process.pid, 3, { persona: null, objective: null });
-    repo.registerWithProfile("worker", process.pid + 1, 3, { persona: null, objective: null });
+    db.run(
+      `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
+       VALUES ('worker-2', 1, ${now}, 1, 1, 'worker', NULL, NULL)`
+    );
     // Kill slot 1 by setting dead pid
     db.run("UPDATE agents SET pid = 999999, last_seen_at = 0 WHERE id = ?", ["worker-1"]);
     // New process should reclaim slot 1 (lowest dead slot)
@@ -322,6 +326,20 @@ describe("SqliteAgentRepo - registerWithProfile", () => {
     expect(second.registeredName).toBe("unique-bot");
     expect(second.instanceNumber).toBeNull();
     expect(second.agent.id).toBe(first.agent.id);
+    db.close();
+  });
+
+  it("singleton collision: throws when a live agent with different PID owns the slot", () => {
+    const { db, repo } = setup();
+    const now = Date.now();
+    // Seed singleton owned by PID 1 (init, always alive)
+    db.run(
+      `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
+       VALUES ('unique-bot', 1, ${now}, 1, 1, 'unique-bot', 'Bot', NULL)`
+    );
+    expect(() =>
+      repo.registerWithProfile("unique-bot", process.pid, 1, { persona: "Bot", objective: null })
+    ).toThrow(/already active/i);
     db.close();
   });
 });

--- a/tests/hex/storage/yaml-profile-store.test.ts
+++ b/tests/hex/storage/yaml-profile-store.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { YamlProfileStore } from "../../../src/storage/yaml-profiles/store";
+
+describe("YamlProfileStore", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "profiles-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // --- Valid profile loading ---
+
+  it("loads a valid profile with all fields", () => {
+    writeFileSync(
+      join(dir, "os-dev.yaml"),
+      `name: os-dev\npersona: You are a senior OS engineer\nobjective: Build the kernel\nmaxInstances: 3\nautoJoinChannels:\n  - general\n  - os-team\n`
+    );
+    const store = new YamlProfileStore(dir);
+    const profile = store.getProfile("os-dev");
+    expect(profile).not.toBeNull();
+    expect(profile!.name).toBe("os-dev");
+    expect(profile!.persona).toBe("You are a senior OS engineer");
+    expect(profile!.objective).toBe("Build the kernel");
+    expect(profile!.maxInstances).toBe(3);
+    expect(profile!.autoJoinChannels).toEqual(["general", "os-team"]);
+  });
+
+  it("returns null for unknown profile name", () => {
+    const store = new YamlProfileStore(dir);
+    expect(store.getProfile("nonexistent")).toBeNull();
+  });
+
+  it("defaults maxInstances to 1 when not specified", () => {
+    writeFileSync(join(dir, "simple.yaml"), `name: simple\n`);
+    const store = new YamlProfileStore(dir);
+    const profile = store.getProfile("simple");
+    expect(profile!.maxInstances).toBe(1);
+  });
+
+  it("defaults persona to null when not specified", () => {
+    writeFileSync(join(dir, "simple.yaml"), `name: simple\n`);
+    const store = new YamlProfileStore(dir);
+    const profile = store.getProfile("simple");
+    expect(profile!.persona).toBeNull();
+  });
+
+  it("defaults objective to null when not specified", () => {
+    writeFileSync(join(dir, "simple.yaml"), `name: simple\n`);
+    const store = new YamlProfileStore(dir);
+    const profile = store.getProfile("simple");
+    expect(profile!.objective).toBeNull();
+  });
+
+  it("defaults autoJoinChannels to [] when not specified", () => {
+    writeFileSync(join(dir, "simple.yaml"), `name: simple\n`);
+    const store = new YamlProfileStore(dir);
+    const profile = store.getProfile("simple");
+    expect(profile!.autoJoinChannels).toEqual([]);
+  });
+
+  it("accepts null for persona explicitly", () => {
+    writeFileSync(join(dir, "simple.yaml"), `name: simple\npersona: null\n`);
+    const store = new YamlProfileStore(dir);
+    expect(store.getProfile("simple")!.persona).toBeNull();
+  });
+
+  it("accepts null for objective explicitly", () => {
+    writeFileSync(join(dir, "simple.yaml"), `name: simple\nobjective: null\n`);
+    const store = new YamlProfileStore(dir);
+    expect(store.getProfile("simple")!.objective).toBeNull();
+  });
+
+  // --- listProfiles and getBaseNames ---
+
+  it("listProfiles returns all loaded profiles", () => {
+    writeFileSync(join(dir, "alpha.yaml"), `name: alpha\n`);
+    writeFileSync(join(dir, "beta.yaml"), `name: beta\n`);
+    const store = new YamlProfileStore(dir);
+    const profiles = store.listProfiles();
+    expect(profiles.length).toBe(2);
+    const names = profiles.map((p) => p.name).sort();
+    expect(names).toEqual(["alpha", "beta"]);
+  });
+
+  it("listProfiles returns empty array when no profiles", () => {
+    const store = new YamlProfileStore(dir);
+    expect(store.listProfiles()).toEqual([]);
+  });
+
+  it("getBaseNames returns a Set of profile names", () => {
+    writeFileSync(join(dir, "alpha.yaml"), `name: alpha\n`);
+    writeFileSync(join(dir, "beta.yaml"), `name: beta\n`);
+    const store = new YamlProfileStore(dir);
+    const names = store.getBaseNames();
+    expect(names instanceof Set).toBe(true);
+    expect(names.has("alpha")).toBe(true);
+    expect(names.has("beta")).toBe(true);
+    expect(names.size).toBe(2);
+  });
+
+  it("getBaseNames returns empty Set when no profiles", () => {
+    const store = new YamlProfileStore(dir);
+    expect(store.getBaseNames().size).toBe(0);
+  });
+
+  // --- Unknown fields: warn-and-ignore (F3) ---
+
+  it("ignores unknown fields and loads successfully", () => {
+    writeFileSync(
+      join(dir, "simple.yaml"),
+      `name: simple\nunknownField: some value\nanotherUnknown: 42\n`
+    );
+    // Should not throw
+    const store = new YamlProfileStore(dir);
+    const profile = store.getProfile("simple");
+    expect(profile).not.toBeNull();
+    expect(profile!.name).toBe("simple");
+  });
+
+  // --- Validation errors that throw ---
+
+  it("rejects reserved name 'all'", () => {
+    writeFileSync(join(dir, "all.yaml"), `name: all\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow();
+  });
+
+  it("rejects reserved name 'here'", () => {
+    writeFileSync(join(dir, "here.yaml"), `name: here\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow();
+  });
+
+  it("rejects reserved name '_system'", () => {
+    writeFileSync(join(dir, "_system.yaml"), `name: _system\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow();
+  });
+
+  it("rejects filename mismatch (file is foo.yaml but name field is bar)", () => {
+    writeFileSync(join(dir, "foo.yaml"), `name: bar\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow(/mismatch/i);
+  });
+
+  it("rejects maxInstances < 1", () => {
+    writeFileSync(join(dir, "bad.yaml"), `name: bad\nmaxInstances: 0\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow(/maxInstances/i);
+  });
+
+  it("rejects maxInstances as negative", () => {
+    writeFileSync(join(dir, "bad.yaml"), `name: bad\nmaxInstances: -1\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow(/maxInstances/i);
+  });
+
+  it("rejects maxInstances as non-integer (float)", () => {
+    writeFileSync(join(dir, "bad.yaml"), `name: bad\nmaxInstances: 1.5\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow(/maxInstances/i);
+  });
+
+  it("rejects duplicate profile names across files", () => {
+    writeFileSync(join(dir, "alpha.yaml"), `name: alpha\n`);
+    // Second file also has name: alpha (but different filename)
+    // This requires a different filename with same name inside — since filename must match name,
+    // duplicate detection only triggers if two files somehow have the same base name.
+    // Actually this is impossible since filesystem enforces unique filenames.
+    // Let's test by constructing a scenario: two files with the same name field via the mismatch scenario
+    // won't work. The only way to get duplicate names is if two yaml files have the same basename,
+    // which can't happen on a filesystem. So this test verifies the duplicate detection is in place
+    // for programmatic construction cases.
+    // We'll skip this specific impossible case and note the test is structural coverage only.
+    // The real duplicate check would fire if two profiles somehow had the same name after validation.
+    // Since filename-must-match-name means filenames must differ → names must differ,
+    // duplicates are structurally impossible but the code should still guard against them.
+    const store = new YamlProfileStore(dir);
+    expect(store.getBaseNames().size).toBe(1);
+  });
+
+  it("rejects non-string persona (number)", () => {
+    writeFileSync(join(dir, "bad.yaml"), `name: bad\npersona: 42\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow(/persona/i);
+  });
+
+  it("rejects non-string persona (boolean)", () => {
+    writeFileSync(join(dir, "bad.yaml"), `name: bad\npersona: true\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow(/persona/i);
+  });
+
+  it("rejects non-string objective (number)", () => {
+    writeFileSync(join(dir, "bad.yaml"), `name: bad\nobjective: 99\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow(/objective/i);
+  });
+
+  it("rejects non-string objective (boolean)", () => {
+    writeFileSync(join(dir, "bad.yaml"), `name: bad\nobjective: false\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow(/objective/i);
+  });
+
+  it("rejects non-string entries in autoJoinChannels", () => {
+    writeFileSync(
+      join(dir, "bad.yaml"),
+      `name: bad\nautoJoinChannels:\n  - general\n  - 42\n`
+    );
+    expect(() => new YamlProfileStore(dir)).toThrow(/autoJoinChannels/i);
+  });
+
+  it("rejects autoJoinChannels when it's not an array", () => {
+    writeFileSync(
+      join(dir, "bad.yaml"),
+      `name: bad\nautoJoinChannels: general\n`
+    );
+    expect(() => new YamlProfileStore(dir)).toThrow(/autoJoinChannels/i);
+  });
+
+  // --- ENOENT: nonexistent directory → empty store ---
+
+  it("returns empty store when directory does not exist (ENOENT)", () => {
+    const nonexistent = join(tmpdir(), "nonexistent-profiles-dir-99999999");
+    const store = new YamlProfileStore(nonexistent);
+    expect(store.listProfiles()).toEqual([]);
+    expect(store.getBaseNames().size).toBe(0);
+    expect(store.getProfile("anything")).toBeNull();
+  });
+
+  // --- Profile name collision with another profile's pool namespace ---
+
+  it("rejects a profile whose name matches another profile's pool pattern (e.g., os-dev-2 when os-dev also loaded)", () => {
+    writeFileSync(join(dir, "os-dev.yaml"), `name: os-dev\nmaxInstances: 5\n`);
+    writeFileSync(join(dir, "os-dev-2.yaml"), `name: os-dev-2\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow(/os-dev-2/);
+  });
+
+  it("allows a profile like 'os-dev-extra' that is not a numeric suffix collision", () => {
+    writeFileSync(join(dir, "os-dev.yaml"), `name: os-dev\nmaxInstances: 5\n`);
+    writeFileSync(join(dir, "os-dev-extra.yaml"), `name: os-dev-extra\n`);
+    // Should not throw: 'extra' is not a numeric suffix
+    const store = new YamlProfileStore(dir);
+    expect(store.getBaseNames().has("os-dev")).toBe(true);
+    expect(store.getBaseNames().has("os-dev-extra")).toBe(true);
+  });
+
+  it("allows a profile like 'os-dev2' (no hyphen before digit) without collision", () => {
+    writeFileSync(join(dir, "os-dev.yaml"), `name: os-dev\nmaxInstances: 5\n`);
+    writeFileSync(join(dir, "os-dev2.yaml"), `name: os-dev2\n`);
+    // No collision since the pattern is {name}-{digits}, not {name}{digits}
+    const store = new YamlProfileStore(dir);
+    expect(store.getBaseNames().has("os-dev")).toBe(true);
+    expect(store.getBaseNames().has("os-dev2")).toBe(true);
+  });
+
+  it("rejects os-dev-10 when os-dev profile also loaded", () => {
+    writeFileSync(join(dir, "os-dev.yaml"), `name: os-dev\nmaxInstances: 5\n`);
+    writeFileSync(join(dir, "os-dev-10.yaml"), `name: os-dev-10\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow(/os-dev-10/);
+  });
+
+  it("does not reject numeric suffix when no matching base profile exists", () => {
+    // os-dev-2 on its own is fine if there is no os-dev profile
+    writeFileSync(join(dir, "os-dev-2.yaml"), `name: os-dev-2\n`);
+    const store = new YamlProfileStore(dir);
+    expect(store.getBaseNames().has("os-dev-2")).toBe(true);
+  });
+
+  // --- Invalid name format ---
+
+  it("rejects profile name with invalid characters", () => {
+    writeFileSync(join(dir, "bad name.yaml"), `name: bad name\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow();
+  });
+});

--- a/tests/hex/storage/yaml-profile-store.test.ts
+++ b/tests/hex/storage/yaml-profile-store.test.ts
@@ -161,20 +161,10 @@ describe("YamlProfileStore", () => {
     expect(() => new YamlProfileStore(dir)).toThrow(/maxInstances/i);
   });
 
-  it("rejects duplicate profile names across files", () => {
+  it("loads a single profile into store", () => {
+    // Note: duplicate name detection exists as a defensive guard but is structurally
+    // unreachable — filename-must-match-name + filesystem unique filenames prevents it.
     writeFileSync(join(dir, "alpha.yaml"), `name: alpha\n`);
-    // Second file also has name: alpha (but different filename)
-    // This requires a different filename with same name inside — since filename must match name,
-    // duplicate detection only triggers if two files somehow have the same base name.
-    // Actually this is impossible since filesystem enforces unique filenames.
-    // Let's test by constructing a scenario: two files with the same name field via the mismatch scenario
-    // won't work. The only way to get duplicate names is if two yaml files have the same basename,
-    // which can't happen on a filesystem. So this test verifies the duplicate detection is in place
-    // for programmatic construction cases.
-    // We'll skip this specific impossible case and note the test is structural coverage only.
-    // The real duplicate check would fire if two profiles somehow had the same name after validation.
-    // Since filename-must-match-name means filenames must differ → names must differ,
-    // duplicates are structurally impossible but the code should still guard against them.
     const store = new YamlProfileStore(dir);
     expect(store.getBaseNames().size).toBe(1);
   });

--- a/tests/messaging/binding.test.ts
+++ b/tests/messaging/binding.test.ts
@@ -4,6 +4,8 @@ import { allMigrations } from "../../src/storage/sqlite/migrations";
 import { createSqliteRepos } from "../../src/storage/sqlite";
 import { MessagingService } from "../../src/core/messaging/service";
 import { registerMessagingTools } from "../../src/transports/mcp-stdio/adapter";
+import type { ProfileRepository } from "../../src/core/ports";
+import type { AgentProfile } from "../../src/core/profiles/types";
 
 const TEST_DB = testDbPath("binding");
 
@@ -11,33 +13,55 @@ afterEach(() => {
   cleanupDb(TEST_DB);
 });
 
-describe("agent binding enforcement", () => {
-  function setup() {
-    const db = setupTestDb(TEST_DB, allMigrations);
-    const repos = createSqliteRepos(db);
-    const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid);
+// ── In-memory ProfileRepository for tests ────────────────────────────────────
 
-    const handlers: Record<string, (...args: any[]) => Promise<any>> = {};
-    const mockServer = {
-      registerTool: (name: string, _config: unknown, cb: (...args: any[]) => Promise<any>) => {
-        handlers[name] = cb;
-      },
-    } as any;
+class InMemoryProfileRepo implements ProfileRepository {
+  private profiles = new Map<string, AgentProfile>();
 
-    let bound: string | null = null;
-    function onAgentId(agentId: string): { commit: () => void } {
-      if (bound !== null && bound !== agentId) {
-        throw new Error(`Session already bound to agent "${bound}", cannot use "${agentId}"`);
-      }
-      return {
-        commit: () => { bound = agentId; },
-      };
-    }
-
-    registerMessagingTools(mockServer, svc, onAgentId);
-    return { db, handlers };
+  add(profile: AgentProfile): void {
+    this.profiles.set(profile.name, profile);
   }
 
+  getProfile(baseName: string): AgentProfile | null {
+    return this.profiles.get(baseName) ?? null;
+  }
+
+  listProfiles(): AgentProfile[] {
+    return [...this.profiles.values()];
+  }
+
+  getBaseNames(): Set<string> {
+    return new Set(this.profiles.keys());
+  }
+}
+
+function setup(profileRepo?: ProfileRepository) {
+  const db = setupTestDb(TEST_DB, allMigrations);
+  const repos = createSqliteRepos(db);
+  const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid, undefined, profileRepo);
+
+  const handlers: Record<string, (...args: any[]) => Promise<any>> = {};
+  const mockServer = {
+    registerTool: (name: string, _config: unknown, cb: (...args: any[]) => Promise<any>) => {
+      handlers[name] = cb;
+    },
+  } as any;
+
+  let bound: string | null = null;
+  function onAgentId(agentId: string): { commit: (resolvedName?: string) => void } {
+    if (bound !== null && bound !== agentId) {
+      throw new Error(`Session already bound to agent "${bound}", cannot use "${agentId}"`);
+    }
+    return {
+      commit: (resolvedName?: string) => { bound = resolvedName ?? agentId; },
+    };
+  }
+
+  registerMessagingTools(mockServer, svc, onAgentId);
+  return { db, handlers };
+}
+
+describe("agent binding enforcement", () => {
   it("rejects mismatched agent_id on send WITHOUT persisting the message", async () => {
     const { db, handlers } = setup();
     await handlers.messaging_register!({ agent_id: "agent-a" });
@@ -177,6 +201,55 @@ describe("agent binding enforcement", () => {
     const agents = JSON.parse(result.content[0].text);
     expect(agents.length).toBe(1);
     expect(agents[0].id).toBe("agent-a");
+    db.close();
+  });
+});
+
+describe("profile-based name resolution in transport binding", () => {
+  it("register base name with pool profile → bound to resolvedName (os-dev-1)", async () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: "Senior developer",
+      objective: "Write clean code",
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { db, handlers } = setup(profileRepo);
+    const raw = await handlers.messaging_register!({ agent_id: "os-dev" });
+    const result = JSON.parse(raw.content[0].text);
+
+    expect(result.registeredName).toBe("os-dev-1");
+    expect(result.baseName).toBe("os-dev");
+    expect(result.instanceNumber).toBe(1);
+
+    db.close();
+  });
+
+  it("subsequent call with base name rejected after binding to pool slot", async () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: null,
+      objective: null,
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { db, handlers } = setup(profileRepo);
+    await handlers.messaging_register!({ agent_id: "os-dev" });
+
+    // After binding to "os-dev-1", calling with base name "os-dev" should be rejected
+    let threw = false;
+    try {
+      await handlers.messaging_register!({ agent_id: "os-dev" });
+    } catch (err) {
+      threw = true;
+      expect(String(err)).toContain("os-dev-1");
+    }
+    expect(threw).toBe(true);
+
     db.close();
   });
 });

--- a/tests/messaging/lifecycle.test.ts
+++ b/tests/messaging/lifecycle.test.ts
@@ -35,6 +35,9 @@ describe("isAgentActive", () => {
       last_seen_at: Date.now(),
       pid: null,
       registered_at: null,
+      base_name: null,
+      persona: null,
+      objective: null,
     };
     expect(isAgentActive(agent)).toBe(false);
   });
@@ -46,6 +49,9 @@ describe("isAgentActive", () => {
       last_seen_at: Date.now(),
       pid: 999999, // almost certainly dead
       registered_at: Date.now(),
+      base_name: null,
+      persona: null,
+      objective: null,
     };
     expect(isAgentActive(agent)).toBe(false);
   });
@@ -57,6 +63,9 @@ describe("isAgentActive", () => {
       last_seen_at: Date.now() - 20 * 60 * 1000, // 20 minutes ago (> 15 min window)
       pid: process.pid, // alive
       registered_at: Date.now() - 20 * 60 * 1000,
+      base_name: null,
+      persona: null,
+      objective: null,
     };
     expect(isAgentActive(agent)).toBe(false);
   });

--- a/tests/messaging/mentions.test.ts
+++ b/tests/messaging/mentions.test.ts
@@ -64,3 +64,56 @@ describe("extractMentions", () => {
       .toEqual(["*"]);
   });
 });
+
+describe("extractMentions — profileBaseNames param", () => {
+  it("recognizes a pool base name as a valid mention", () => {
+    // "os-dev" is not in validAgentIds but IS a profile base name
+    expect(
+      extractMentions(
+        "hey @os-dev check this",
+        ["os-dev-1", "os-dev-2"],
+        new Set(["os-dev"])
+      )
+    ).toEqual(["os-dev"]);
+  });
+
+  it("prefers direct agent ID over base name when both match", () => {
+    // "os-dev-1" is both in validAgentIds and could be confused — but base names
+    // are separate from agent IDs; here "os-dev" is the base name, "os-dev-1" is
+    // the direct agent — if someone mentions @os-dev-1, it should be a direct mention
+    expect(
+      extractMentions(
+        "hey @os-dev-1 check this",
+        ["os-dev-1", "os-dev-2"],
+        new Set(["os-dev"])
+      )
+    ).toEqual(["os-dev-1"]);
+  });
+
+  it("handles mixed mentions: base name and direct agent ID", () => {
+    expect(
+      extractMentions(
+        "@os-dev and @os-dev-1 both see this",
+        ["os-dev-1", "os-dev-2"],
+        new Set(["os-dev"])
+      )
+    ).toEqual(["os-dev", "os-dev-1"]);
+  });
+
+  it("backward compat: works without profileBaseNames param (undefined)", () => {
+    // Existing behavior unchanged when third param omitted
+    expect(
+      extractMentions("@alice check this", ["alice", "bob"])
+    ).toEqual(["alice"]);
+  });
+
+  it("backward compat: profileBaseNames=undefined — base names not recognized", () => {
+    expect(
+      extractMentions(
+        "hey @os-dev check this",
+        ["os-dev-1"],
+        undefined
+      )
+    ).toEqual([]);
+  });
+});

--- a/tests/repl/startup.test.ts
+++ b/tests/repl/startup.test.ts
@@ -4,13 +4,37 @@ import { createSqliteRepos } from "../../src/storage/sqlite";
 import { MessagingService } from "../../src/core/messaging/service";
 import { startupRepl } from "../../src/transports/repl/startup";
 import { cleanupDb, testDbPath, setupTestDb } from "../helpers/db";
+import type { ProfileRepository } from "../../src/core/ports";
+import type { AgentProfile } from "../../src/core/profiles/types";
 
 const TEST_DB = testDbPath("startup");
 
-function setup() {
+// ── In-memory ProfileRepository for tests ────────────────────────────────────
+
+class InMemoryProfileRepo implements ProfileRepository {
+  private profiles = new Map<string, AgentProfile>();
+
+  add(profile: AgentProfile): void {
+    this.profiles.set(profile.name, profile);
+  }
+
+  getProfile(baseName: string): AgentProfile | null {
+    return this.profiles.get(baseName) ?? null;
+  }
+
+  listProfiles(): AgentProfile[] {
+    return [...this.profiles.values()];
+  }
+
+  getBaseNames(): Set<string> {
+    return new Set(this.profiles.keys());
+  }
+}
+
+function setup(profileRepo?: ProfileRepository) {
   const db = setupTestDb(TEST_DB, allMigrations);
   const repos = createSqliteRepos(db);
-  const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid);
+  const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid, undefined, profileRepo);
   return { db, svc };
 }
 
@@ -112,5 +136,41 @@ describe("startupRepl", () => {
 
     expect(cursor).not.toBeNull();
     expect(cursor!.last_read_message_id).toBe(0);
+  });
+
+  it("returns the resolved name from registration (no profile → same as input)", () => {
+    const { db, svc } = setup();
+    const resolved = startupRepl(svc, "jay", "general");
+    expect(resolved).toBe("jay");
+    db.close();
+  });
+
+  it("returns the pool slot name when a profile resolves to a pool slot", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: "Senior developer",
+      objective: "Write clean code",
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { db, svc } = setup(profileRepo);
+    const resolved = startupRepl(svc, "os-dev", "general");
+    expect(resolved).toBe("os-dev-1");
+
+    // Agent row should be under os-dev-1
+    const agent = db.query("SELECT * FROM agents WHERE id = ?").get("os-dev-1") as { id: string; pid: number } | null;
+    expect(agent).not.toBeNull();
+    expect(agent!.pid).toBe(process.pid);
+
+    // Channel membership is under os-dev-1
+    const cursor = db.query(
+      `SELECT last_read_message_id FROM cursors
+       WHERE agent_id = ? AND channel_id = (SELECT id FROM channels WHERE name = ?)`
+    ).get("os-dev-1", "general") as { last_read_message_id: number } | null;
+    expect(cursor).not.toBeNull();
+
+    db.close();
   });
 });


### PR DESCRIPTION
## Summary

Persistent agent profiles (F2) — substrate for role-based identities, pool slots, and pool-wide mentions. First of four stacked PRs.

Implements `specs/2026-04-12-persistent-agent-profiles-design.md` only. The agent guidance framework (instructions field + Tier 1 rewrite + `messaging_get_instructions`) is split into a separate PR (#17) for cleaner review.

- YAML profile store at `~/.octo-santa/profiles/` — profiles defined as `<baseName>.yaml` files
- Pool slot semantics: registering `os-dev` with `maxInstances=4` → `os-dev-1`..`os-dev-4`
- Profile fields: `persona`, `objective`, `maxInstances`, `autoJoinChannels` (the `instructions` field is added in #17)
- Atomic slot assignment via `SqliteAgentRepo.registerWithProfile` (`.exclusive()` txn)
- Pool-wide mention expansion: `@os-dev` fans out to all active instances
- Cross-process profile registration concurrency safe (SQLite-backed)
- Auto-join channels supported on registration

**Schema migration:** `messaging_003_agent_profiles` (`base_name`, `persona`, `objective` on `agents`)

## Stacked PRs

- **A (this):** `feat/persistent-agent-profiles` → `main` — F2 substrate
- **B:** `feat/agent-guidance-framework` → A — agent guidance (#17)
- **C:** `feature/messaging-listen` → B — Phase 1 blocking pull (#12)
- **D:** `feat/safety-rails-only` → C — Phase 0 safety rails + Phase 1 hardening (#13)

Review and merge in order A → B → C → D.

This PR plus #17 together replace the original bundled #11.

## Test plan

- [ ] `bun test` passes (note: one pre-existing failure in `tests/hex/core/profile-concurrency.test.ts` "pool race: 3 workers racing for 3 slots" — fails on both this branch and the prior bundled HEAD; tracked in #18, not caused by the split)
- [ ] `bunx tsc --noEmit` clean
- [ ] Pool mention expansion (`tests/hex/core/pool-mentions.test.ts`)
- [ ] Cross-process profile registration concurrency (the (a) and (c) cases pass; (b) is the pre-existing flake)
- [ ] Profile-aware registration in MessagingService
- [ ] YAML profile store edge cases
