### PR TITLE
feat: messaging_listen blocking pull mode

### DIFF
--- a/src/core/messaging/service.ts
+++ b/src/core/messaging/service.ts
@@ -11,6 +11,7 @@ import type {
   Channel,
   Message,
   ReadOptions,
+  UnreadResult,
 } from "./types";
 import type { RegisterResult, AutoJoinResult } from "../profiles/types";
 import {
@@ -262,6 +263,22 @@ export class MessagingService {
       channel.id,
       opts?.limit ?? 100
     );
+  }
+
+  readAllUnread(agentId: string): UnreadResult[] {
+    this.requireRegistered(agentId);
+    const cursorList = this.cursors.listForAgent(agentId);
+    const results: UnreadResult[] = [];
+    for (const cursor of cursorList) {
+      const messages = this.messages.readForwardAndAdvance(agentId, cursor.channelId, 100);
+      if (messages.length === 0) continue;
+      results.push({
+        channel: cursor.channelName,
+        messages,
+        is_dm: isDmChannel(cursor.channelName),
+      });
+    }
+    return results;
   }
 
   /**

--- a/src/core/messaging/types.ts
+++ b/src/core/messaging/types.ts
@@ -44,3 +44,9 @@ export interface CursorWithChannel {
 }
 
 export type HeartbeatResult = "ok" | "lost";
+
+export interface UnreadResult {
+  channel: string;
+  messages: Message[];
+  is_dm: boolean;
+}

--- a/src/transports/mcp-stdio/adapter.ts
+++ b/src/transports/mcp-stdio/adapter.ts
@@ -82,7 +82,8 @@ export function registerMessagingTools(
   messaging: MessagingService,
   onAgentId?: (agentId: string) => { commit: (resolvedName?: string) => void },
   onProfile?: (profile: { baseName: string; persona: string | null; objective: string | null; instructions: string | null }) => void,
-  sessionGuidance?: string
+  sessionGuidance?: string,
+  agents?: AgentRepository
 ): void {
   server.registerTool("messaging_register", {
     description:
@@ -272,6 +273,28 @@ export function registerMessagingTools(
       jsonResult(messaging.renameChannel(agent_id, channel, new_name))
     );
   });
+
+  server.registerTool("messaging_listen", {
+    description: "Block and wait for new messages across all subscribed channels. Returns when messages arrive or timeout is reached. Use this for agent polling loops instead of repeatedly calling messaging_read_messages.",
+    inputSchema: {
+      agent_id: z.string().trim().min(1).describe("Your registered agent name"),
+      timeout_ms: z.number().int().optional().describe("Max wait time in ms (default 10000, max 30000)"),
+    },
+  }, async ({ agent_id, timeout_ms }) => {
+    return withAgent(onAgentId, agent_id, async () => {
+      const timeout = Math.max(1000, Math.min(30000, timeout_ms ?? 10000));
+      agents?.heartbeatOrReclaim(agent_id, process.pid);
+      const deadline = Date.now() + timeout;
+      while (Date.now() < deadline) {
+        const result = messaging.readAllUnread(agent_id);
+        if (result.length > 0) {
+          return jsonResult({ channels: result, timed_out: false });
+        }
+        await Bun.sleep(1000);
+      }
+      return jsonResult({ channels: [], timed_out: true });
+    });
+  });
 }
 
 export function registerBrainTools(
@@ -451,7 +474,7 @@ export async function startMcpStdio(opts: McpStdioOpts): Promise<void> {
   const sessionInstructions = buildInstructions(config, brainIndex);
   registerMessagingTools(mcpServer, messaging, onAgentId, (profile) => {
     boundProfile = profile;
-  }, sessionInstructions);
+  }, sessionInstructions, agents);
   registerBrainTools(mcpServer, brain, config, hasBrain, onAgentId);
 
   const transport = new StdioServerTransport();

--- a/tests/hex/core/listen.test.ts
+++ b/tests/hex/core/listen.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { MessagingService } from "../../../src/core/messaging/service";
+import { createSqliteRepos } from "../../../src/storage/sqlite";
+import { createDb } from "../../../src/storage/sqlite/db";
+import { runMigrations, allMigrations } from "../../../src/storage/sqlite/migrations";
+import { createNotificationDispatcher } from "../../../src/notifications/dispatch/dispatcher";
+import { cleanupDb } from "../../helpers/db";
+
+const TEST_DB = `/tmp/octo-santa-test-hex-listen-${process.pid}.sqlite`;
+
+function setup() {
+  cleanupDb(TEST_DB);
+  const db = createDb(TEST_DB);
+  runMigrations(db, allMigrations);
+  const repos = createSqliteRepos(db);
+  const dispatcher = createNotificationDispatcher();
+  const svc = new MessagingService(
+    repos.agents,
+    repos.channels,
+    repos.messages,
+    repos.cursors,
+    process.pid,
+    dispatcher
+  );
+  return { db, repos, svc };
+}
+
+afterEach(() => cleanupDb(TEST_DB));
+
+describe("readAllUnread()", () => {
+  it("returns empty array when agent has no subscriptions", () => {
+    const { svc } = setup();
+    svc.register("alice");
+
+    const result = svc.readAllUnread("alice");
+    expect(result).toEqual([]);
+  });
+
+  it("returns only channels with unread messages, skips empty ones", () => {
+    const { svc } = setup();
+    svc.register("alice");
+    svc.register("bob");
+
+    svc.createChannel("alice", "active");
+    svc.subscribe("alice", "active");
+    svc.subscribe("bob", "active");
+
+    svc.createChannel("alice", "quiet");
+    svc.subscribe("alice", "quiet");
+
+    svc.send("bob", "active", "hello alice");
+
+    const result = svc.readAllUnread("alice");
+    expect(result.length).toBe(1);
+    expect(result[0]!.channel).toBe("active");
+    expect(result[0]!.messages.length).toBe(1);
+    expect(result[0]!.messages[0]!.content).toBe("hello alice");
+  });
+
+  it("advances cursors so second call returns empty", () => {
+    const { svc } = setup();
+    svc.register("alice");
+    svc.register("bob");
+
+    svc.createChannel("alice", "general");
+    svc.subscribe("alice", "general");
+    svc.subscribe("bob", "general");
+
+    svc.send("bob", "general", "first message");
+
+    const first = svc.readAllUnread("alice");
+    expect(first.length).toBe(1);
+    expect(first[0]!.messages.length).toBe(1);
+
+    const second = svc.readAllUnread("alice");
+    expect(second).toEqual([]);
+  });
+
+  it("marks DM channels with is_dm: true", () => {
+    const { svc } = setup();
+    svc.register("alice");
+    svc.register("bob");
+
+    svc.directMessage("bob", "alice", "hey alice");
+
+    const result = svc.readAllUnread("alice");
+    expect(result.length).toBe(1);
+    expect(result[0]!.channel).toBe("alice,bob");
+    expect(result[0]!.is_dm).toBe(true);
+    expect(result[0]!.messages.length).toBe(1);
+    expect(result[0]!.messages[0]!.content).toBe("hey alice");
+  });
+
+  it("marks regular channels with is_dm: false", () => {
+    const { svc } = setup();
+    svc.register("alice");
+    svc.register("bob");
+
+    svc.createChannel("alice", "general");
+    svc.subscribe("alice", "general");
+    svc.subscribe("bob", "general");
+
+    svc.send("bob", "general", "hello");
+
+    const result = svc.readAllUnread("alice");
+    expect(result.length).toBe(1);
+    expect(result[0]!.is_dm).toBe(false);
+  });
+
+  it("throws if agent is not registered", () => {
+    const { svc } = setup();
+
+    expect(() => svc.readAllUnread("ghost")).toThrow(
+      'Agent "ghost" must call messaging_register before using messaging tools'
+    );
+  });
+});

--- a/tests/messaging/listen.test.ts
+++ b/tests/messaging/listen.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { cleanupDb, testDbPath, setupTestDb } from "../helpers/db";
+import { allMigrations } from "../../src/storage/sqlite/migrations";
+import { createSqliteRepos } from "../../src/storage/sqlite";
+import { MessagingService } from "../../src/core/messaging/service";
+import { registerMessagingTools } from "../../src/transports/mcp-stdio/adapter";
+
+const TEST_DB = testDbPath("listen");
+
+afterEach(() => {
+  cleanupDb(TEST_DB);
+});
+
+function setup() {
+  const db = setupTestDb(TEST_DB, allMigrations);
+  const repos = createSqliteRepos(db);
+  const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid);
+
+  const handlers: Record<string, (...args: any[]) => Promise<any>> = {};
+  const mockServer = {
+    registerTool: (name: string, _config: unknown, cb: (...args: any[]) => Promise<any>) => {
+      handlers[name] = cb;
+    },
+  } as any;
+
+  let bound: string | null = null;
+  function onAgentId(agentId: string): { commit: (resolvedName?: string) => void } {
+    if (bound !== null && bound !== agentId) {
+      throw new Error(`Session already bound to agent "${bound}", cannot use "${agentId}"`);
+    }
+    return {
+      commit: (resolvedName?: string) => { bound = resolvedName ?? agentId; },
+    };
+  }
+
+  registerMessagingTools(mockServer, svc, onAgentId, undefined, undefined, repos.agents);
+  return { db, svc, handlers };
+}
+
+describe("messaging_listen", () => {
+  it("returns messages immediately when unread exist", async () => {
+    const { db, svc, handlers } = setup();
+
+    await handlers.messaging_register!({ agent_id: "alice" });
+    svc.register("bob");
+    await handlers.messaging_create_channel!({ agent_id: "alice", name: "general" });
+    await handlers.messaging_subscribe!({ agent_id: "alice", channel: "general" });
+    svc.subscribe("bob", "general");
+    svc.send("bob", "general", "hello alice");
+
+    const result = await handlers.messaging_listen!({ agent_id: "alice", timeout_ms: 5000 });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.timed_out).toBe(false);
+    expect(parsed.channels.length).toBeGreaterThan(0);
+    expect(parsed.channels[0].channel).toBe("general");
+    expect(parsed.channels[0].messages[0].content).toBe("hello alice");
+
+    db.close();
+  }, 10000);
+
+  it("times out when no messages", async () => {
+    const { db, handlers } = setup();
+
+    await handlers.messaging_register!({ agent_id: "alice" });
+    await handlers.messaging_create_channel!({ agent_id: "alice", name: "quiet" });
+    await handlers.messaging_subscribe!({ agent_id: "alice", channel: "quiet" });
+
+    const start = performance.now();
+    const result = await handlers.messaging_listen!({ agent_id: "alice", timeout_ms: 1500 });
+    const elapsed = performance.now() - start;
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.timed_out).toBe(true);
+    expect(parsed.channels).toEqual([]);
+    expect(elapsed).toBeGreaterThanOrEqual(1000);
+
+    db.close();
+  }, 10000);
+
+  it("clamps timeout_ms below 1000 to 1000", async () => {
+    const { db, handlers } = setup();
+
+    await handlers.messaging_register!({ agent_id: "alice" });
+    await handlers.messaging_create_channel!({ agent_id: "alice", name: "quiet2" });
+    await handlers.messaging_subscribe!({ agent_id: "alice", channel: "quiet2" });
+
+    const start = performance.now();
+    const result = await handlers.messaging_listen!({ agent_id: "alice", timeout_ms: 100 });
+    const elapsed = performance.now() - start;
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.timed_out).toBe(true);
+    expect(elapsed).toBeGreaterThanOrEqual(900);
+
+    db.close();
+  }, 10000);
+
+  it("requires agent registration", async () => {
+    const { db, handlers } = setup();
+
+    let threw = false;
+    try {
+      await handlers.messaging_listen!({ agent_id: "unregistered", timeout_ms: 1500 });
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(true);
+    db.close();
+  });
+});


### PR DESCRIPTION
## Summary

`messaging_listen` blocking pull mode. Second of three stacked PRs (depends on PR A).

Adds non-push delivery support for MCP clients that don't surface push notifications as conversation tags (Codex, Gemini CLI, OpenCode, local-model clients).

**Core:** `MessagingService.readAllUnread(agentId)` walks every cursor for the agent and returns inline messages per channel. Cursor is advanced by `readForward`; each call is idempotent and serves the read-once semantics.

**MCP transport:** `messaging_listen` tool blocks up to `timeout_ms` (default 10000, max 30000). On wake it returns `{ channels, timed_out }` where each channel entry includes its messages inline — no follow-up `messaging_read_messages` call required. Heartbeat-or-reclaim runs at the start of each listen so listening agents stay live even when there's no incoming traffic.

## Stacked PRs

- **A:** `feat/persistent-agent-profiles` → `main`
- **B (this):** `feature/messaging-listen` → `feat/persistent-agent-profiles`
- **C:** `feat/safety-rails-only` → `feature/messaging-listen`

Merge A before this. After A merges, GitHub auto-retargets this PR to `main`.

## Test plan

- [ ] `bun test` passes
- [ ] `bunx tsc --noEmit` clean
- [ ] Core `readAllUnread` coverage (`tests/hex/core/listen.test.ts`)
- [ ] MCP `messaging_listen` tool handler tests (`tests/messaging/listen.test.ts`)
