### PR TITLE
feat: per-channel safety rails + non-push delivery contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ octo-santa takes the collaboration path. Instead of making one agent smarter, it
 - **Brain** — a knowledge layer that makes agents into domain experts. Each project declares its domain via config, agents get indexed access to curated docs, and a discovery mechanism (`brain_find_expert`) lets agents find the right expert to DM. Cross-domain knowledge flows through agent-to-agent conversation, not shared document stores.
 - **Per-domain config** (`.octo-santa/config.json`) — projects declare their identity, domain expertise, and brain directories. The agent's role in the network is defined by the repo it lives in.
 - **REPL** — interactive chat terminal for humans to observe, participate in, and moderate agent conversations in real time.
+- **Safety rails** — per-channel hop counter (default 50 agent messages before block), self-mention guard, `_system` block notifications, and human-only `/continue` REPL command. Prevents runaway agent loops; humans control resumption.
+- **Persistent agent profiles** — YAML profile store at `~/.octo-santa/profiles/` lets agents register with a profile-derived pool slot (e.g. `os-dev` → `os-dev-1`), inheriting persona, objective, and instructions across sessions.
+- **`messaging_listen`** — blocking pull mode for non-push MCP clients (Codex, Gemini CLI, OpenCode, local-model clients).
 
 **Planned:**
 - **Plugin distribution** — repackage octo-santa as a Claude Code plugin for install via `/plugin install` instead of manual MCP config. Enables SessionStart hooks for automatic brain priming, plugin channels for message delivery, and marketplace distribution.
@@ -95,15 +98,17 @@ Push and poll are fully compatible — agents using either mode can communicate 
 | Tool | Description |
 |------|-------------|
 | `messaging_register` | Register an agent with a unique name |
-| `messaging_create_channel` | Create a named channel |
+| `messaging_create_channel` | Create a named channel (optional `max_hops` override, default 50, max 50) |
 | `messaging_subscribe` | Subscribe to an existing channel for notifications |
-| `messaging_send_message` | Send a message to an existing channel |
+| `messaging_send_message` | Send a message to an existing channel (subject to per-channel hop limit) |
 | `messaging_read_messages` | Read unread messages with cursor tracking |
 | `messaging_direct_message` | Send a DM — creates channel and subscribes both parties |
+| `messaging_listen` | Block and wait for new messages across subscribed channels (non-push fallback, max 30s) |
 | `messaging_list_channels` | List all channels |
 | `messaging_list_agents` | List agents (active by default) |
 | `messaging_list_members` | List channel members with active/inactive status |
 | `messaging_rename_channel` | Rename a channel (members only) |
+| `messaging_get_instructions` | Re-read profile instructions and universal messaging guidance |
 
 ### Brain
 
@@ -161,6 +166,16 @@ Docs in `~/.octo-santa/brain/` are accessible to all agents across all repos via
 ### Cross-domain queries
 
 The cross-domain flow: discover an expert with `brain_find_expert`, then DM them with `messaging_direct_message`. The expert agent reads its brain docs and answers. No cross-domain brain access — the agent IS the query interface.
+
+## Safety Rails
+
+Per-channel hop counter prevents runaway agent loops. Each channel has a `max_hops` limit (default **50**). Every agent-sourced message increments the counter; when it reaches the limit, sends are blocked and a `_system` notice is posted to the channel announcing the block.
+
+- **Default:** 50 agent messages per channel before block. Override via `messaging_create_channel`'s `max_hops` argument (range 1–50; lower = stricter loop guard).
+- **Reset:** any message sent with the `human: true` flag (REPL-only) resets the counter to 0.
+- **Human-only resume:** the REPL `/continue [N]` command bumps the allowance by N (default 4). This is **not** an MCP tool — agents cannot invoke it. Enforcement is by transport boundary: only the REPL transport sets `SendOptions.human` and only the REPL surfaces `/continue`.
+- **Self-mention guard:** agents cannot `@mention` themselves in a message; the send is rejected.
+- **Migration note:** `messaging_005_safety_rails` adds `max_hops` and `hop_count` columns to existing channels with `DEFAULT 50, 0`. No action required on upgrade — pre-existing channels gain the default limit transparently.
 
 ## REPL
 

--- a/docs/repl.md
+++ b/docs/repl.md
@@ -36,6 +36,7 @@ Type a slash command at the prompt and press Enter.
 | `/history [N]` | Show last N messages (default 20) |
 | `/send -f <path>` | Send a file's contents as a message |
 | `/members` | List members of the current channel |
+| `/continue [N]` | Resume a hop-limited channel by bumping the allowance by N (default 4). Human-only — not exposed to agents. |
 | `/help` | Show command help |
 | `/quit` | Exit the REPL |
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "octo-santa",
   "description": "Local-first agent collaboration framework — messaging, channels, and an interactive REPL, all backed by SQLite",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "module": "src/main.ts",
   "type": "module",
   "scripts": {

--- a/scripts/smoke-non-push.ts
+++ b/scripts/smoke-non-push.ts
@@ -1,0 +1,189 @@
+// scripts/smoke-non-push.ts
+//
+// Non-push MCP client smoke test (Phase 1 success criterion #4).
+//
+// Spawns two real MCP stdio server processes (sharing a temp SQLite DB) and
+// drives them as if from a non-push client — using messaging_listen in place
+// of pushed <channel> tags. Verifies the inline-delivery listen-poll flow:
+//
+//   1. register as os-listen-tester
+//   2. subscribe to a test channel
+//   3. messaging_listen (5s timeout) with no traffic  → timed_out: true
+//   4. second process sends a message to the channel
+//   5. messaging_listen again                          → channels non-empty,
+//      messages arrive inline under channels[].messages (no follow-up
+//      messaging_read_messages needed). A subsequent messaging_listen
+//      times out, proving the cursor advanced and the same batch is not
+//      re-served.
+//
+// Run: bun run scripts/smoke-non-push.ts
+// Exit code 0 on success, 1 on failure.
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import pkg from "../package.json";
+
+function log(step: string, msg: string): void {
+  console.log(`[${step}] ${msg}`);
+}
+
+async function connect(clientName: string, dbPath: string): Promise<Client> {
+  const transport = new StdioClientTransport({
+    command: "bun",
+    args: ["run", "src/main.ts"],
+    env: {
+      ...(process.env as Record<string, string>),
+      OCTO_SANTA_DB: dbPath,
+    },
+  });
+  const client = new Client(
+    { name: clientName, version: "0.0.0-smoke" },
+    { capabilities: {} }
+  );
+  await client.connect(transport);
+  return client;
+}
+
+async function callJson<T = unknown>(
+  client: Client,
+  name: string,
+  args: Record<string, unknown>
+): Promise<T> {
+  const res = await client.callTool({ name, arguments: args });
+  const content = res.content as Array<{ type: string; text?: string }> | undefined;
+  const text = content?.[0]?.text ?? "{}";
+  if (res.isError) {
+    throw new Error(`${name} tool error: ${text}`);
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch (err) {
+    throw new Error(`${name} response not JSON: ${text.slice(0, 200)}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const tmp = mkdtempSync(join(tmpdir(), "octo-santa-smoke-"));
+  const dbPath = join(tmp, "messages.db");
+  log("version", `octo-santa ${pkg.version} (db: ${dbPath})`);
+
+  let tester: Client | null = null;
+  let sender: Client | null = null;
+  try {
+    tester = await connect("smoke-tester", dbPath);
+    sender = await connect("smoke-sender", dbPath);
+
+    // Confirm the server instructions text advertises the non-push loop.
+    const instr = tester.getInstructions() ?? "";
+    const bytes = Buffer.byteLength(instr, "utf-8");
+    if (!instr.includes("NON-PUSH CLIENTS")) {
+      throw new Error(
+        `instructions missing NON-PUSH CLIENTS block (got ${bytes} B)`
+      );
+    }
+    log("instructions", `${bytes} B, NON-PUSH CLIENTS block present`);
+
+    // Step 1: register
+    const reg = await callJson<{ registeredName: string }>(
+      tester,
+      "messaging_register",
+      { agent_id: "os-listen-tester" }
+    );
+    log("step1", `registered as ${reg.registeredName}`);
+
+    await callJson(sender, "messaging_register", { agent_id: "os-listen-sender" });
+
+    // Step 2: subscribe to test channel (sender creates, tester subscribes)
+    await callJson(sender, "messaging_create_channel", {
+      agent_id: "os-listen-sender",
+      name: "smoke-listen",
+    });
+    await callJson(tester, "messaging_subscribe", {
+      agent_id: "os-listen-tester",
+      channel: "smoke-listen",
+    });
+    log("step2", "subscribed os-listen-tester to smoke-listen");
+
+    // Step 3: listen with no traffic → timed_out
+    const t0 = Date.now();
+    const idle = await callJson<{ channels: unknown[]; timed_out: boolean }>(
+      tester,
+      "messaging_listen",
+      { agent_id: "os-listen-tester", timeout_ms: 5000 }
+    );
+    const idleDt = Date.now() - t0;
+    if (!idle.timed_out || idle.channels.length !== 0) {
+      throw new Error(
+        `step3 expected timed_out:true, channels:[]; got ${JSON.stringify(idle)}`
+      );
+    }
+    log("step3", `listen timed out after ${idleDt}ms, channels=[]`);
+
+    // Step 4: sender sends a message to the channel
+    const sent = await callJson<{ id: number }>(sender, "messaging_send_message", {
+      agent_id: "os-listen-sender",
+      channel: "smoke-listen",
+      content: "hello from non-push smoke test @os-listen-tester",
+    });
+    log("step4", `sender posted message id=${sent.id}`);
+
+    // Step 5a: listen again → channel entry with the message INLINE (no
+    // separate messaging_read_messages call needed; that is the steady-state
+    // non-push contract after os-pm's decision A on msg 1807).
+    const t1 = Date.now();
+    const hit = await callJson<{
+      channels: Array<{ channel: string; messages: Array<{ id: number; content: string }> }>;
+      timed_out: boolean;
+    }>(tester, "messaging_listen", { agent_id: "os-listen-tester", timeout_ms: 5000 });
+    const hitDt = Date.now() - t1;
+    const smoke = hit.channels.find((c) => c.channel === "smoke-listen");
+    if (hit.timed_out || !smoke) {
+      throw new Error(
+        `step5 expected smoke-listen in channels; got ${JSON.stringify(hit)}`
+      );
+    }
+    const inline = smoke.messages ?? [];
+    if (inline.length === 0 || inline[0]!.id !== sent.id) {
+      throw new Error(
+        `step5 expected inline message id=${sent.id}; got ${JSON.stringify(inline)}`
+      );
+    }
+    log(
+      "step5a",
+      `listen returned after ${hitDt}ms: inline ${inline.length} message(s) on smoke-listen (id=${inline[0]!.id})`
+    );
+
+    // Step 5b: cursor-advance proof — subsequent listen must time out because
+    // the previous listen already consumed the unread batch.
+    const t2 = Date.now();
+    const drained = await callJson<{ channels: unknown[]; timed_out: boolean }>(
+      tester,
+      "messaging_listen",
+      { agent_id: "os-listen-tester", timeout_ms: 3000 }
+    );
+    const drainDt = Date.now() - t2;
+    if (!drained.timed_out || drained.channels.length !== 0) {
+      throw new Error(
+        `step5b expected timed_out:true, channels:[] (cursor should have advanced); got ${JSON.stringify(drained)}`
+      );
+    }
+    log(
+      "step5b",
+      `cursor proof: follow-up listen timed out after ${drainDt}ms (inline batch not re-served)`
+    );
+
+    console.log("\n✓ non-push smoke test passed — Phase 1 criterion #4 verified");
+  } finally {
+    await tester?.close().catch(() => {});
+    await sender?.close().catch(() => {});
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+main().catch((err) => {
+  console.error("✗ non-push smoke test failed:", err);
+  process.exit(1);
+});

--- a/src/core/messaging/service.ts
+++ b/src/core/messaging/service.ts
@@ -12,6 +12,8 @@ import type {
   Message,
   ReadOptions,
   UnreadResult,
+  SendOptions,
+  ContinueResult,
 } from "./types";
 import type { RegisterResult, AutoJoinResult } from "../profiles/types";
 import {
@@ -180,10 +182,13 @@ export class MessagingService {
     this.agents.clearPid(agentId, this.pid);
   }
 
-  createChannel(agentId: string, name: string): Channel {
+  createChannel(agentId: string, name: string, maxHops?: number): Channel {
     if (!name.trim()) throw new Error("channel name must not be empty");
+    if (maxHops !== undefined && maxHops < 1) {
+      throw new Error("maxHops must be at least 1");
+    }
     this.requireRegistered(agentId);
-    return this.channels.create(name, agentId);
+    return this.channels.create(name, agentId, maxHops);
   }
 
   subscribe(agentId: string, channelName: string): void {
@@ -194,7 +199,7 @@ export class MessagingService {
     this.channels.addMember(agentId, channel.id, 0);
   }
 
-  send(agentId: string, channelName: string, content: string): Message {
+  send(agentId: string, channelName: string, content: string, options?: SendOptions): Message {
     if (!content.trim()) throw new Error("message content must not be empty");
     this.requireRegistered(agentId);
     assertDmAccess(channelName, agentId);
@@ -207,6 +212,26 @@ export class MessagingService {
     const allAgents = this.agents.listAll();
     const validIds = allAgents.map((a) => a.id);
     const mentions = extractMentions(content, validIds, this.profiles?.getBaseNames());
+    if (mentions.includes(agentId)) throw new Error("Cannot @mention yourself in a message");
+
+    // Hop counter logic
+    if (options?.human) {
+      this.channels.resetHopCount(channel.id);
+    } else {
+      const hop = this.channels.checkAndIncrementHop(channel.id);
+      if (!hop.allowed) {
+        if (!this.hasRecentHopNotice(channel.id)) {
+          this.sendSystemNotice(
+            channel,
+            `hop limit reached (${hop.hopCount}/${hop.maxHops}) in #${channelName} -- message from @${agentId} blocked. Waiting for human input.`
+          );
+        }
+        throw new Error(
+          `Hop limit reached (${hop.hopCount}/${hop.maxHops}) in #${channelName}. Message dropped. Only a human can /continue.`
+        );
+      }
+    }
+
     const message = this.messages.insertAndJoinSender(
       channel.id,
       agentId,
@@ -310,6 +335,22 @@ export class MessagingService {
     const allAgents = this.agents.listAll();
     const validIds = allAgents.map((a) => a.id);
     const mentions = extractMentions(content, validIds, this.profiles?.getBaseNames());
+    if (mentions.includes(agentId)) throw new Error("Cannot @mention yourself in a message");
+
+    // Hop counter logic for DMs (always agent, no human option)
+    const hopResult = this.channels.checkAndIncrementHop(channel.id);
+    if (!hopResult.allowed) {
+      if (!this.hasRecentHopNotice(channel.id)) {
+        this.sendSystemNotice(
+          channel,
+          `hop limit reached (${hopResult.hopCount}/${hopResult.maxHops}) in #${channelName} -- message from @${agentId} blocked. Waiting for human input.`
+        );
+      }
+      throw new Error(
+        `Hop limit reached (${hopResult.hopCount}/${hopResult.maxHops}) in #${channelName}. Message dropped. Only a human can /continue.`
+      );
+    }
+
     const message = this.messages.insertAndJoinSender(
       channel.id,
       agentId,
@@ -329,6 +370,56 @@ export class MessagingService {
     }
 
     return message;
+  }
+
+  /**
+   * Best-effort dedup for hop-limit `_system` notices.
+   *
+   * **Race window accepted by design.** This read sits OUTSIDE the
+   * checkAndIncrementHop transaction, so under concurrent multi-agent load
+   * (N processes hitting the limit simultaneously) up to N duplicate notices
+   * may be emitted. That is the intended trade-off:
+   *
+   *   (a) The dedup-inside-txn alternative would serialize the increment hot
+   *       path. Hop checks happen on every send; serializing them under load
+   *       is a correctness win for dedup but a throughput cliff for messaging.
+   *   (b) Downstream consumers (REPL display, future Slack mirror, audit log)
+   *       must already tolerate duplicate messages from at-least-once delivery
+   *       semantics — duplicate hop notices are a strict subset of that
+   *       tolerance requirement.
+   *   (c) Noise is bounded: max(duplicates) === count(concurrent listening
+   *       processes hitting the limit at the same instant). Once the limit is
+   *       hit, subsequent sends are blocked and stop emitting notices, so the
+   *       fan-out self-resolves within one increment cycle.
+   *
+   * If the empirical fan-out is ever observed > ~3 duplicates in production,
+   * revisit by either (i) moving dedup into the increment transaction, or
+   * (ii) adding an INSERT … WHERE NOT EXISTS guard at the storage layer.
+   */
+  private hasRecentHopNotice(channelId: number): boolean {
+    const recent = this.messages.readRecent(channelId, 1);
+    return recent.length > 0
+      && recent[0]!.agent_id === '_system'
+      && recent[0]!.content.startsWith('hop limit reached');
+  }
+
+  private sendSystemNotice(channel: Channel, content: string): void {
+    const message = this.messages.insertAndJoinSender(channel.id, '_system', content, ['*']);
+
+    if (this.dispatch) {
+      const members = this.channels.getMembers(channel.id);
+      const targetAgents = members.map((m) => m.id).filter((id) => id !== '_system');
+      if (targetAgents.length > 0) {
+        this.dispatch.dispatch({
+          channelName: channel.name,
+          sender: '_system',
+          content,
+          messageId: message.id,
+          isDm: isDmChannel(channel.name),
+          targetAgents,
+        });
+      }
+    }
   }
 
   renameChannel(
@@ -395,6 +486,37 @@ export class MessagingService {
         instructions: agent.instructions,
       },
     };
+  }
+
+  /**
+   * Bump a channel's hop allowance to resume after a hop-limit block.
+   *
+   * **Human-only / transport-restricted.** This method MUST only be invoked
+   * from a transport that enforces the human-source invariant by construction.
+   * The REPL `/continue` command is the canonical surface; the future `ocs
+   * continue` CLI subcommand will be the second.
+   *
+   * Do NOT expose this method via any MCP tool, RPC endpoint, HTTP handler, or
+   * other agent-callable interface. Agents bypassing this restriction would
+   * defeat the safety-rails design — they could indefinitely extend their own
+   * hop budget. The original `messaging_continue` MCP tool was removed for
+   * exactly this reason; see `tests/hex/transports/no-messaging-continue-tool.test.ts`
+   * and `tests/hex/core/continue-channel-transport-boundary.test.ts` for the
+   * regression guards.
+   *
+   * Enforcement is by transport boundary, not by code-level role check. Adding
+   * a check here is impractical — the core has no concept of "human" beyond the
+   * `SendOptions.human` flag, which is itself transport-set. The contract is:
+   * if you wire a new transport, you are responsible for ensuring this method
+   * is invoked only from a human-driven code path.
+   */
+  continueChannel(agentId: string, channelName: string, amount: number = 4): ContinueResult {
+    this.requireRegistered(agentId);
+    if (amount < 1) throw new Error("amount must be at least 1");
+    const channel = this.channels.findByName(channelName);
+    if (!channel) throw new Error(`Channel "${channelName}" not found`);
+    const result = this.channels.bumpHopAllowance(channel.id, amount);
+    return { channel: channelName, hopCount: result.hopCount, maxHops: result.maxHops, bumped: amount };
   }
 
   readRecent(channelId: number, limit: number): Message[] {

--- a/src/core/messaging/types.ts
+++ b/src/core/messaging/types.ts
@@ -16,6 +16,25 @@ export interface Channel {
   name: string;
   created_by: string;
   created_at: number;
+  max_hops: number;
+  hop_count: number;
+}
+
+export interface HopCheckResult {
+  allowed: boolean;
+  hopCount: number;
+  maxHops: number;
+}
+
+export interface SendOptions {
+  human?: boolean;
+}
+
+export interface ContinueResult {
+  channel: string;
+  hopCount: number;
+  maxHops: number;
+  bumped: number;
 }
 
 export interface Message {

--- a/src/core/ports.ts
+++ b/src/core/ports.ts
@@ -5,6 +5,7 @@ import type {
   Message,
   CursorWithChannel,
   HeartbeatResult,
+  HopCheckResult,
 } from "./messaging/types";
 import type { BrainDoc, DomainWithClaims } from "./brain/types";
 import type { AgentProfile } from "./profiles/types";
@@ -36,7 +37,7 @@ export interface ProfileRepository {
 
 export interface ChannelRepository {
   findByName(name: string): Channel | null;
-  create(name: string, createdBy: string): Channel;
+  create(name: string, createdBy: string, maxHops?: number): Channel;
   list(): Channel[];
   addMember(agentId: string, channelId: number, initialCursorId: number): void;
   getMembers(channelId: number): Agent[];
@@ -46,6 +47,9 @@ export interface ChannelRepository {
     newName: string,
     agentId: string
   ): Channel;
+  checkAndIncrementHop(channelId: number): HopCheckResult;
+  resetHopCount(channelId: number): void;
+  bumpHopAllowance(channelId: number, amount: number): HopCheckResult;
 }
 
 export interface MessageRepository {

--- a/src/storage/sqlite/channel-repo.ts
+++ b/src/storage/sqlite/channel-repo.ts
@@ -1,6 +1,6 @@
 import type { Database } from "bun:sqlite";
 import type { ChannelRepository } from "../../core/ports";
-import type { Agent, Channel } from "../../core/messaging/types";
+import type { Agent, Channel, HopCheckResult } from "../../core/messaging/types";
 import { withRetrySync } from "./db";
 
 export class SqliteChannelRepo implements ChannelRepository {
@@ -10,13 +10,21 @@ export class SqliteChannelRepo implements ChannelRepository {
     return (this.db.query("SELECT * FROM channels WHERE name = ?").get(name) as Channel) ?? null;
   }
 
-  create(name: string, createdBy: string): Channel {
+  create(name: string, createdBy: string, maxHops?: number): Channel {
     return withRetrySync(() => {
-      this.db.run(
-        `INSERT INTO channels (name, created_by, created_at) VALUES (?, ?, ?)
-         ON CONFLICT(name) DO NOTHING`,
-        [name, createdBy, Date.now()]
-      );
+      if (maxHops !== undefined) {
+        this.db.run(
+          `INSERT INTO channels (name, created_by, created_at, max_hops) VALUES (?, ?, ?, ?)
+           ON CONFLICT(name) DO NOTHING`,
+          [name, createdBy, Date.now(), maxHops]
+        );
+      } else {
+        this.db.run(
+          `INSERT INTO channels (name, created_by, created_at) VALUES (?, ?, ?)
+           ON CONFLICT(name) DO NOTHING`,
+          [name, createdBy, Date.now()]
+        );
+      }
       return this.findByName(name) as Channel;
     });
   }
@@ -51,6 +59,33 @@ export class SqliteChannelRepo implements ChannelRepository {
       .query("SELECT COUNT(*) as count FROM cursors WHERE channel_id = ?")
       .get(channelId) as { count: number };
     return row.count;
+  }
+
+  checkAndIncrementHop(channelId: number): HopCheckResult {
+    const doCheck = this.db.transaction(() => {
+      const row = this.db.query("SELECT hop_count, max_hops FROM channels WHERE id = ?").get(channelId) as { hop_count: number; max_hops: number };
+      if (row.hop_count < row.max_hops) {
+        this.db.run("UPDATE channels SET hop_count = hop_count + 1 WHERE id = ?", [channelId]);
+        return { allowed: true, hopCount: row.hop_count + 1, maxHops: row.max_hops };
+      }
+      return { allowed: false, hopCount: row.hop_count, maxHops: row.max_hops };
+    });
+    return withRetrySync(() => doCheck.immediate());
+  }
+
+  resetHopCount(channelId: number): void {
+    withRetrySync(() => {
+      this.db.run("UPDATE channels SET hop_count = 0 WHERE id = ?", [channelId]);
+    });
+  }
+
+  bumpHopAllowance(channelId: number, amount: number): HopCheckResult {
+    const doBump = this.db.transaction(() => {
+      this.db.run("UPDATE channels SET hop_count = MAX(0, hop_count - ?) WHERE id = ?", [amount, channelId]);
+      const row = this.db.query("SELECT hop_count, max_hops FROM channels WHERE id = ?").get(channelId) as { hop_count: number; max_hops: number };
+      return { allowed: row.hop_count < row.max_hops, hopCount: row.hop_count, maxHops: row.max_hops };
+    });
+    return withRetrySync(() => doBump.immediate());
   }
 
   renameWithAnnouncement(channelId: number, newName: string, agentId: string): Channel {

--- a/src/storage/sqlite/migrations.ts
+++ b/src/storage/sqlite/migrations.ts
@@ -149,6 +149,13 @@ const messagingMigrations: Migration[] = [
       ALTER TABLE agents ADD COLUMN instructions TEXT;
     `,
   },
+  {
+    name: "messaging_005_safety_rails",
+    up: `
+      ALTER TABLE channels ADD COLUMN max_hops INTEGER NOT NULL DEFAULT 50;
+      ALTER TABLE channels ADD COLUMN hop_count INTEGER NOT NULL DEFAULT 0;
+    `,
+  },
 ];
 
 const brainMigrations: Migration[] = [

--- a/src/transports/mcp-stdio/adapter.ts
+++ b/src/transports/mcp-stdio/adapter.ts
@@ -69,6 +69,27 @@ export function buildInstructions(
   }
   instructions += brainSuffix;
 
+  // NON-PUSH CLIENTS block is appended AFTER the brain section intentionally.
+  // Claude Code truncates server instructions at 2KB. End-of-doc placement means
+  // that if truncation clips anything, it clips this tail — which Claude Code
+  // (a push-tag client) does not need. Non-push clients (Codex, Gemini CLI,
+  // OpenCode, most local-model clients) have no 2KB limit and receive the
+  // full block. Phase 0c will restructure this and reclaim budget.
+  instructions +=
+    "\n\nNON-PUSH CLIENTS: This section overrides the BOUNDARIES prohibition on " +
+    "polling loops — for messaging_listen only. If your MCP client does not " +
+    "deliver server notifications as pushed tags (Claude Code does; Codex, " +
+    "Gemini CLI, OpenCode, and most local-model clients do not), poll instead. " +
+    "After messaging_register and messaging_subscribe, loop:\n" +
+    "  result = messaging_listen(timeout_ms: 30000)\n" +
+    "  for each ch in result.channels: process ch.messages   # messages arrive inline\n" +
+    "  re-enter loop\n" +
+    "messaging_listen blocks until new messages arrive or the timeout elapses " +
+    "(default 10000 ms, max 30000 ms) and returns {channels, timed_out}. " +
+    "Each channel entry includes its messages inline -- no follow-up " +
+    "messaging_read_messages needed in the steady-state loop. " +
+    "Keep the loop running for the life of the agent.";
+
   return instructions;
 }
 
@@ -122,10 +143,11 @@ export function registerMessagingTools(
     inputSchema: {
       agent_id: z.string().trim().min(1).describe("Your agent/project name"),
       name: z.string().trim().min(1).describe("Channel name"),
+      max_hops: z.number().int().min(1).max(50).optional().describe("Max consecutive agent messages before channel blocks (default 50; set lower for stricter loop guard, max 50)"),
     },
-  }, async ({ agent_id, name }) => {
+  }, async ({ agent_id, name, max_hops }) => {
     return withAgent(onAgentId, agent_id, () => {
-      const channel = messaging.createChannel(agent_id, name);
+      const channel = messaging.createChannel(agent_id, name, max_hops);
       return jsonResult(channel);
     });
   });
@@ -156,7 +178,7 @@ export function registerMessagingTools(
 
   server.registerTool("messaging_send_message", {
     description:
-      "Send a message to an existing channel. Requires prior messaging_register. Use @agent-name to notify specific agents, or @all to notify everyone. Messages without mentions are silent — recipients see them only when they check the channel.",
+      "Send a message to an existing channel. Requires prior messaging_register. Use @agent-name to notify specific agents, or @all to notify everyone. Messages without mentions are silent -- recipients see them only when they check the channel. Messages are subject to per-channel hop limits; blocked messages are dropped with a system notice.",
     inputSchema: {
       agent_id: z.string().trim().min(1).describe("Your agent/project name"),
       channel: z.string().trim().min(1).describe("Channel name"),
@@ -275,7 +297,7 @@ export function registerMessagingTools(
   });
 
   server.registerTool("messaging_listen", {
-    description: "Block and wait for new messages across all subscribed channels. Returns when messages arrive or timeout is reached. Use this for agent polling loops instead of repeatedly calling messaging_read_messages.",
+    description: "Block and wait for new messages across all subscribed channels. Returns `{channels, timed_out}` where each channel entry includes its messages inline — no follow-up messaging_read_messages needed in the steady-state poll loop. Use this for agent polling loops instead of repeatedly calling messaging_read_messages.",
     inputSchema: {
       agent_id: z.string().trim().min(1).describe("Your registered agent name"),
       timeout_ms: z.number().int().optional().describe("Max wait time in ms (default 10000, max 30000)"),

--- a/src/transports/repl/app.ts
+++ b/src/transports/repl/app.ts
@@ -119,7 +119,7 @@ export function startApp(opts: AppOptions): () => void {
 
         // Send message
         try {
-          svc.send(agentId, state.activeChannel, text);
+          svc.send(agentId, state.activeChannel, text, { human: true });
           // Local echo
           const formatted = formatMessage(
             { agent_id: agentId, content: text },

--- a/src/transports/repl/commands.ts
+++ b/src/transports/repl/commands.ts
@@ -24,7 +24,7 @@ export interface CommandResult {
 
 export const KNOWN_COMMANDS = new Set([
   "channels", "agents", "join", "create", "history",
-  "send", "members", "help", "quit",
+  "send", "members", "help", "quit", "continue",
 ]);
 
 export function parseCommand(input: string): ParsedCommand | null {
@@ -100,7 +100,7 @@ export function executeCommand(
       const filePath = match[1]!.trim();
       try {
         const content = readFileSync(filePath, "utf-8");
-        svc.send(state.agentId, state.activeChannel, content);
+        svc.send(state.agentId, state.activeChannel, content, { human: true });
         return {
           output: [],
           localEcho: { agent_id: state.agentId, content },
@@ -116,6 +116,13 @@ export function executeCommand(
       return { output: members.map(m => `  ${m.agent_id} ${m.active ? "(active)" : "(inactive)"}`) };
     }
 
+    case "continue": {
+      let amount = parseInt(cmd.args, 10);
+      if (!Number.isFinite(amount) || amount <= 0) amount = 4;
+      const result = svc.continueChannel(state.agentId, state.activeChannel, amount);
+      return { output: [`Bumped ${state.activeChannel}: hop count ${result.hopCount}/${result.maxHops} (+${result.bumped})`] };
+    }
+
     case "help":
       return {
         output: [
@@ -127,6 +134,7 @@ export function executeCommand(
           "  /history [N]     — Show last N messages (default 20)",
           "  /send -f <path>  — Send file contents",
           "  /members         — List channel members",
+          "  /continue [N]    -- Resume hop-limited channel (+N hops, default 4)",
           "  /help            — Show this help",
           "  /quit            — Exit",
         ],

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -25,7 +25,8 @@ describe("concurrency", () => {
     const { db: setupDbRef, svc } = setup();
     // Subscribe verifier before workers run so cursor starts at 0 (sees all messages)
     svc.register("verifier");
-    svc.createChannel("verifier", "stress-test");
+    // Use a high maxHops so workers can send many messages without triggering hop limit
+    svc.createChannel("verifier", "stress-test", 1000);
     svc.subscribe("verifier", "stress-test");
     setupDbRef.close();
 

--- a/tests/hex/core/continue-channel-transport-boundary.test.ts
+++ b/tests/hex/core/continue-channel-transport-boundary.test.ts
@@ -1,0 +1,70 @@
+// tests/hex/core/continue-channel-transport-boundary.test.ts
+//
+// Transport-boundary regression guard for `MessagingService.continueChannel()`.
+//
+// `continueChannel()` is human-only by transport-restriction (see JSDoc on the
+// method in src/core/messaging/service.ts). The architectural invariant is
+// that no agent-callable transport (MCP, future RPC, future HTTP) is allowed
+// to invoke this method. Currently REPL `/continue` is the sole surface;
+// future `ocs continue` CLI will be the second.
+//
+// This test scans `src/transports/` for `.continueChannel(` references and
+// fails if any non-REPL transport invokes it. Adding the method to MCP, RPC,
+// or any other agent-driven path will fail here.
+
+import { describe, it, expect } from "bun:test";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "../../..");
+const TRANSPORTS_ROOT = join(REPO_ROOT, "src/transports");
+const ALLOWED_TRANSPORT_PREFIXES = [
+  "src/transports/repl/",
+  // Future: "src/transports/cli/" once `ocs continue` ships
+];
+
+function walkTsFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      walkTsFiles(full, acc);
+    } else if (entry.endsWith(".ts")) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+function findContinueChannelInvocations(): Array<{ file: string; lines: number[] }> {
+  const files = walkTsFiles(TRANSPORTS_ROOT);
+  const results: Array<{ file: string; lines: number[] }> = [];
+  for (const file of files) {
+    const content = readFileSync(file, "utf-8");
+    const lines = content.split("\n");
+    const matchedLines: number[] = [];
+    lines.forEach((line, idx) => {
+      if (/\.continueChannel\s*\(/.test(line)) {
+        matchedLines.push(idx + 1);
+      }
+    });
+    if (matchedLines.length > 0) {
+      results.push({ file: relative(REPO_ROOT, file), lines: matchedLines });
+    }
+  }
+  return results;
+}
+
+describe("continueChannel — transport-boundary discipline", () => {
+  it("is invoked only from REPL transport files", () => {
+    const invocations = findContinueChannelInvocations();
+    const violators = invocations.filter(
+      (inv) => !ALLOWED_TRANSPORT_PREFIXES.some((prefix) => inv.file.startsWith(prefix))
+    );
+    expect(violators).toEqual([]);
+  });
+
+  it("at least one transport actually calls continueChannel (sanity)", () => {
+    const invocations = findContinueChannelInvocations();
+    expect(invocations.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/hex/core/safety-rails-cross-process.test.ts
+++ b/tests/hex/core/safety-rails-cross-process.test.ts
@@ -1,0 +1,142 @@
+// tests/hex/core/safety-rails-cross-process.test.ts
+import { describe, it, expect, afterEach } from "bun:test";
+import { cleanupDb } from "../../helpers/db";
+import { createDb } from "../../../src/storage/sqlite/db";
+import { runMigrations, allMigrations } from "../../../src/storage/sqlite/migrations";
+import { createSqliteRepos } from "../../../src/storage/sqlite";
+import { MessagingService } from "../../../src/core/messaging/service";
+import { existsSync, unlinkSync } from "fs";
+
+const projectRoot = process.cwd();
+const TEST_DB = `/tmp/octo-santa-test-safety-rails-cross-process-${process.pid}.sqlite`;
+
+afterEach(() => {
+  cleanupDb(TEST_DB);
+});
+
+describe("hop counter atomicity across processes", () => {
+  it("two worker processes share hop counter via SQLite -- total messages capped at explicit max_hops=4", async () => {
+    // ── Setup: create channel with explicit max_hops=4 in main process ─────
+    {
+      const db = createDb(TEST_DB);
+      runMigrations(db, allMigrations);
+      const repos = createSqliteRepos(db);
+      const svc = new MessagingService(
+        repos.agents,
+        repos.channels,
+        repos.messages,
+        repos.cursors,
+        process.pid
+      );
+
+      svc.register("worker-a");
+      svc.register("worker-b");
+      svc.createChannel("worker-a", "hop-test", 4); // explicit max_hops=4 for this test
+      svc.subscribe("worker-a", "hop-test");
+      svc.subscribe("worker-b", "hop-test");
+
+      // Unregister so workers can re-register under their own PIDs
+      svc.unregister("worker-a");
+      svc.unregister("worker-b");
+      db.close();
+    }
+
+    // ── Worker script: tries to send 3 messages, handles hop limit gracefully ──
+    const makeWorkerScript = (agentId: string) => `
+      import { createDb } from "${projectRoot}/src/storage/sqlite/db";
+      import { runMigrations, allMigrations } from "${projectRoot}/src/storage/sqlite/migrations";
+      import { createSqliteRepos } from "${projectRoot}/src/storage/sqlite";
+      import { MessagingService } from "${projectRoot}/src/core/messaging/service";
+
+      const db = createDb("${TEST_DB}");
+      runMigrations(db, allMigrations);
+      const repos = createSqliteRepos(db);
+      const svc = new MessagingService(repos.agents, repos.channels, repos.messages, repos.cursors, process.pid);
+
+      svc.register("${agentId}");
+
+      let sent = 0;
+      for (let i = 0; i < 3; i++) {
+        try {
+          svc.send("${agentId}", "hop-test", "msg-${agentId}-" + i);
+          sent++;
+        } catch (e) {
+          // Hop limit reached -- expected
+          break;
+        }
+      }
+
+      db.close();
+      process.exit(0);
+    `;
+
+    const workerPathA = "/tmp/octo-santa-hop-worker-a.ts";
+    const workerPathB = "/tmp/octo-santa-hop-worker-b.ts";
+    await Bun.write(workerPathA, makeWorkerScript("worker-a"));
+    await Bun.write(workerPathB, makeWorkerScript("worker-b"));
+
+    // ── Spawn both workers concurrently ────────────────────────────────────
+    const workerA = Bun.spawn(["bun", "run", workerPathA], {
+      cwd: process.cwd(),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const workerB = Bun.spawn(["bun", "run", workerPathB], {
+      cwd: process.cwd(),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [exitA, exitB] = await Promise.all([workerA.exited, workerB.exited]);
+
+    if (exitA !== 0) {
+      const stderr = await new Response(workerA.stderr).text();
+      console.error(`Worker A failed (code ${exitA}): ${stderr}`);
+    }
+    if (exitB !== 0) {
+      const stderr = await new Response(workerB.stderr).text();
+      console.error(`Worker B failed (code ${exitB}): ${stderr}`);
+    }
+
+    expect(exitA).toBe(0);
+    expect(exitB).toBe(0);
+
+    // ── Verify: exactly 4 non-system messages and hop_count=4 ──────────────
+    const db2 = createDb(TEST_DB);
+    runMigrations(db2, allMigrations);
+
+    const channelRow = db2
+      .query<{ id: number; hop_count: number }, [string]>(
+        "SELECT id, hop_count FROM channels WHERE name = ?"
+      )
+      .get("hop-test");
+
+    expect(channelRow).not.toBeNull();
+    const channelId = channelRow!.id;
+
+    const userMessages = db2
+      .query<{ id: number; content: string; agent_id: string }, [number]>(
+        "SELECT id, content, agent_id FROM messages WHERE channel_id = ? AND agent_id != '_system' ORDER BY id"
+      )
+      .all(channelId);
+
+    // Exactly 4 messages got through (hop counter shared atomically)
+    expect(userMessages.length).toBe(4);
+
+    // hop_count is exactly 4 (at the limit)
+    expect(channelRow!.hop_count).toBe(4);
+
+    // Both workers contributed at least 1 message (not one process monopolised all 4)
+    const fromA = userMessages.filter((m) => m.agent_id === "worker-a").length;
+    const fromB = userMessages.filter((m) => m.agent_id === "worker-b").length;
+    expect(fromA).toBeGreaterThanOrEqual(1);
+    expect(fromB).toBeGreaterThanOrEqual(1);
+
+    db2.close();
+
+    // Cleanup temp worker files
+    for (const p of [workerPathA, workerPathB]) {
+      if (existsSync(p)) unlinkSync(p);
+    }
+  });
+});

--- a/tests/hex/core/safety-rails-integration.test.ts
+++ b/tests/hex/core/safety-rails-integration.test.ts
@@ -1,0 +1,231 @@
+// tests/hex/core/safety-rails-integration.test.ts
+//
+// Full lifecycle integration tests for safety rails: hop counter and
+// self-mention guard running against real SQLite.
+
+import { describe, it, expect, afterEach } from "bun:test";
+import { MessagingService } from "../../../src/core/messaging/service";
+import { createSqliteRepos } from "../../../src/storage/sqlite";
+import { createDb } from "../../../src/storage/sqlite/db";
+import { runMigrations, allMigrations } from "../../../src/storage/sqlite/migrations";
+import { cleanupDb } from "../../helpers/db";
+import type { Database } from "bun:sqlite";
+
+const TEST_DB = `/tmp/octo-santa-test-safety-integration-${process.pid}.sqlite`;
+
+function setup() {
+  cleanupDb(TEST_DB);
+  const db = createDb(TEST_DB);
+  runMigrations(db, allMigrations);
+  const repos = createSqliteRepos(db);
+  const svc = new MessagingService(
+    repos.agents,
+    repos.channels,
+    repos.messages,
+    repos.cursors,
+    process.pid
+  );
+  return { db, repos, svc };
+}
+
+afterEach(() => cleanupDb(TEST_DB));
+
+// ── Verification helpers ───────────────────────────────────────────────────
+
+function getHopCount(db: Database, channelName: string): number {
+  const row = db
+    .query<{ hop_count: number }, [string]>(
+      "SELECT hop_count FROM channels WHERE name = ?"
+    )
+    .get(channelName);
+  return row?.hop_count ?? -1;
+}
+
+function getMessages(db: Database, channelName: string) {
+  return db
+    .query<{ id: number; agent_id: string; content: string }, [string]>(
+      "SELECT m.id, m.agent_id, m.content FROM messages m JOIN channels c ON m.channel_id = c.id WHERE c.name = ? ORDER BY m.id"
+    )
+    .all(channelName);
+}
+
+// ── Test 1: Ping-pong full lifecycle ──────────────────────────────────────
+
+describe("safety rails integration - ping-pong lifecycle", () => {
+  it("two agents ping-pong until hop limit, /continue, then human reset", () => {
+    const { db, svc } = setup();
+
+    // Step 1: Create channel with explicit max_hops=4 (test the hop limit mechanism at a low value)
+    svc.register("agent-a");
+    svc.register("agent-b");
+    const channel = svc.createChannel("agent-a", "test-channel", 4);
+    svc.subscribe("agent-b", "test-channel");
+
+    // Step 2: Ping-pong to hop=4
+    svc.send("agent-a", "test-channel", "hop 1"); // hop 1
+    svc.send("agent-b", "test-channel", "hop 2"); // hop 2
+    svc.send("agent-a", "test-channel", "hop 3"); // hop 3
+    svc.send("agent-b", "test-channel", "hop 4"); // hop 4
+
+    expect(getHopCount(db, "test-channel")).toBe(4);
+
+    // Step 3: Agent A tries to send (hop 5) — blocked
+    expect(() => svc.send("agent-a", "test-channel", "hop 5 - should fail")).toThrow(
+      "Hop limit reached (4/4) in #test-channel. Message dropped. Only a human can /continue."
+    );
+
+    // Step 4: Verify _system message exists with hop limit text
+    const messages = getMessages(db, "test-channel");
+    const systemMsgs = messages.filter((m) => m.agent_id === "_system");
+    expect(systemMsgs.length).toBe(1);
+    expect(systemMsgs[0]!.content).toBe(
+      "hop limit reached (4/4) in #test-channel -- message from @agent-a blocked. Waiting for human input."
+    );
+
+    // Step 5: /continue +4 — hop_count decremented by 4
+    const continueResult = svc.continueChannel("agent-a", "test-channel", 4);
+    expect(continueResult.hopCount).toBe(0);
+    expect(continueResult.maxHops).toBe(4);
+    expect(continueResult.bumped).toBe(4);
+    expect(getHopCount(db, "test-channel")).toBe(0);
+
+    // Step 6: Agent A can send again after /continue
+    expect(() => svc.send("agent-a", "test-channel", "back in action")).not.toThrow();
+    expect(getHopCount(db, "test-channel")).toBe(1);
+
+    // Step 7: Human sends { human: true } → hop_count reset to 0
+    svc.send("agent-a", "test-channel", "a human speaks", { human: true });
+    expect(getHopCount(db, "test-channel")).toBe(0);
+
+    // Step 8: Verify all messages in correct order (hop1..hop4, _system, back-in-action, human)
+    const allMsgs = getMessages(db, "test-channel");
+    const agentMsgs = allMsgs.filter((m) => m.agent_id !== "_system");
+    expect(agentMsgs[0]!.content).toBe("hop 1");
+    expect(agentMsgs[0]!.agent_id).toBe("agent-a");
+    expect(agentMsgs[1]!.content).toBe("hop 2");
+    expect(agentMsgs[1]!.agent_id).toBe("agent-b");
+    expect(agentMsgs[2]!.content).toBe("hop 3");
+    expect(agentMsgs[2]!.agent_id).toBe("agent-a");
+    expect(agentMsgs[3]!.content).toBe("hop 4");
+    expect(agentMsgs[3]!.agent_id).toBe("agent-b");
+    expect(agentMsgs[4]!.content).toBe("back in action");
+    expect(agentMsgs[4]!.agent_id).toBe("agent-a");
+    expect(agentMsgs[5]!.content).toBe("a human speaks");
+    expect(agentMsgs[5]!.agent_id).toBe("agent-a");
+
+    // _system notice appears after hop 4 messages
+    const systemIdx = allMsgs.findIndex((m) => m.agent_id === "_system");
+    const hop4Idx = allMsgs.findIndex((m) => m.content === "hop 4");
+    const backIdx = allMsgs.findIndex((m) => m.content === "back in action");
+    expect(systemIdx).toBeGreaterThan(hop4Idx);
+    expect(backIdx).toBeGreaterThan(systemIdx);
+  });
+});
+
+// ── Test 2: Custom max_hops on channel creation ───────────────────────────
+
+describe("safety rails integration - custom max_hops", () => {
+  it("channel with maxHops=2 blocks on third send", () => {
+    const { db, svc } = setup();
+
+    // Step 1: Create channel with maxHops=2
+    svc.register("agent-a");
+    svc.createChannel("agent-a", "tight-channel", 2);
+
+    // Step 2: Agent sends twice — succeeds
+    expect(() => svc.send("agent-a", "tight-channel", "send 1")).not.toThrow();
+    expect(() => svc.send("agent-a", "tight-channel", "send 2")).not.toThrow();
+    expect(getHopCount(db, "tight-channel")).toBe(2);
+
+    // Step 3: Third send — blocked
+    expect(() => svc.send("agent-a", "tight-channel", "send 3")).toThrow(
+      "Hop limit reached (2/2) in #tight-channel. Message dropped. Only a human can /continue."
+    );
+
+    // Verify blocked message was NOT inserted
+    const msgs = getMessages(db, "tight-channel");
+    const agentMsgs = msgs.filter((m) => m.agent_id === "agent-a");
+    expect(agentMsgs.length).toBe(2);
+    expect(agentMsgs.some((m) => m.content === "send 3")).toBe(false);
+
+    // Verify _system notice was posted
+    const systemMsgs = msgs.filter((m) => m.agent_id === "_system");
+    expect(systemMsgs.length).toBe(1);
+    expect(systemMsgs[0]!.content).toBe(
+      "hop limit reached (2/2) in #tight-channel -- message from @agent-a blocked. Waiting for human input."
+    );
+  });
+});
+
+// ── Test 3: Self-mention blocked ──────────────────────────────────────────
+
+describe("safety rails integration - self-mention blocked", () => {
+  it("agent sends message containing @self - error thrown, no message inserted", () => {
+    const { db, svc } = setup();
+
+    // Step 1: Register agent and create channel
+    svc.register("agent-x");
+    svc.createChannel("agent-x", "self-mention-channel");
+
+    // Step 2: Agent sends message containing @self — error thrown
+    expect(() =>
+      svc.send("agent-x", "self-mention-channel", "hey @agent-x look at this")
+    ).toThrow("Cannot @mention yourself in a message");
+
+    // Step 3: Verify no message was inserted
+    const msgs = getMessages(db, "self-mention-channel");
+    expect(msgs.length).toBe(0);
+
+    // Hop count should also remain at 0 (self-mention check happens before hop increment)
+    expect(getHopCount(db, "self-mention-channel")).toBe(0);
+  });
+});
+
+// ── Test 4: DM hop counter ────────────────────────────────────────────────
+
+describe("safety rails integration - DM hop counter", () => {
+  it("two agents DM back and forth and hit explicit limit (channel pre-created with max_hops=4)", () => {
+    const { db, svc } = setup();
+
+    // Step 1: Register two agents
+    svc.register("dm-alice");
+    svc.register("dm-bob");
+
+    const dmName = ["dm-alice", "dm-bob"].sort().join(",");
+
+    // Pre-create DM channel with explicit max_hops=4 so the hop-limit mechanism
+    // can be exercised without sending 50 DMs. directMessage() will find this
+    // channel via ON CONFLICT DO NOTHING and use its existing limit.
+    svc.createChannel("dm-alice", dmName, 4);
+
+    // Step 2: Send 4 DMs alternating — should succeed
+    svc.directMessage("dm-alice", "dm-bob", "hello bob");   // hop 1
+    svc.directMessage("dm-bob", "dm-alice", "hello alice"); // hop 2
+    svc.directMessage("dm-alice", "dm-bob", "how are you"); // hop 3
+    svc.directMessage("dm-bob", "dm-alice", "doing well");  // hop 4
+
+    expect(getHopCount(db, dmName)).toBe(4);
+
+    // Step 3: Fifth DM hits the configured limit (4)
+    expect(() => svc.directMessage("dm-alice", "dm-bob", "one more")).toThrow(
+      `Hop limit reached (4/4) in #${dmName}. Message dropped. Only a human can /continue.`
+    );
+
+    // Verify _system notice was posted in the DM channel
+    const msgs = getMessages(db, dmName);
+    const systemMsgs = msgs.filter((m) => m.agent_id === "_system");
+    expect(systemMsgs.length).toBe(1);
+    expect(systemMsgs[0]!.content).toContain("hop limit reached (4/4)");
+    expect(systemMsgs[0]!.content).toContain("Waiting for human input.");
+
+    // Hop count stays at 4
+    expect(getHopCount(db, dmName)).toBe(4);
+
+    // /continue allows more DMs
+    svc.continueChannel("dm-alice", dmName, 4);
+    expect(getHopCount(db, dmName)).toBe(0);
+
+    expect(() => svc.directMessage("dm-alice", "dm-bob", "resumed")).not.toThrow();
+    expect(getHopCount(db, dmName)).toBe(1);
+  });
+});

--- a/tests/hex/core/safety-rails.test.ts
+++ b/tests/hex/core/safety-rails.test.ts
@@ -1,0 +1,478 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { MessagingService } from "../../../src/core/messaging/service";
+import { createSqliteRepos } from "../../../src/storage/sqlite";
+import { createDb } from "../../../src/storage/sqlite/db";
+import {
+  runMigrations,
+  allMigrations,
+} from "../../../src/storage/sqlite/migrations";
+import { cleanupDb } from "../../helpers/db";
+import type { ProfileRepository } from "../../../src/core/ports";
+import type { AgentProfile } from "../../../src/core/profiles/types";
+import type { Database } from "bun:sqlite";
+
+const TEST_DB = `/tmp/octo-santa-test-safety-rails-${process.pid}.sqlite`;
+
+// ── In-memory ProfileRepository ────────────────────────────────────────────
+
+class InMemoryProfileRepo implements ProfileRepository {
+  private profiles = new Map<string, AgentProfile>();
+
+  add(profile: AgentProfile): void {
+    this.profiles.set(profile.name, profile);
+  }
+
+  getProfile(baseName: string): AgentProfile | null {
+    return this.profiles.get(baseName) ?? null;
+  }
+
+  listProfiles(): AgentProfile[] {
+    return [...this.profiles.values()];
+  }
+
+  getBaseNames(): Set<string> {
+    return new Set(this.profiles.keys());
+  }
+}
+
+// ── Setup helper ───────────────────────────────────────────────────────────
+
+function setup(profileRepo?: ProfileRepository) {
+  cleanupDb(TEST_DB);
+  const db = createDb(TEST_DB);
+  runMigrations(db, allMigrations);
+  const repos = createSqliteRepos(db);
+  const svc = new MessagingService(
+    repos.agents,
+    repos.channels,
+    repos.messages,
+    repos.cursors,
+    process.pid,
+    undefined,
+    profileRepo
+  );
+  return { db, repos, svc };
+}
+
+afterEach(() => cleanupDb(TEST_DB));
+
+// ── Self-mention guard ─────────────────────────────────────────────────────
+
+describe("self-mention guard", () => {
+  it("send() with @self mention throws 'Cannot @mention yourself in a message'", () => {
+    const { svc } = setup();
+
+    svc.register("alice");
+    svc.createChannel("alice", "general");
+
+    expect(() => svc.send("alice", "general", "hey @alice check this out")).toThrow(
+      "Cannot @mention yourself in a message"
+    );
+  });
+
+  it("send() with @other-agent mention succeeds (not a self-mention)", () => {
+    const { svc } = setup();
+
+    svc.register("alice");
+    svc.register("bob");
+    svc.createChannel("alice", "general");
+
+    expect(() => svc.send("alice", "general", "hey @bob check this out")).not.toThrow();
+  });
+
+  it("send() with @pool-base-name mention by pool instance is NOT a self-mention", () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-dev",
+      persona: null,
+      objective: null,
+      instructions: null,
+      maxInstances: 3,
+      autoJoinChannels: [],
+    });
+
+    const { svc } = setup(profileRepo);
+
+    svc.register("admin");
+    svc.createChannel("admin", "general");
+
+    // Register pool instance (os-dev -> os-dev-1)
+    const r1 = svc.register("os-dev");
+    const instanceId = r1.registeredName; // "os-dev-1"
+    svc.subscribe(instanceId, "general");
+
+    // os-dev-1 sends @os-dev (pool base name) - should NOT be a self-mention
+    // because extractMentions stores "os-dev" (base name), not "os-dev-1" (instance)
+    expect(() =>
+      svc.send(instanceId, "general", "hey @os-dev all instances check this")
+    ).not.toThrow();
+  });
+
+  it("directMessage() with @self mention throws 'Cannot @mention yourself in a message'", () => {
+    const { svc } = setup();
+
+    svc.register("alice");
+    svc.register("bob");
+
+    expect(() =>
+      svc.directMessage("alice", "bob", "hey @alice I am talking to myself")
+    ).toThrow("Cannot @mention yourself in a message");
+  });
+});
+
+// ── Hop counter ────────────────────────────────────────────────────────────
+
+function getHopCount(db: Database, channelName: string): number {
+  const row = db
+    .query<{ hop_count: number }, [string]>(
+      "SELECT hop_count FROM channels WHERE name = ?"
+    )
+    .get(channelName);
+  return row?.hop_count ?? -1;
+}
+
+function countMessages(db: Database, channelId: number): number {
+  const row = db
+    .query<{ cnt: number }, [number]>(
+      "SELECT COUNT(*) as cnt FROM messages WHERE channel_id = ?"
+    )
+    .get(channelId);
+  return row?.cnt ?? 0;
+}
+
+function getSystemMessages(db: Database, channelId: number) {
+  return db
+    .query<{ id: number; content: string }, [number]>(
+      "SELECT id, content FROM messages WHERE channel_id = ? AND agent_id = '_system'"
+    )
+    .all(channelId);
+}
+
+describe("hop counter", () => {
+  it("agent message increments hop counter from 0 to 1", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    const channel = svc.createChannel("alice", "general");
+
+    expect(getHopCount(db, "general")).toBe(0);
+
+    svc.send("alice", "general", "hello");
+
+    expect(getHopCount(db, "general")).toBe(1);
+  });
+
+  it("agent message at limit (4/4) throws hop limit error and message NOT inserted", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    // Create channel with maxHops=4
+    const channel = svc.createChannel("alice", "general", 4);
+    // Send 4 messages to hit the limit
+    svc.send("alice", "general", "msg 1");
+    svc.send("alice", "general", "msg 2");
+    svc.send("alice", "general", "msg 3");
+    svc.send("alice", "general", "msg 4");
+
+    expect(getHopCount(db, "general")).toBe(4);
+
+    // The 5th send should be blocked
+    expect(() => svc.send("alice", "general", "msg 5")).toThrow(
+      "Hop limit reached (4/4) in #general. Message dropped. Only a human can /continue."
+    );
+
+    // Blocked message was NOT inserted
+    const rows = db
+      .query<{ content: string }, [number]>(
+        "SELECT content FROM messages WHERE channel_id = ? AND agent_id = 'alice'"
+      )
+      .all(channel.id);
+    expect(rows.some((r) => r.content === "msg 5")).toBe(false);
+  });
+
+  it("agent message at limit posts _system notice with blocked message info", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    const channel = svc.createChannel("alice", "general", 4);
+    svc.send("alice", "general", "msg 1");
+    svc.send("alice", "general", "msg 2");
+    svc.send("alice", "general", "msg 3");
+    svc.send("alice", "general", "msg 4");
+
+    expect(() => svc.send("alice", "general", "msg 5")).toThrow();
+
+    const notices = getSystemMessages(db, channel.id);
+    expect(notices.length).toBe(1);
+    expect(notices[0]!.content).toBe(
+      "hop limit reached (4/4) in #general -- message from @alice blocked. Waiting for human input."
+    );
+  });
+
+  it("human message resets hop counter to 0", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    svc.createChannel("alice", "general", 4);
+    svc.send("alice", "general", "msg 1");
+    svc.send("alice", "general", "msg 2");
+
+    expect(getHopCount(db, "general")).toBe(2);
+
+    // Human send resets counter
+    svc.send("alice", "general", "human says hi", { human: true });
+
+    expect(getHopCount(db, "general")).toBe(0);
+  });
+
+  it("human message after limit resets and succeeds", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    const channel = svc.createChannel("alice", "general", 2);
+    svc.send("alice", "general", "msg 1");
+    svc.send("alice", "general", "msg 2");
+
+    // Now blocked
+    expect(() => svc.send("alice", "general", "blocked")).toThrow();
+
+    // Human resets
+    expect(() =>
+      svc.send("alice", "general", "human resets", { human: true })
+    ).not.toThrow();
+
+    expect(getHopCount(db, "general")).toBe(0);
+
+    // Agent can send again
+    expect(() => svc.send("alice", "general", "back in action")).not.toThrow();
+    expect(getHopCount(db, "general")).toBe(1);
+  });
+
+  it("multiple agent messages increment counter correctly 0->1->2->3->4->blocked", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    const channel = svc.createChannel("alice", "general", 4);
+
+    for (let i = 1; i <= 4; i++) {
+      svc.send("alice", "general", `msg ${i}`);
+      expect(getHopCount(db, "general")).toBe(i);
+    }
+
+    expect(() => svc.send("alice", "general", "msg 5")).toThrow(
+      "Hop limit reached (4/4)"
+    );
+    // Counter stays at 4 (not incremented on blocked message)
+    expect(getHopCount(db, "general")).toBe(4);
+  });
+
+  it("_system notices do NOT increment hop counter", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    const channel = svc.createChannel("alice", "general", 4);
+    svc.send("alice", "general", "msg 1");
+    svc.send("alice", "general", "msg 2");
+    svc.send("alice", "general", "msg 3");
+    svc.send("alice", "general", "msg 4");
+
+    expect(getHopCount(db, "general")).toBe(4);
+
+    // Trigger blocked send which posts _system notice
+    expect(() => svc.send("alice", "general", "blocked")).toThrow();
+
+    // Hop count stays at 4, not incremented by _system notice
+    expect(getHopCount(db, "general")).toBe(4);
+  });
+
+  it("DM hop counter: two agents DMing increment DM channel hop counter", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    svc.register("bob");
+
+    // alice DMs bob - creates DM channel
+    svc.directMessage("alice", "bob", "hello bob");
+
+    // Determine the DM channel name
+    const dmName = ["alice", "bob"].sort().join(",");
+    expect(getHopCount(db, dmName)).toBe(1);
+
+    // bob DMs alice - uses same channel
+    svc.directMessage("bob", "alice", "hello alice");
+    expect(getHopCount(db, dmName)).toBe(2);
+  });
+});
+
+// ── continueChannel ────────────────────────────────────────────────────────
+
+describe("continueChannel", () => {
+  it("continueChannel at hop_count=4 with amount=4 decrements to 0 and returns correct result", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    svc.createChannel("alice", "test-channel", 4);
+    svc.send("alice", "test-channel", "msg 1");
+    svc.send("alice", "test-channel", "msg 2");
+    svc.send("alice", "test-channel", "msg 3");
+    svc.send("alice", "test-channel", "msg 4");
+
+    expect(getHopCount(db, "test-channel")).toBe(4);
+
+    const result = svc.continueChannel("alice", "test-channel", 4);
+
+    expect(result).toEqual({ channel: "test-channel", hopCount: 0, maxHops: 4, bumped: 4 });
+    expect(getHopCount(db, "test-channel")).toBe(0);
+  });
+
+  it("continueChannel at hop_count=4 with amount=2 decrements to 2", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    svc.createChannel("alice", "test-channel", 4);
+    svc.send("alice", "test-channel", "msg 1");
+    svc.send("alice", "test-channel", "msg 2");
+    svc.send("alice", "test-channel", "msg 3");
+    svc.send("alice", "test-channel", "msg 4");
+
+    const result = svc.continueChannel("alice", "test-channel", 2);
+
+    expect(result.hopCount).toBe(2);
+    expect(result.bumped).toBe(2);
+    expect(getHopCount(db, "test-channel")).toBe(2);
+  });
+
+  it("continueChannel with no amount uses default of 4", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    svc.createChannel("alice", "test-channel", 4);
+    svc.send("alice", "test-channel", "msg 1");
+    svc.send("alice", "test-channel", "msg 2");
+    svc.send("alice", "test-channel", "msg 3");
+    svc.send("alice", "test-channel", "msg 4");
+
+    const result = svc.continueChannel("alice", "test-channel");
+
+    expect(result.bumped).toBe(4);
+    expect(result.hopCount).toBe(0);
+    expect(getHopCount(db, "test-channel")).toBe(0);
+  });
+
+  it("continueChannel on nonexistent channel throws channel not found", () => {
+    const { svc } = setup();
+
+    svc.register("alice");
+    expect(() => svc.continueChannel("alice", "nonexistent")).toThrow(
+      'Channel "nonexistent" not found'
+    );
+  });
+
+  it("after continueChannel, agents can send again until new limit", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    svc.createChannel("alice", "test-channel", 4);
+    svc.send("alice", "test-channel", "msg 1");
+    svc.send("alice", "test-channel", "msg 2");
+    svc.send("alice", "test-channel", "msg 3");
+    svc.send("alice", "test-channel", "msg 4");
+
+    // Channel is now blocked
+    expect(() => svc.send("alice", "test-channel", "blocked")).toThrow("Hop limit reached");
+
+    // /continue gives 4 more hops
+    svc.continueChannel("alice", "test-channel", 4);
+
+    // Agent can send again
+    expect(() => svc.send("alice", "test-channel", "back in action")).not.toThrow();
+    expect(getHopCount(db, "test-channel")).toBe(1);
+  });
+
+  it("continueChannel on non-blocked channel (hop_count=1) decrements to 0, giving extra headroom", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    svc.createChannel("alice", "test-channel", 4);
+    svc.send("alice", "test-channel", "msg 1");
+
+    expect(getHopCount(db, "test-channel")).toBe(1);
+
+    const result = svc.continueChannel("alice", "test-channel", 4);
+
+    // hop_count decrements from 1 to 0 (clamped at 0, not negative)
+    expect(result.hopCount).toBe(0);
+    expect(getHopCount(db, "test-channel")).toBe(0);
+  });
+
+  it("continueChannel throws for unregistered agent", () => {
+    const { svc } = setup();
+
+    svc.register("alice");
+    svc.createChannel("alice", "test-channel");
+
+    expect(() => svc.continueChannel("nobody", "test-channel")).toThrow(
+      'Agent "nobody" must call messaging_register'
+    );
+  });
+
+  it("continueChannel rejects amount < 1", () => {
+    const { svc } = setup();
+
+    svc.register("alice");
+    svc.createChannel("alice", "test-channel");
+
+    expect(() => svc.continueChannel("alice", "test-channel", 0)).toThrow(
+      "amount must be at least 1"
+    );
+    expect(() => svc.continueChannel("alice", "test-channel", -1)).toThrow(
+      "amount must be at least 1"
+    );
+  });
+});
+
+describe("validation", () => {
+  it("createChannel rejects maxHops < 1", () => {
+    const { svc } = setup();
+
+    svc.register("alice");
+
+    expect(() => svc.createChannel("alice", "blocked-ch", 0)).toThrow(
+      "maxHops must be at least 1"
+    );
+    expect(() => svc.createChannel("alice", "blocked-ch", -1)).toThrow(
+      "maxHops must be at least 1"
+    );
+  });
+
+  it("createChannel allows maxHops > 50 (upper bound enforced at transport)", () => {
+    const { svc } = setup();
+
+    svc.register("alice");
+
+    const ch = svc.createChannel("alice", "stress-ch", 100);
+    expect(ch.max_hops).toBe(100);
+  });
+});
+
+describe("_system notice deduplication", () => {
+  it("repeated blocked sends emit only one _system notice", () => {
+    const { db, svc } = setup();
+
+    svc.register("alice");
+    svc.createChannel("alice", "test-channel", 2);
+    svc.subscribe("alice", "test-channel");
+
+    svc.send("alice", "test-channel", "msg 1");
+    svc.send("alice", "test-channel", "msg 2");
+
+    // Three blocked attempts
+    expect(() => svc.send("alice", "test-channel", "blocked 1")).toThrow("Hop limit reached");
+    expect(() => svc.send("alice", "test-channel", "blocked 2")).toThrow("Hop limit reached");
+    expect(() => svc.send("alice", "test-channel", "blocked 3")).toThrow("Hop limit reached");
+
+    // Only one _system notice should exist
+    const allMsgs = db.query("SELECT * FROM messages WHERE channel_id = (SELECT id FROM channels WHERE name = 'test-channel') AND agent_id = '_system'").all();
+    expect(allMsgs.length).toBe(1);
+  });
+});

--- a/tests/hex/notifications/cross-process-poller.test.ts
+++ b/tests/hex/notifications/cross-process-poller.test.ts
@@ -136,12 +136,12 @@ describe("cross-process poller integration", () => {
 
     poller.start();
 
-    // agent-b sends a message that mentions themselves
-    svc.send("agent-b", "general", "@agent-b this is a self-message");
+    // agent-b sends a message mentioning agent-a (not itself)
+    svc.send("agent-b", "general", "@agent-a this is agent-b speaking");
 
     await poller._tick();
 
-    // agent-b should NOT be notified about their own messages
+    // agent-b should NOT be notified about their own messages (sender is excluded)
     expect(calls.length).toBe(0);
 
     poller.stop();

--- a/tests/hex/storage/channel-repo.test.ts
+++ b/tests/hex/storage/channel-repo.test.ts
@@ -75,4 +75,106 @@ describe("SqliteChannelRepo", () => {
     expect(msgs[0]!.mentions).toBe('["*"]');
     db.close();
   });
+
+  it("create with default maxHops returns channel with max_hops = 50", () => {
+    const { db, channels } = setup();
+    const ch = channels.create("test-channel", "agent-a");
+    expect(ch.max_hops).toBe(50);
+    expect(ch.hop_count).toBe(0);
+    db.close();
+  });
+
+  it("create with custom maxHops stores the provided value", () => {
+    const { db, channels } = setup();
+    const ch = channels.create("test-channel", "agent-a", 10);
+    expect(ch.max_hops).toBe(10);
+    expect(ch.hop_count).toBe(0);
+    db.close();
+  });
+
+  it("checkAndIncrementHop - allowed at 0/4", () => {
+    const { db, channels } = setup();
+    const ch = channels.create("hop-channel", "agent-a", 4);
+    const result = channels.checkAndIncrementHop(ch.id);
+    expect(result.allowed).toBe(true);
+    expect(result.hopCount).toBe(1);
+    expect(result.maxHops).toBe(4);
+    db.close();
+  });
+
+  it("checkAndIncrementHop - allowed at 3/4", () => {
+    const { db, channels } = setup();
+    const ch = channels.create("hop-channel", "agent-a", 4);
+    // Manually set hop_count to 3
+    db.run("UPDATE channels SET hop_count = 3 WHERE id = ?", [ch.id]);
+    const result = channels.checkAndIncrementHop(ch.id);
+    expect(result.allowed).toBe(true);
+    expect(result.hopCount).toBe(4);
+    expect(result.maxHops).toBe(4);
+    db.close();
+  });
+
+  it("checkAndIncrementHop - blocked at 4/4", () => {
+    const { db, channels } = setup();
+    const ch = channels.create("hop-channel", "agent-a", 4);
+    // Manually set hop_count to 4 (at limit)
+    db.run("UPDATE channels SET hop_count = 4 WHERE id = ?", [ch.id]);
+    const result = channels.checkAndIncrementHop(ch.id);
+    expect(result.allowed).toBe(false);
+    expect(result.hopCount).toBe(4);
+    expect(result.maxHops).toBe(4);
+    db.close();
+  });
+
+  it("checkAndIncrementHop - counter not incremented when blocked", () => {
+    const { db, channels } = setup();
+    const ch = channels.create("hop-channel", "agent-a", 4);
+    db.run("UPDATE channels SET hop_count = 4 WHERE id = ?", [ch.id]);
+    channels.checkAndIncrementHop(ch.id);
+    const row = db.query("SELECT hop_count FROM channels WHERE id = ?").get(ch.id) as { hop_count: number };
+    expect(row.hop_count).toBe(4);
+    db.close();
+  });
+
+  it("resetHopCount resets hop_count to 0", () => {
+    const { db, channels } = setup();
+    const ch = channels.create("hop-channel", "agent-a", 4);
+    db.run("UPDATE channels SET hop_count = 3 WHERE id = ?", [ch.id]);
+    channels.resetHopCount(ch.id);
+    const row = db.query("SELECT hop_count FROM channels WHERE id = ?").get(ch.id) as { hop_count: number };
+    expect(row.hop_count).toBe(0);
+    db.close();
+  });
+
+  it("bumpHopAllowance decrements hop_count by N", () => {
+    const { db, channels } = setup();
+    const ch = channels.create("hop-channel", "agent-a", 4);
+    db.run("UPDATE channels SET hop_count = 3 WHERE id = ?", [ch.id]);
+    const result = channels.bumpHopAllowance(ch.id, 2);
+    expect(result.hopCount).toBe(1);
+    expect(result.maxHops).toBe(4);
+    expect(result.allowed).toBe(true);
+    db.close();
+  });
+
+  it("bumpHopAllowance clamps hop_count to 0, not negative", () => {
+    const { db, channels } = setup();
+    const ch = channels.create("hop-channel", "agent-a", 4);
+    db.run("UPDATE channels SET hop_count = 2 WHERE id = ?", [ch.id]);
+    const result = channels.bumpHopAllowance(ch.id, 10);
+    expect(result.hopCount).toBe(0);
+    expect(result.allowed).toBe(true);
+    db.close();
+  });
+
+  it("bumpHopAllowance returns new state after decrement", () => {
+    const { db, channels } = setup();
+    const ch = channels.create("hop-channel", "agent-a", 5);
+    db.run("UPDATE channels SET hop_count = 5 WHERE id = ?", [ch.id]);
+    const result = channels.bumpHopAllowance(ch.id, 1);
+    expect(result.hopCount).toBe(4);
+    expect(result.maxHops).toBe(5);
+    expect(result.allowed).toBe(true);
+    db.close();
+  });
 });

--- a/tests/hex/transports/mcp-instructions.test.ts
+++ b/tests/hex/transports/mcp-instructions.test.ts
@@ -2,26 +2,54 @@ import { describe, it, expect } from "bun:test";
 import { buildInstructions, UNIVERSAL_GUIDANCE } from "../../../src/transports/mcp-stdio/adapter";
 
 describe("buildInstructions", () => {
-  // Claude Code truncates server instructions at 2KB (2048 bytes).
-  // The BRAIN section adds ~50 bytes with domain. If the base text exceeds budget,
-  // trim SENDING and DISCOVERY first -- REACTING TO MESSAGES and BOUNDARIES
-  // are highest priority for weak models.
+  // Claude Code truncates server instructions at 2KB (2048 bytes). Everything
+  // up through the BRAIN section must fit inside that window. The NON-PUSH
+  // CLIENTS block is appended AFTER BRAIN intentionally: end-of-doc placement
+  // means Claude Code's truncation clips the tail the push-client doesn't
+  // need, while non-push clients (Codex, Gemini CLI, OpenCode) have no 2KB
+  // limit and receive the full text. The 2900-byte ceiling below accommodates
+  // the sacrificial tail. Phase 0c will restructure the whole block and
+  // reclaim budget.
 
-  it("stays under 2KB without brain config", () => {
+  it("pre-NON-PUSH section stays under 2KB without brain config", () => {
     const text = buildInstructions(null);
-    const bytes = Buffer.byteLength(text, "utf-8");
-    console.log(`buildInstructions(null): ${bytes} bytes`);
+    const preTail = text.split("\n\nNON-PUSH CLIENTS:")[0]!;
+    const bytes = Buffer.byteLength(preTail, "utf-8");
+    console.log(`buildInstructions(null) pre-NON-PUSH: ${bytes} bytes`);
     expect(bytes).toBeLessThan(2048);
   });
 
-  it("stays under 2KB with brain config", () => {
+  it("pre-NON-PUSH section stays under 2KB with brain config", () => {
     const text = buildInstructions({
       domain: { identifier: "test-domain", tags: ["test"], description: "A test domain" },
       brain: { dirs: ["docs"], files: [] },
     });
-    const bytes = Buffer.byteLength(text, "utf-8");
-    console.log(`buildInstructions(with brain): ${bytes} bytes`);
+    const preTail = text.split("\n\nNON-PUSH CLIENTS:")[0]!;
+    const bytes = Buffer.byteLength(preTail, "utf-8");
+    console.log(`buildInstructions(with brain) pre-NON-PUSH: ${bytes} bytes`);
     expect(bytes).toBeLessThan(2048);
+  });
+
+  it("full instructions stay under the non-push ceiling", () => {
+    const none = Buffer.byteLength(buildInstructions(null), "utf-8");
+    const withBrain = Buffer.byteLength(
+      buildInstructions({
+        domain: { identifier: "test-domain", tags: ["test"], description: "A test domain" },
+        brain: { dirs: ["docs"], files: [] },
+      }),
+      "utf-8"
+    );
+    console.log(`full: none=${none}, withBrain=${withBrain}`);
+    expect(none).toBeLessThan(2900);
+    expect(withBrain).toBeLessThan(2900);
+  });
+
+  it("includes NON-PUSH CLIENTS section at end of document", () => {
+    const text = buildInstructions(null);
+    expect(text).toContain("NON-PUSH CLIENTS:");
+    expect(text).toContain("messaging_listen(timeout_ms");
+    expect(text).toContain("messages arrive inline");
+    expect(text.indexOf("NON-PUSH CLIENTS:")).toBeGreaterThan(text.indexOf("BRAIN:"));
   });
 
   it("includes REACTING TO MESSAGES section with anti-polling guidance", () => {

--- a/tests/hex/transports/no-messaging-continue-tool.test.ts
+++ b/tests/hex/transports/no-messaging-continue-tool.test.ts
@@ -1,0 +1,75 @@
+// tests/hex/transports/no-messaging-continue-tool.test.ts
+//
+// Regression guard for the messaging_continue MCP tool removal (commit dd777fa).
+//
+// `messaging_continue` was originally an MCP tool with a "human-only"
+// description. That was description-as-enforcement — agents could ignore the
+// text and call the tool. The architectural fix was to remove it from the MCP
+// surface entirely; the REPL `/continue` command (and future `ocs continue`
+// CLI subcommand) is the only human-callable surface.
+//
+// This file pins the registered MCP tool list. Adding `messaging_continue`
+// back to the registry — or any new agent-callable hop-bypass tool — fails
+// loudly here. Any other change to the tool surface also fails this test,
+// forcing a deliberate update with reviewer awareness.
+
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ADAPTER_PATH = join(
+  import.meta.dir,
+  "../../../src/transports/mcp-stdio/adapter.ts"
+);
+
+const EXPECTED_MCP_TOOLS = [
+  "brain_claim_domain",
+  "brain_find_expert",
+  "brain_index",
+  "brain_read",
+  "brain_shared_index",
+  "brain_shared_read",
+  "messaging_create_channel",
+  "messaging_direct_message",
+  "messaging_get_instructions",
+  "messaging_list_agents",
+  "messaging_list_channels",
+  "messaging_list_members",
+  "messaging_listen",
+  "messaging_read_messages",
+  "messaging_register",
+  "messaging_rename_channel",
+  "messaging_send_message",
+  "messaging_subscribe",
+];
+
+function extractRegisteredToolNames(): string[] {
+  const source = readFileSync(ADAPTER_PATH, "utf-8");
+  const re = /server\.registerTool\("([^"]+)"/g;
+  const names: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(source)) !== null) {
+    names.push(match[1]!);
+  }
+  return names.sort();
+}
+
+describe("MCP tool registry — pinned surface", () => {
+  it("registered tool names match the expected list exactly", () => {
+    const actual = extractRegisteredToolNames();
+    expect(actual).toEqual(EXPECTED_MCP_TOOLS);
+  });
+
+  it("messaging_continue is NOT registered as an MCP tool (transport-boundary invariant)", () => {
+    const actual = extractRegisteredToolNames();
+    expect(actual).not.toContain("messaging_continue");
+  });
+
+  it("no other agent-callable hop-bypass tool snuck in", () => {
+    const actual = extractRegisteredToolNames();
+    const suspicious = actual.filter((name) =>
+      /continue|reset.*hop|bump.*hop|hop.*reset|hop.*bump|allowance|bypass/i.test(name)
+    );
+    expect(suspicious).toEqual([]);
+  });
+});

--- a/tests/repl/app.test.ts
+++ b/tests/repl/app.test.ts
@@ -116,6 +116,19 @@ describe("REPL integration", () => {
     expect(result.messages!.some(m => m.content === "their msg")).toBe(true);
   });
 
+  it("plain message send uses human flag - resets hop count on hop-limited channel", () => {
+    const { db, svc } = setup();
+    svc.register("jay");
+    // Create channel with maxHops=1: first non-human send uses the 1 hop (hop_count 0->1).
+    // A second non-human send would fail (hop_count 1 >= max_hops 1).
+    // app.ts passes { human: true }, which resets hop_count to 0, allowing the send.
+    svc.createChannel("jay", "planning", 1);
+    svc.send("jay", "planning", "first agent msg"); // exhausts the 1 hop
+    // Simulates what app.ts does — passes { human: true }
+    const msg = svc.send("jay", "planning", "human typed message", { human: true });
+    expect(msg.content).toBe("human typed message");
+  });
+
   it("poll excludes self messages", () => {
     const { db, svc } = setup();
     svc.register("jay");

--- a/tests/repl/commands.test.ts
+++ b/tests/repl/commands.test.ts
@@ -43,6 +43,14 @@ describe("parseCommand", () => {
   it("returns null for empty input", () => {
     expect(parseCommand("")).toBeNull();
   });
+
+  it("parses /continue as a known command with no args", () => {
+    expect(parseCommand("/continue")).toEqual({ name: "continue", args: "" });
+  });
+
+  it("parses /continue 8 with args", () => {
+    expect(parseCommand("/continue 8")).toEqual({ name: "continue", args: "8" });
+  });
 });
 
 describe("executeCommand", () => {
@@ -85,7 +93,7 @@ describe("executeCommand", () => {
   it("/history defaults to 20 for invalid N", () => {
     const { db, svc, channelRepo } = setup();
     svc.register("user");
-    svc.createChannel("user", "test-ch");
+    svc.createChannel("user", "test-ch", 100);
     // Insert 25 messages so the limit is exercised
     for (let i = 0; i < 25; i++) svc.send("user", "test-ch", `msg-${i}`);
     const state = { activeChannel: "test-ch", joinedChannels: new Set(["test-ch"]), cursors: new Map(), agentId: "user" };
@@ -155,7 +163,7 @@ describe("executeCommand", () => {
   it("/history 0 falls back to 20", () => {
     const { db, svc, channelRepo } = setup();
     svc.register("user");
-    svc.createChannel("user", "test-ch");
+    svc.createChannel("user", "test-ch", 100);
     for (let i = 0; i < 25; i++) svc.send("user", "test-ch", `msg-${i}`);
     const state = { activeChannel: "test-ch", joinedChannels: new Set(["test-ch"]), cursors: new Map(), agentId: "user" };
     const result = executeCommand({ name: "history", args: "0" }, svc, channelRepo, state);
@@ -165,7 +173,7 @@ describe("executeCommand", () => {
   it("/history -1 falls back to 20", () => {
     const { db, svc, channelRepo } = setup();
     svc.register("user");
-    svc.createChannel("user", "test-ch");
+    svc.createChannel("user", "test-ch", 100);
     for (let i = 0; i < 25; i++) svc.send("user", "test-ch", `msg-${i}`);
     const state = { activeChannel: "test-ch", joinedChannels: new Set(["test-ch"]), cursors: new Map(), agentId: "user" };
     const result = executeCommand({ name: "history", args: "-1" }, svc, channelRepo, state);
@@ -177,5 +185,65 @@ describe("executeCommand", () => {
     const state = { activeChannel: "ch", joinedChannels: new Set(["ch"]), cursors: new Map(), agentId: "user" };
     const result = executeCommand({ name: "help", args: "" }, svc, channelRepo, state);
     expect(result.output.length).toBeGreaterThan(0);
+  });
+
+  it("/help includes /continue entry", () => {
+    const { db, svc, channelRepo } = setup();
+    const state = { activeChannel: "ch", joinedChannels: new Set(["ch"]), cursors: new Map(), agentId: "user" };
+    const result = executeCommand({ name: "help", args: "" }, svc, channelRepo, state);
+    expect(result.output.some(l => l.includes("/continue"))).toBe(true);
+  });
+
+  it("/continue with no args uses default amount of 4", () => {
+    const { db, svc, channelRepo } = setup();
+    svc.register("user");
+    svc.createChannel("user", "test-ch", 10);
+    const state = { activeChannel: "test-ch", joinedChannels: new Set(["test-ch"]), cursors: new Map(), agentId: "user" };
+    const result = executeCommand({ name: "continue", args: "" }, svc, channelRepo, state);
+    expect(result.output[0]).toContain("+4");
+    expect(result.output[0]).toContain("test-ch");
+  });
+
+  it("/continue 8 passes amount 8", () => {
+    const { db, svc, channelRepo } = setup();
+    svc.register("user");
+    svc.createChannel("user", "test-ch", 10);
+    const state = { activeChannel: "test-ch", joinedChannels: new Set(["test-ch"]), cursors: new Map(), agentId: "user" };
+    const result = executeCommand({ name: "continue", args: "8" }, svc, channelRepo, state);
+    expect(result.output[0]).toContain("+8");
+  });
+
+  it("/continue with invalid arg defaults to 4", () => {
+    const { db, svc, channelRepo } = setup();
+    svc.register("user");
+    svc.createChannel("user", "test-ch", 10);
+    const state = { activeChannel: "test-ch", joinedChannels: new Set(["test-ch"]), cursors: new Map(), agentId: "user" };
+    const result = executeCommand({ name: "continue", args: "abc" }, svc, channelRepo, state);
+    expect(result.output[0]).toContain("+4");
+  });
+
+  it("/continue 0 defaults to 4", () => {
+    const { db, svc, channelRepo } = setup();
+    svc.register("user");
+    svc.createChannel("user", "test-ch", 10);
+    const state = { activeChannel: "test-ch", joinedChannels: new Set(["test-ch"]), cursors: new Map(), agentId: "user" };
+    const result = executeCommand({ name: "continue", args: "0" }, svc, channelRepo, state);
+    expect(result.output[0]).toContain("+4");
+  });
+
+  it("/send -f sends with human flag, allowing send on hop-limited channel", () => {
+    const { db, svc, channelRepo } = setup();
+    svc.register("user");
+    // Create channel with maxHops=1: first non-human send succeeds (hop 0->1),
+    // second would fail. Human flag resets hop count.
+    svc.createChannel("user", "test-ch", 1);
+    svc.send("user", "test-ch", "first agent msg"); // exhausts the 1 hop
+    const tmpFile = "/tmp/octo-santa-test-send-f-human.txt";
+    writeFileSync(tmpFile, "human file content");
+    const state = { activeChannel: "test-ch", joinedChannels: new Set(["test-ch"]), cursors: new Map(), agentId: "user" };
+    // Human flag should reset hop count, so this send succeeds despite exhausted hops
+    const result = executeCommand({ name: "send", args: `-f ${tmpFile}` }, svc, channelRepo, state);
+    expect(result.localEcho?.content).toBe("human file content");
+    unlinkSync(tmpFile);
   });
 });


### PR DESCRIPTION
## Summary

Phase 0 per-channel safety rails + Phase 1 hardening (non-push delivery contract). Fourth of four stacked PRs.

> **Bundled scope:** Implements Phase 0 safety rails (hop counter, self-mention guard, `/continue`, migration `messaging_005`) and Phase 1 hardening (NON-PUSH instructions block, inline-delivery contract docs, `scripts/smoke-non-push.ts`, `messaging_continue` removal). Bundled because the work landed as a single Codex-reviewed commit (`b16c670`) with both concerns interleaved at the hunk level; splitting after the fact would be judgmental and costly. Phase 1's headline feature (`messaging_listen`) ships in #12.
>
> Note on `messaging_continue`: this PR *removes* the tool. It was added in earlier #10-era work and is now obsolete per the human-only `/continue` design — there is no add/remove contradiction within this stack.

**Phase 0 — Safety Rails:**
- Per-channel hop counter on `channels` table (`max_hops`, `hop_count`); default 50 agent messages before block, configurable 1-50 via `messaging_create_channel`.
- Self-mention guard: agents cannot @mention themselves; rejected at both send and directMessage paths.
- `_system` block notification posted via `sendSystemNotice` when hop limit reached; `isDm` flag controls fan-out target filtering.
- Human-only `/continue [N]` REPL command bumps the allowance via `MessagingService.continueChannel()`. Sole human surface — by design not exposed as an MCP tool. `SendOptions.human` flag (REPL-only) resets `hop_count` to 0 on human-sourced sends.
- Atomic check-and-increment in `SqliteChannelRepo` via `.immediate()` transaction; cross-process safe (verified by `safety-rails-cross-process.test.ts` spawning worker subprocesses).
- Migration `messaging_005_safety_rails` adds `max_hops`/`hop_count` columns with `DEFAULT 50` and `DEFAULT 0`; pre-existing channels gain the limit transparently.

**Phase 1 hardening — non-push delivery contract:**
- `NON-PUSH CLIENTS` instruction block appended at end-of-doc in `buildInstructions()`; rationale comment explains end-placement (Claude Code truncates at 2KB, non-push clients have no cap, so the tail clipped is the one push clients don't need).
- Inline-delivery contract documented for `messaging_listen`: returns `{ channels, timed_out }` with messages inline per channel — no follow-up `read_messages` call required.
- `scripts/smoke-non-push.ts` verifies non-Claude stdio client round-trip.

**Architectural correction:**
- `messaging_continue` MCP tool removed (originally added in pre-stack work). Description-as-enforcement was a string, not a guardrail. REPL `/continue` is the only human-callable surface.

**Adversarial review fixes (H1-H4 + M2):**
- H1: `max_hops` default raised 4 → 50 to prevent silent DM bricking under normal use.
- H2: detailed JSDoc on `continueChannel()` naming it human-only/transport-restricted. Static-analysis test asserts the method is invoked only from `src/transports/repl/` files.
- H3: `hasRecentHopNotice` fan-out justification documented inline.
- H4: regression test pins the registered MCP tool list (18 tools) and asserts `messaging_continue` is absent.
- M2: README "Shipped" expanded; Tools table adds `messaging_listen` and `messaging_get_instructions`; new "Safety Rails" section explains hop counter. `docs/repl.md` command table adds `/continue`.

Verification: 628 pass / 0 fail (1260 expects), `bunx tsc --noEmit` clean.

## Stacked PRs

- **A:** `feat/persistent-agent-profiles` → `main` — F2 substrate (#11)
- **B:** `feat/agent-guidance-framework` → A — agent guidance (#17)
- **C:** `feature/messaging-listen` → B — Phase 1 blocking pull (#12)
- **D (this):** `feat/safety-rails-only` → C

Merge order: A → B → C → D. After upstream PRs merge, GitHub auto-retargets this PR to `main`.

This PR supersedes #10 (the bundled version).

## Test plan

- [ ] `bun test` passes (628+)
- [ ] `bunx tsc --noEmit` clean
- [ ] Safety rails core (`tests/hex/core/safety-rails.test.ts`)
- [ ] Cross-process safety rails (`tests/hex/core/safety-rails-cross-process.test.ts`)
- [ ] Continue-channel transport boundary static analysis
- [ ] No `messaging_continue` MCP tool regression test
- [ ] Non-push smoke script (`scripts/smoke-non-push.ts`)
