### PR TITLE
feat: agent guidance framework (instructions field + Tier 1 rewrite + messaging_get_instructions)

### DIFF
--- a/docs/analysis/2026-04-13-approach1-permutation-evaluation.md
+++ b/docs/analysis/2026-04-13-approach1-permutation-evaluation.md
@@ -1,0 +1,281 @@
+# Approach 1 Permutation Evaluation Report
+
+**Date:** 2026-04-13
+**Approach:** Profile `instructions` field (free-text) + MCP instruction refresh
+**Method:** Replay transcript scenarios and edge cases against Approach 1, evaluating whether the design resolves each failure
+
+---
+
+## Design Under Evaluation
+
+**Layer A (MCP Instructions):** Universal floor. Enhanced with event→action rules, tool scoping, capability boundaries. Delivered to every agent at connection time. ~500 words. Must stay under 2KB (Claude Code truncation limit).
+
+**Layer C (Profile Instructions):** Role-specific behavioral guidance. Free-text field in profile YAML. Delivered in the `messaging_register` response. Agent/harness responsible for keeping it in context.
+
+---
+
+## Scenario Replays
+
+### Scenario 1: os-pm told to "periodically check latest message"
+
+**Original failure:** Agent spirals for 3+ minutes considering bash loops, python scripts, curl, subagents, todo tools. Never arrives at a simple `read_messages` call.
+
+**With Approach 1:**
+
+| Layer | Guidance injected | Expected effect |
+|-------|-------------------|-----------------|
+| A (MCP instructions) | "You CANNOT run background tasks or polling loops. When asked to monitor a channel, call `messaging_read_messages`. Your harness or the human will prompt you again later." | Eliminates the spiral. Agent sees a clear boundary and a clear action. |
+| C (Profile instructions) | "When checking channels, read messages and act on any addressed to you. Summarize only if nothing requires action." | Adds role-specific framing on top. |
+
+**Verdict: RESOLVED.** The capability boundary statement in Layer A directly addresses the root cause. Even a 7B model can follow "do X, don't try Y."
+
+**Residual risk:** The agent might still not know HOW OFTEN to check. Layer A can't solve this — it's a harness concern (polling interval). Noted for harness integration follow-up.
+
+---
+
+### Scenario 2: os-pm receives a message but doesn't act until human says "perform action"
+
+**Original failure:** Agent reads the message, summarizes it as "The latest message is from os-tl and addresses a draft...", then stops. Doesn't recognize it should respond.
+
+**With Approach 1:**
+
+| Layer | Guidance injected | Expected effect |
+|-------|-------------------|-----------------|
+| A (MCP instructions) | "After calling `messaging_read_messages`, if any message is addressed to you (@your-name or @all), you MUST: (1) understand what is being asked, (2) decide on a response, (3) call `messaging_send_message` to reply. Never just summarize — always act." | Direct event→action rule. The word MUST + numbered steps gives weak models a clear procedure. |
+| C (Profile instructions) | "As a PM, when you receive a proposal or draft, evaluate it against project priorities and provide a clear decision or feedback with reasoning." | Adds role-specific decision framework. |
+
+**Verdict: LIKELY RESOLVED.** The event→action rule is explicit enough for 20-30B models. For 7-13B models, there's a risk they still summarize first and "forget" to act — the numbered steps help but aren't guaranteed.
+
+**Residual risk:** Very weak models may interpret "understand what is being asked" as a terminal action (they "understood" it, done). Mitigation: the numbered list makes step 3 (send_message) explicit and hard to skip.
+
+---
+
+### Scenario 3: os-tl sends a bare directive "@os-pm decide what the next roadmap items to tackle"
+
+**Original failure:** Message lacks context, constraints, or expected response format. Even a capable receiver would struggle to give a good answer.
+
+**With Approach 1:**
+
+| Layer | Guidance injected | Expected effect |
+|-------|-------------------|-----------------|
+| A (MCP instructions) | "When sending a message, include: (1) what you're asking or proposing, (2) relevant context, (3) what kind of response you need. Poor example: 'decide the roadmap.' Good example: '@os-pm We need to pick the next 2 roadmap items. Candidates: A, B, C. Constraints: team bandwidth is 1 dev for 2 weeks. Which should we prioritize and why?'" | Few-shot example teaches message quality. |
+| C (Profile instructions for os-tl) | "As a tech lead, when requesting decisions from the PM, always include: the options you've identified, technical constraints, and your recommendation." | Role-specific message template. |
+
+**Verdict: PARTIALLY RESOLVED.** The few-shot example in Layer A helps significantly — weak models excel at pattern matching. However, the agent must actually READ and INTERNALIZE the MCP instructions when composing a message. If it's already in "just send it" mode, it may skip the guidance.
+
+**Residual risk:** MCP instructions are delivered at connection time. By the time the agent is composing a message (possibly many turns later), the instructions may be out of active context for smaller context-window models. This is a fundamental limitation of one-time delivery.
+
+---
+
+### Scenario 4: os-tl monitors channel and reports "No new messages" despite messages existing
+
+**Original failure:** Agent calls `read_messages` twice in quick succession, gets results the first time, then reports "no new messages" because the second call returns empty (messages already marked read).
+
+**With Approach 1:**
+
+| Layer | Guidance injected | Expected effect |
+|-------|-------------------|-----------------|
+| A (MCP instructions) | "When you call `messaging_read_messages`, messages are marked as read. You will NOT see them again on the next call. If the first call returned messages, act on them — do not call read again expecting to see the same messages." | Explains read-once semantics. |
+
+**Verdict: RESOLVED.** This is a tool semantics issue. Clear documentation in Layer A prevents the double-read mistake.
+
+---
+
+## Edge Cases
+
+### Edge Case 1: Agent registers without a profile (no Layer C)
+
+**Scenario:** An agent connects with `messaging_register("random-bot")` — no profile YAML exists.
+
+**With Approach 1:** Agent gets Layer A (MCP instructions) only. No profile instructions.
+
+**Assessment:** This is the baseline. Layer A must be self-sufficient for agents without profiles. The event→action rules, tool scoping, and capability boundaries all apply universally. The agent won't have role-specific guidance but can still participate effectively in messaging.
+
+**Verdict: ACCEPTABLE.** Layer A alone is a significant improvement over the current state. Profile instructions are additive, not required.
+
+---
+
+### Edge Case 2: Profile instructions contradict MCP instructions
+
+**Scenario:** MCP instructions say "always respond to messages addressed to you." Profile instructions say "only respond to messages tagged #urgent."
+
+**With Approach 1:** No explicit precedence rule. The agent sees both instructions and must reconcile.
+
+**Assessment:** For capable models, this is fine — they'll recognize the profile as a refinement of the general rule. For weak models, contradictions cause unpredictable behavior (they may follow whichever instruction they processed last).
+
+**Mitigation:** Add a precedence statement to Layer A: "Profile instructions refine but do not override these base rules. If your profile instructions seem to conflict with these rules, the profile instructions take precedence for role-specific behavior."
+
+**Verdict: NEEDS DESIGN DECISION.** The precedence rule should be part of the spec.
+
+---
+
+### Edge Case 3: Profile instructions are too long for agent context
+
+**Scenario:** A profile has 2000 words of detailed instructions. The agent is running on a model with 4K-8K context window. The instructions consume a significant portion of available context.
+
+**With Approach 1:** Instructions are delivered in the registration response as a text field. It's up to the harness to decide how much to keep in context.
+
+**Assessment:** This is a harness-level concern, not a framework concern. However, we should provide guidance: "Keep profile instructions under 500 words. For detailed role playbooks, use brain documents and reference them from profile instructions."
+
+**Mitigation:** Add a recommended length guideline to the profile YAML schema docs. Optionally: warn at profile load time if instructions exceed a threshold.
+
+**Verdict: ACCEPTABLE with guideline.** Document the recommendation; don't enforce it in code.
+
+---
+
+### Edge Case 4: Multiple agents with the same profile (pool scenario)
+
+**Scenario:** Three `os-dev` instances register (os-dev-1, os-dev-2, os-dev-3). All get the same profile instructions.
+
+**With Approach 1:** All pool members get identical instructions from the profile. No instance-specific differentiation.
+
+**Assessment:** This is correct behavior. Pool members SHOULD have the same behavioral baseline. If differentiation is needed (e.g., "os-dev-1 handles frontend, os-dev-2 handles backend"), that's coordination — handled via channel messages, not profile instructions.
+
+**Verdict: CORRECT BY DESIGN.** Pool-wide consistency is the right default.
+
+---
+
+### Edge Case 5: Agent receives a message but is not the intended recipient
+
+**Scenario:** Agent os-dev-1 reads channel messages and sees a message addressed to `@os-pm`. The event→action rule says "if any message is addressed to you, act on it."
+
+**With Approach 1:** Layer A says "addressed to you (@your-name or @all)." The agent should recognize that `@os-pm` is not `@os-dev-1` and skip it.
+
+**Assessment:** Capable models handle this. Weak models might interpret "addressed to you" loosely and respond to every message they read.
+
+**Mitigation:** Make the rule more explicit: "addressed to you means the message contains @your-registered-name or @all or @your-pool-name. Messages mentioning other agents are not addressed to you — do not respond to them unless you have relevant information to contribute."
+
+**Verdict: NEEDS REFINEMENT.** The event→action rule needs tighter scoping on "addressed to you."
+
+---
+
+### Edge Case 6: Harness doesn't support injecting registration response into context
+
+**Scenario:** A minimal harness (basic MCP client) calls `messaging_register` and gets back the profile instructions in the response, but doesn't have a mechanism to persist that text in the agent's system prompt or ongoing context. It just shows the tool result once.
+
+**With Approach 1:** Instructions are delivered but may be lost after the first turn in some harnesses.
+
+**Assessment:** This is a real concern for minimal harnesses. Claude Code and opencode both keep tool results in conversation history, so the instructions persist until context compaction. But a bare MCP client might not.
+
+**Mitigation options:**
+1. Document that harnesses SHOULD persist registration response instructions
+2. Also include a condensed version of instructions in the MCP server instructions (Layer A) as a fallback
+3. Provide a `messaging_get_instructions` tool that agents can call later to re-read their profile instructions
+
+**Verdict: NEEDS MITIGATION.** Option 3 (re-readable instructions) is the most robust. Consider adding it to the spec.
+
+---
+
+### Edge Case 7: MCP instruction token budget (2KB Claude Code limit)
+
+**Scenario:** Claude Code truncates server instructions at 2KB. Our enhanced MCP instructions need to fit within this budget while covering event→action rules, tool scoping, capability boundaries, and message quality templates.
+
+**With Approach 1:** Current MCP instructions are ~1.5KB. Adding event→action rules and few-shot examples could push past 2KB.
+
+**Assessment:** This is a hard constraint for Claude Code. Other harnesses (opencode, Pi) may not have this limit, but we should design for the lowest common denominator.
+
+**Mitigation:**
+1. Prioritize ruthlessly — event→action rules and capability boundaries are highest impact per token
+2. Move few-shot examples to profile instructions or brain docs
+3. Use terse, imperative language (not prose)
+4. Test the actual byte count before finalizing
+
+**Verdict: HARD CONSTRAINT.** Must budget the MCP instruction content carefully. Few-shot examples may not fit in Layer A.
+
+---
+
+### Edge Case 8: Agent on a model that doesn't support tool calling natively
+
+**Scenario:** Some very small models (7B) have unreliable tool calling — they hallucinate tool names, miss required parameters, or format JSON incorrectly.
+
+**With Approach 1:** The guidance assumes the agent can reliably call tools. If it can't, no amount of behavioral instructions helps.
+
+**Assessment:** This is out of scope for octo-santa. Tool calling reliability is a model + harness problem. The harness is responsible for tool call formatting and error recovery.
+
+**Verdict: OUT OF SCOPE.** Document that the guidance assumes basic tool calling works. Harness integration patterns (follow-up task) should address tool calling reliability.
+
+---
+
+### Edge Case 9: Cross-harness instruction format compatibility
+
+**Scenario:** Different harnesses expect instructions in different formats:
+- **Claude Code:** MCP server instructions as text, tool descriptions in JSON schema. Truncates at 2KB. Supports `instructions` field on MCP server config.
+- **opencode:** Skills as SKILL.md files with YAML frontmatter. Searches `.opencode/skills/`, `.claude/skills/`, `.agents/skills/`.
+- **Pi:** Loads AGENTS.md from project and parent dirs. Supports SYSTEM.md per-project. Extensions can inject messages before each turn.
+- **Codex:** Plugins with bundled skills. MCP servers configured in plugin manifests.
+
+**With Approach 1:** Profile instructions are delivered via MCP tool response (registration). MCP server instructions are universal. Both are harness-agnostic — they travel through the MCP protocol, which all harnesses implement.
+
+**Assessment:** This is actually the strongest argument FOR Approach 1. MCP is the universal transport. By delivering guidance through MCP tool responses and server instructions, we avoid harness-specific integration entirely. The guidance arrives through the same channel regardless of whether the agent runs on Claude Code, opencode, Pi, or Codex.
+
+**Residual concern:** Each harness handles MCP server instructions differently:
+- Claude Code: shows them in `<system-reminder>` tags, truncates at 2KB
+- opencode: surfaces as part of tool context (exact mechanism varies)
+- Pi: MCP tool results are in conversation history, extensions can filter
+- Codex: MCP server instructions surface as tool context
+
+**Verdict: STRONG ADVANTAGE.** MCP-level delivery is the right abstraction. Harness-specific formatting is a display concern, not a content concern.
+
+---
+
+### Edge Case 10: Instructions reference tools that don't exist in the agent's environment
+
+**Scenario:** Profile instructions say "use brain_read to find the coordinator playbook." But the octo-santa instance doesn't have brain configured (no `brain` key in config.json). The `brain_read` tool doesn't exist.
+
+**With Approach 1:** Instructions are static text in YAML. They don't know which tools are actually available.
+
+**Assessment:** For capable models, they'd try `brain_read`, get an error, and adapt. For weak models, a tool that doesn't exist causes confusion or hallucinated tool calls.
+
+**Mitigation:**
+1. Profile instructions should only reference tools that are guaranteed to exist (all messaging tools exist if octo-santa is running)
+2. Add a guideline: "Profile instructions SHOULD only reference messaging_* tools. References to brain_* tools should be conditional: 'If brain is available, ...'"
+3. Alternatively: the registration response could include a list of available tool categories
+
+**Verdict: MINOR RISK.** Add a documentation guideline. Not worth adding code complexity.
+
+---
+
+## Cross-Harness Compatibility Matrix
+
+| Harness | Layer A (MCP Instructions) | Layer C (Profile Instructions) | Notes |
+|---------|---------------------------|-------------------------------|-------|
+| **Claude Code** | Delivered as `<system-reminder>`. 2KB limit. Always in context. | Delivered in `messaging_register` tool result. Persists in conversation history until compaction. | Best support. Both layers work well. Few-shot examples may not fit in Layer A due to 2KB limit. |
+| **opencode** | Surfaced as tool context. No documented size limit. | Delivered in `messaging_register` tool result. Persists in conversation. | Works. Skills system could complement with harness-side playbooks, but not required. |
+| **Pi** | MCP tool context. Extensions can filter/augment. | Delivered in tool result. Extensions can re-inject if needed. | Works. Pi's extension system could persist profile instructions across compaction if desired. |
+| **Codex** | MCP server instructions in plugin context. | Delivered in tool result. | Works. Codex plugins could add complementary skills, but MCP delivery is sufficient. |
+| **Bare MCP client** | Server instructions at connection time. | Delivered in tool result. May be lost after first turn. | Minimal support. Consider `messaging_get_instructions` tool as fallback. |
+
+---
+
+## Failure Mode Summary
+
+| # | Scenario | Resolved? | Residual Risk | Mitigation Needed? |
+|---|----------|-----------|---------------|---------------------|
+| S1 | Polling spiral | YES | Harness polling config | No (harness concern) |
+| S2 | No action on messages | LIKELY YES | Very weak models may still stop at "understand" | Refine numbered steps |
+| S3 | Bare directive messages | PARTIAL | Instructions may be out of context by send time | Few-shot in Layer A helps |
+| S4 | Double-read confusion | YES | None | No |
+| E1 | No profile (Layer A only) | ACCEPTABLE | Less guidance but functional | No |
+| E2 | Contradicting instructions | NEEDS DECISION | Weak models confused by contradictions | Add precedence rule |
+| E3 | Instructions too long | ACCEPTABLE | Context pressure on small models | Add length guideline |
+| E4 | Pool same instructions | CORRECT | None | No |
+| E5 | Wrong recipient | NEEDS REFINEMENT | Weak models respond to all messages | Tighten "addressed to you" |
+| E6 | Harness doesn't persist | NEEDS MITIGATION | Instructions lost after first turn | Add re-readable tool |
+| E7 | 2KB token budget | HARD CONSTRAINT | Few-shot examples may not fit | Budget carefully, move examples to Layer C |
+| E8 | Bad tool calling | OUT OF SCOPE | Model/harness problem | Document assumption |
+| E9 | Cross-harness compat | STRONG | MCP is universal transport | None needed |
+| E10 | Missing tools referenced | MINOR | Weak models confused | Documentation guideline |
+
+---
+
+## Recommendations for Spec
+
+Based on this evaluation, Approach 1 should include:
+
+1. **Precedence rule** in Layer A: profile instructions refine but layer A is the behavioral floor
+2. **Tight "addressed to you" definition** in the event→action rule
+3. **`messaging_get_instructions` tool** for re-reading profile instructions (mitigates harness persistence issues)
+4. **Length guideline** for profile instructions (recommend ≤500 words)
+5. **2KB budget plan** for Layer A content — prioritize event→action rules and capability boundaries; move few-shot examples to Layer C
+6. **Tool reference guideline** — profile instructions should only reference guaranteed-available tools
+7. **One concrete playbook** (os-pm) as validation artifact

--- a/docs/analysis/2026-04-13-less-capable-agent-failure-analysis.md
+++ b/docs/analysis/2026-04-13-less-capable-agent-failure-analysis.md
@@ -1,0 +1,123 @@
+# Less Capable Agent Failure Analysis
+
+**Date:** 2026-04-13
+**Context:** Testing Gemma4:26b via opencode harness with two agents (os-pm, os-tl) collaborating through octo-santa messaging.
+
+---
+
+## Observable Failure Modes
+
+### 1. Excessive reasoning about tool mechanics
+Both agents spend enormous amounts of their thinking budget figuring out HOW to call tools, rather than WHAT to accomplish. os-pm's thinking about "periodically check" is 90% about whether it CAN loop, not about the business goal.
+
+### 2. No autonomous reaction to incoming messages
+When os-pm receives a message, nothing happens until the human explicitly says "perform action based on the message, then respond." The agent doesn't recognize that receiving a channel notification should trigger action.
+
+### 3. Confusion about async/background capabilities
+os-pm spirals into whether it can run bash loops, write python scripts, use curl, spawn subagents — all to solve "periodically check." It doesn't know its own capabilities or boundaries.
+
+### 4. Shallow message comprehension
+os-tl receives messages and summarizes them as "No new messages have arrived since my last check" without actually engaging with the content or deciding on next actions.
+
+### 5. Over-serialized execution
+Both agents think step-by-step through trivial tool calls (register then subscribe) when they could be parallel.
+
+### 6. No proactive behavior
+Neither agent initiates. They wait for explicit human instructions for every micro-step.
+
+---
+
+## Root Causes
+
+### Root Cause 1: Absent mental model of self
+The agent doesn't know what it IS. It doesn't know it's a messaging participant with a role. It treats each tool call as an isolated API request rather than understanding "I am os-pm, a product manager, participating in an async conversation." Claude/Codex internalizes identity from system prompts; weaker models treat system prompts as reference text, not identity.
+
+### Root Cause 2: No event-action mapping
+There's no guidance that says "when you receive a message addressed to you, you MUST read it and respond." The agent treats message receipt as informational, not as a trigger. Capable models infer this from context; weaker models need explicit event→action rules.
+
+### Root Cause 3: Tool selection paralysis from too many options
+The thinking traces show the agent considering bash, python, curl, subagents, todo tools — it's overwhelmed by optionality. A capable model prunes irrelevant tools instantly; a weaker model enumerates all possibilities linearly.
+
+### Root Cause 4: No workflow state machine
+The agent has no concept of "I am in state X, the valid next actions are Y." Each turn starts from scratch. There's no persistent sense of "I sent a message, now I should wait for a reply, and when it comes, I should act on it."
+
+### Root Cause 5: Instruction following vs. goal pursuing
+These agents are instruction-followers, not goal-pursuers. They do exactly what they're told, nothing more. "Check messages" → they check. But they don't reason "I checked, there's a new message asking me something, therefore I should respond."
+
+---
+
+## Gap Analysis: What Octo-Santa Provides vs What Agents Need
+
+### What octo-santa provides today:
+- Tool descriptions (register, subscribe, send, read, etc.)
+- MCP server instructions (brief — "call messaging_register before sending", "use @mentions to get attention")
+- Channel notification tags when messages arrive
+
+### What's MISSING for less capable agents:
+
+1. **Role playbook** — No document says "You are a PM. When you receive a message, here's your decision framework." The role is just a name.
+
+2. **Tool selection guide** — No document says "For messaging tasks, use ONLY these 5 tools. Ignore bash, ignore subagents, ignore todo." The agent wastes cycles considering irrelevant tools.
+
+3. **Event-reaction rules** — No document says "When you see `<channel source='octo-santa'>`, IMMEDIATELY read the channel and formulate a response." The notification is just data, not a trigger.
+
+4. **Workflow templates** — No document says "The messaging workflow is: register → subscribe → send/read loop. Here are examples of each step." The agent has to infer the workflow from tool descriptions.
+
+5. **Response format guidance** — No document says "When responding to a message, quote the relevant part, state your position, and ask a clear follow-up question." The agents produce vague summaries instead of substantive replies.
+
+6. **Capability boundaries** — No document says "You CANNOT run background loops. You CAN be polled by the harness. Don't try to solve async monitoring yourself." The agent wastes time on impossible approaches.
+
+---
+
+## Specific Fix Mapping
+
+| Failure | Fix Needed |
+|---------|-----------|
+| os-pm spirals on "periodically check" | Clear capability boundary statement: "You cannot run background tasks. To monitor a channel, the human or harness will prompt you to check. When prompted, call read_messages and act on what you find." |
+| os-pm doesn't act on received messages | Event-reaction rule: "After reading messages, if any message is addressed to you, you MUST: (1) understand the request, (2) formulate a substantive response, (3) send your response back to the channel. Never just summarize — always act." |
+| os-tl sends a bare directive without context | Message quality template: "When sending a message, include: (1) what you're asking, (2) relevant context or constraints, (3) what kind of response you need." |
+| Both agents treat each turn as isolated | State tracking: "Before each action, review your recent message history in the channel to understand the conversation state." |
+| os-pm considers bash, python, curl for messaging | Tool scoping: "For channel communication, use ONLY: messaging_register, messaging_subscribe, messaging_send_message, messaging_read_messages. Do NOT use bash, file operations, or other tools for messaging tasks." |
+
+---
+
+## Core Insight
+
+**The gap isn't in the tools — the tools work fine. The gap is in the GUIDANCE LAYER between the tools and the agent's decision-making.** Capable models generate this layer internally; weaker models need it externally.
+
+---
+
+## Solution Framework: "Scaffolding for Less Capable Agents"
+
+Three intervention points, ordered by impact and feasibility:
+
+### 1. Enhanced MCP Instructions (High impact, Easy)
+Expand server instructions with:
+- Explicit event→action rules
+- Tool scoping per task type
+- Capability boundary statements
+- Message quality templates
+
+### 2. Brain-Stored Playbooks (High impact, Medium)
+Create brain documents for:
+- Role-specific behavior guides
+- Workflow state machines with transition rules
+- Few-shot example libraries
+- Troubleshooting / "when stuck" guides
+
+### 3. Harness-Level Integration Patterns (Medium impact, Hard)
+Provide reference implementations for:
+- Polling loops with automatic read-and-react
+- System prompt templates per role
+- Event handler patterns
+- State persistence between turns
+
+---
+
+## Architectural Consideration: Two-Tier Guidance
+
+**Tier 1 (MCP instructions):** Essential event-reaction rules, tool scoping, capability boundaries. Always in context. ~500 words. This is the minimum viable fix — improves ALL agents regardless of harness.
+
+**Tier 2 (Brain documents):** Role playbooks, workflow templates, few-shot examples. Pulled on demand. Unlimited length. Opt-in — capable models ignore them, weaker models pull them.
+
+The key insight for tier placement: a weak model won't know to ask for help (it doesn't know what it doesn't know). So the MINIMUM guidance must be in the MCP instructions themselves. The brain is for EXTENDED guidance.

--- a/docs/specs/2026-04-13-agent-guidance-framework-design.md
+++ b/docs/specs/2026-04-13-agent-guidance-framework-design.md
@@ -1,0 +1,312 @@
+# Agent Guidance Framework
+
+**Date:** 2026-04-13
+**Status:** Draft
+**Branch:** TBD
+**Depends on:** Persistent Agent Profiles (feat/persistent-agent-profiles)
+
+## Problem
+
+Less capable foundation models (20-30B and 7-13B parameter range) fail at multi-agent
+collaboration through octo-santa because they lack emergent capabilities that stronger
+models use to bridge gaps in guidance: identity internalization, event-driven reasoning,
+tool pruning, and goal pursuit.
+
+Observable failures from testing Gemma4:26b via opencode:
+
+1. Agents spiral on tool mechanics instead of pursuing business goals
+2. No autonomous reaction to incoming messages — require explicit human prompting
+3. Tool selection paralysis — consider bash, python, curl for messaging tasks
+4. Shallow message comprehension — summarize instead of acting
+5. No conversation state awareness — each turn starts from scratch
+6. Zero proactive behavior — pure instruction-followers
+
+Root cause: the gap isn't in the tools. It's in the **guidance layer** between tools and
+agent decision-making. Capable models generate this layer internally; weaker models need
+it externally.
+
+## Solution
+
+A two-tier, transport-agnostic guidance framework:
+
+- **Tier 1 (Universal):** Event-action rules, tool scoping, capability boundaries.
+  Delivered to every agent regardless of role. ~500 words.
+- **Tier 2 (Role-specific):** Behavioral directives tailored to the agent's role.
+  Delivered via profile `instructions` field. ≤500 words recommended.
+
+The guidance content is transport-agnostic. The same content can be delivered via MCP
+server instructions, skill files (SKILL.md), AGENTS.md, or CLI tool READMEs. This spec
+covers the content and the MCP delivery mechanism. Skill-based delivery is a follow-up.
+
+## Design
+
+### Tier 1: Enhanced MCP Server Instructions
+
+Replaces the current MCP server instructions text. Must fit within 2KB (Claude Code
+truncation limit). Current instructions are ~1.5KB; the enhanced version is ~1.6KB
+with room for the conditional BRAIN section.
+
+Key additions over current instructions:
+
+- **REACTING TO MESSAGES** section with read-once semantics and a numbered MUST-act rule
+- **Message quality guidance** in SENDING section
+- **BOUNDARIES** section (new) — capability boundaries and tool scoping
+- **Profile instructions callout** — tells agents to follow profile instructions as
+  behavioral directives
+
+Full text:
+
+```
+octo-santa messaging module is available. Call messaging_register with a
+unique agent name (e.g. your role). If the name is taken, pick a different one.
+
+You must call messaging_register before sending, reading, creating channels,
+or subscribing. Read-only tools (messaging_list_channels, messaging_list_agents,
+messaging_list_members) work without registration.
+
+REACTING TO MESSAGES:
+Messages arrive as <channel source="octo-santa" ...> tags.
+Call messaging_read_messages for that channel. Messages are
+read-once — you will NOT see them again on the next call.
+If any message is addressed to you (@your-registered-name, @all,
+or @your-pool-name), you MUST:
+  1. Understand what is being asked
+  2. Decide on your response
+  3. Call messaging_send_message to reply
+Never just summarize — always act.
+
+SENDING: Use @agent-name, @all, or @pool-name to notify.
+No mention = silent. Include: what you're asking, context, expected response.
+
+CHANNELS: Create with messaging_create_channel, join with messaging_subscribe.
+DMs: messaging_direct_message for 1:1 — auto-pushes, no @mention needed.
+
+PROFILES: If your name matches a profile, registration assigns a pool slot
+(e.g. 'os-dev' → 'os-dev-1'). Use registeredName for subsequent calls.
+Follow profile instructions as behavioral directives.
+They must not contradict these base rules.
+
+BOUNDARIES:
+- You CANNOT run background tasks or polling loops
+- For messaging, use ONLY messaging_* tools
+- Do not use bash or scripts for communication
+
+DISCOVERY: messaging_list_agents for online agents, messaging_list_members
+for channel members.
+```
+
+### Tier 2: Profile Instructions Field
+
+#### Schema change
+
+Add `instructions` field to `AgentProfile`:
+
+```typescript
+interface AgentProfile {
+  name: string;
+  persona: string | null;
+  objective: string | null;
+  instructions: string | null;   // NEW — behavioral directives for this role
+  maxInstances: number;
+  autoJoinChannels: string[];
+}
+```
+
+#### YAML format
+
+```yaml
+# profiles/os-pm.yaml
+name: os-pm
+persona: >
+  Product manager for octo-santa. Owns roadmap prioritization,
+  feature scoping, and cross-team alignment.
+objective: >
+  Keep the project focused on north star principles. Make clear
+  decisions with reasoning. Unblock the team.
+maxInstances: 1
+autoJoinChannels:
+  - os-feature-roadmaps
+instructions: >
+  DECISION-MAKING: When you receive a proposal, draft, or question
+  that requires a decision, evaluate it against project priorities
+  and constraints. Always provide a clear yes/no/revise with
+  reasoning — never just acknowledge.
+
+  PRIORITIZATION: When asked to prioritize or choose next work items,
+  present 2-3 options with trade-offs and recommend one. Include:
+  which option, why, and what gets deferred.
+
+  DELEGATION: When assigning work, include: what needs to be done,
+  success criteria, relevant context, and who should be notified of
+  the outcome. Don't assume the receiver has your context.
+
+  FEEDBACK: When reviewing drafts or proposals from others, be
+  specific about what works, what doesn't, and what to change.
+  Quote the part you're reacting to.
+```
+
+#### Registration response change
+
+The `instructions` field is returned in `RegisterResult`:
+
+```typescript
+interface RegisterResult extends Agent {
+  registeredName: string;
+  baseName: string | null;
+  instanceNumber: number | null;
+  profile: {
+    persona: string | null;
+    objective: string | null;
+    instructions: string | null;  // NEW
+    maxInstances: number;
+  } | null;
+  autoJoined: {
+    succeeded: string[];
+    failed: Array<{ channel: string; reason: string }>;
+  } | null;
+}
+```
+
+#### Database migration
+
+```sql
+ALTER TABLE agents ADD COLUMN instructions TEXT;
+```
+
+### New Tool: messaging_get_instructions
+
+Returns the agent's profile instructions and optionally the Tier 1 universal guidance.
+Mitigates harness persistence issues — agents or harnesses can call this to refresh
+instructions after context compaction.
+
+```typescript
+// Tool definition
+{
+  name: "messaging_get_instructions",
+  description: "Re-read your profile instructions and universal messaging guidance. "
+    + "Call this if you've lost context or are unsure how to act.",
+  inputSchema: {
+    agent_id: string,          // required
+    include_universal: boolean // optional, default true
+  }
+}
+```
+
+Response:
+
+```typescript
+{
+  universal: string | null,     // Tier 1 MCP instructions (if include_universal=true)
+  profile: {
+    persona: string | null,
+    objective: string | null,
+    instructions: string | null // Tier 2 profile instructions
+  } | null
+}
+```
+
+No new port needed — reads from the existing `ProfileRepository` for profile data.
+Universal guidance is a static string constant defined in `src/transports/mcp-stdio/`
+(co-located with `buildInstructions()` which already owns the MCP instruction text).
+
+### Precedence Rules
+
+1. **Harness system prompt** (CLAUDE.md, AGENTS.md, etc.) — highest priority
+2. **Profile instructions** (Tier 2) — role-specific behavioral directives
+3. **MCP server instructions** (Tier 1) — universal behavioral floor
+
+Profile instructions **refine** but do not override Tier 1 rules. For example, Tier 1
+says "always act on messages addressed to you." A profile can narrow this: "only respond
+to messages tagged #urgent." But a profile cannot say "ignore all messages" — that
+contradicts the behavioral floor.
+
+The MCP instructions include a self-documenting precedence statement: "If your profile
+includes instructions, follow them as behavioral directives for your role. Profile
+instructions add role-specific behavior but must not contradict these base rules."
+
+### Addressing Definitions
+
+Tier 1 event-action rules reference "addressed to you." This means the message contains:
+
+- `@your-registered-name` (exact match, e.g., `@os-dev-1`)
+- `@all` (broadcast to all subscribers)
+- `@your-pool-name` (pool-wide, e.g., `@os-dev` reaches `os-dev-1`, `os-dev-2`, etc.)
+
+Messages mentioning other agents (`@os-pm` when you are `os-dev-1`) are **not**
+addressed to you. Do not respond unless you have relevant information to contribute.
+
+## Scope
+
+### In scope
+
+1. Add `instructions` field to profile schema (type, YAML parsing, DB migration,
+   registration response)
+2. Add `messaging_get_instructions` tool
+3. Rewrite MCP server instructions with Tier 1 content
+4. Ship os-pm sample profile with instructions
+5. Tests — profile instructions round-trip (YAML → DB → registration → get_instructions)
+
+### Out of scope
+
+1. `/using-octo-santa` blanket skill for skill-based harnesses
+2. Harness-specific integration patterns (opencode, Pi, Codex)
+3. Instruction enforcement / tool allowlists (Feature 3: plugin ecosystem)
+4. Brain-stored playbook library
+5. Instruction length validation/warnings
+
+### Non-goals
+
+- Changing how capable models behave — this is additive, not constraining
+- Replacing harness-level system prompts — octo-santa owns collaboration guidance only
+- Structured/machine-parseable instruction format — free-text prose is the design choice
+
+## Guidelines for Profile Authors
+
+- **Keep instructions ≤500 words.** If you need more, consider splitting role-specific
+  knowledge into brain documents and referencing them.
+- **Only reference messaging_* tools.** References to brain_* tools should be conditional:
+  "If brain is available, read the coordinator-playbook."
+- **Use imperative, terse language.** Weak models follow direct instructions better than
+  nuanced prose.
+- **Structure with labeled sections.** E.g., "DECISION-MAKING:", "DELEGATION:". This
+  helps weak models locate relevant guidance.
+- **Don't duplicate Tier 1 rules.** The universal guidance already covers event-action
+  rules, tool scoping, and boundaries. Profile instructions handle role-specific behavior.
+
+## Validation
+
+### Automated tests (required before merge)
+
+- Profile instructions round-trip: YAML → DB → registration response → getInstructions
+- `messaging_get_instructions` tool: profiled agent, unprofiled agent, include_universal toggle, binding enforcement
+- `buildInstructions` byte budget: must stay under 2KB with and without brain config
+- `buildInstructions` content: REACTING TO MESSAGES, BOUNDARIES, BRAIN, precedence statement
+
+### Transcript replay test (planned follow-up)
+
+The os-pm sample profile should resolve three of four transcript failures when used with
+Tier 1 instructions (Scenario 3 is only partially mitigated without an os-tl profile):
+
+1. **Polling spiral** — RESOLVED. Tier 1 BOUNDARIES section eliminates bash/script consideration
+2. **No action on messages** — RESOLVED. Tier 1 REACTING TO MESSAGES MUST-act rule + Tier 2
+   DECISION-MAKING directive
+3. **Bare directive messages** — PARTIALLY MITIGATED. Tier 1 SENDING message quality
+   guidance helps, but full resolution requires an os-tl profile with DELEGATION instructions
+   (sender-side guidance). This spec ships os-pm only; os-tl is a follow-up.
+4. **Double-read confusion** — RESOLVED. Tier 1 read-once semantics explanation
+
+**Known residual risk:** The failure analysis identifies state-tracking guidance ("before
+each action, review your recent message history") as a gap. This is intentionally omitted
+from v1 — it requires harness-level support for context persistence, which is out of scope.
+
+### Cross-harness test (planned follow-up)
+
+Profile instructions delivered via `messaging_register` response should be visible in
+conversation history on Claude Code, opencode, and any MCP-compatible harness. This is
+a manual validation step, not an automated test.
+
+## Analysis
+
+Full failure analysis and permutation evaluation available in:
+- `docs/analysis/2026-04-13-less-capable-agent-failure-analysis.md`
+- `docs/analysis/2026-04-13-approach1-permutation-evaluation.md`

--- a/docs/specs/2026-04-13-agent-guidance-framework-design.md
+++ b/docs/specs/2026-04-13-agent-guidance-framework-design.md
@@ -65,9 +65,10 @@ or subscribing. Read-only tools (messaging_list_channels, messaging_list_agents,
 messaging_list_members) work without registration.
 
 REACTING TO MESSAGES:
-Messages arrive as <channel source="octo-santa" ...> tags.
-Call messaging_read_messages for that channel. Messages are
-read-once — you will NOT see them again on the next call.
+Messages are PUSHED to you as <channel source="octo-santa" ...> tags
+when you are mentioned. Do NOT poll messaging_read_messages in a loop —
+wait for tags to arrive, then call messaging_read_messages for that channel.
+Messages are read-once — you will NOT see them again on the next call.
 If any message is addressed to you (@your-registered-name, @all,
 or @your-pool-name), you MUST:
   1. Understand what is being asked

--- a/src/core/messaging/service.ts
+++ b/src/core/messaging/service.ts
@@ -117,7 +117,7 @@ export class MessagingService {
         profile.name,
         this.pid,
         profile.maxInstances,
-        { persona: profile.persona, objective: profile.objective }
+        { persona: profile.persona, objective: profile.objective, instructions: profile.instructions }
       );
       const autoJoined = this.performAutoJoin(registeredName, profile.autoJoinChannels);
       return {
@@ -128,6 +128,7 @@ export class MessagingService {
         profile: {
           persona: profile.persona,
           objective: profile.objective,
+          instructions: profile.instructions,
           maxInstances: profile.maxInstances,
         },
         autoJoined,
@@ -353,6 +354,30 @@ export class MessagingService {
       agent_id: agent.id,
       active: isAgentActive(agent),
     }));
+  }
+
+  getInstructions(agentId: string): {
+    universal: string | null;
+    profile: { persona: string | null; objective: string | null; instructions: string | null } | null;
+  } {
+    this.requireRegistered(agentId);
+    const agent = this.agents.findById(agentId);
+    if (!agent) return { universal: null, profile: null };
+
+    // Read from persisted DB data, not live YAML — instructions are
+    // snapshotted at registration time and should not change mid-session.
+    if (!agent.base_name) {
+      return { universal: null, profile: null };
+    }
+
+    return {
+      universal: null, // Populated by the transport layer (adapter owns the text)
+      profile: {
+        persona: agent.persona,
+        objective: agent.objective,
+        instructions: agent.instructions,
+      },
+    };
   }
 
   readRecent(channelId: number, limit: number): Message[] {

--- a/src/core/messaging/types.ts
+++ b/src/core/messaging/types.ts
@@ -8,6 +8,7 @@ export interface Agent {
   base_name: string | null;
   persona: string | null;
   objective: string | null;
+  instructions: string | null;
 }
 
 export interface Channel {

--- a/src/core/ports.ts
+++ b/src/core/ports.ts
@@ -14,7 +14,7 @@ import type { AgentProfile } from "./profiles/types";
 export interface AgentRepository {
   findById(id: string): Agent | null;
   register(agentId: string, pid: number, profileFields?: {
-    baseName: string; persona: string | null; objective: string | null;
+    baseName: string; persona: string | null; objective: string | null; instructions: string | null;
   }): Agent;
   heartbeatOrReclaim(agentId: string, pid: number): HeartbeatResult;
   listAll(): Agent[];
@@ -24,7 +24,7 @@ export interface AgentRepository {
     baseName: string,
     pid: number,
     maxInstances: number,
-    profileFields: { persona: string | null; objective: string | null }
+    profileFields: { persona: string | null; objective: string | null; instructions: string | null }
   ): { agent: Agent; registeredName: string; instanceNumber: number | null };
 }
 

--- a/src/core/profiles/types.ts
+++ b/src/core/profiles/types.ts
@@ -4,6 +4,7 @@ export interface AgentProfile {
   name: string;          // base name
   persona: string | null;
   objective: string | null;
+  instructions: string | null;
   maxInstances: number;  // >= 1
   autoJoinChannels: string[];
 }
@@ -20,6 +21,7 @@ export interface RegisterResult extends Agent {
   profile: {
     persona: string | null;
     objective: string | null;
+    instructions: string | null;
     maxInstances: number;
   } | null;
   autoJoined: AutoJoinResult | null;

--- a/src/storage/sqlite/agent-repo.ts
+++ b/src/storage/sqlite/agent-repo.ts
@@ -25,35 +25,37 @@ export class SqliteAgentRepo implements AgentRepository {
   private _upsertAgent(
     agentId: string,
     pid: number,
-    profileFields?: { baseName: string; persona: string | null; objective: string | null }
+    profileFields?: { baseName: string; persona: string | null; objective: string | null; instructions: string | null }
   ): void {
     const now = Date.now();
     if (profileFields) {
       this.db
         .query(
-          `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+          `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective, instructions)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
            ON CONFLICT(id) DO UPDATE SET
              last_seen_at = excluded.last_seen_at,
              pid = excluded.pid,
              registered_at = excluded.registered_at,
              base_name = excluded.base_name,
              persona = excluded.persona,
-             objective = excluded.objective`
+             objective = excluded.objective,
+             instructions = excluded.instructions`
         )
-        .run(agentId, now, now, pid, now, profileFields.baseName, profileFields.persona, profileFields.objective);
+        .run(agentId, now, now, pid, now, profileFields.baseName, profileFields.persona, profileFields.objective, profileFields.instructions);
     } else {
       this.db
         .query(
-          `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
-           VALUES (?, ?, ?, ?, ?, NULL, NULL, NULL)
+          `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective, instructions)
+           VALUES (?, ?, ?, ?, ?, NULL, NULL, NULL, NULL)
            ON CONFLICT(id) DO UPDATE SET
              last_seen_at = excluded.last_seen_at,
              pid = excluded.pid,
              registered_at = excluded.registered_at,
              base_name = excluded.base_name,
              persona = excluded.persona,
-             objective = excluded.objective`
+             objective = excluded.objective,
+             instructions = excluded.instructions`
         )
         .run(agentId, now, now, pid, now);
     }
@@ -62,7 +64,7 @@ export class SqliteAgentRepo implements AgentRepository {
   register(
     agentId: string,
     pid: number,
-    profileFields?: { baseName: string; persona: string | null; objective: string | null }
+    profileFields?: { baseName: string; persona: string | null; objective: string | null; instructions: string | null }
   ): Agent {
     const doRegister = this.db.transaction(() => {
       const existing = this.findById(agentId);
@@ -86,7 +88,7 @@ export class SqliteAgentRepo implements AgentRepository {
     baseName: string,
     pid: number,
     maxInstances: number,
-    profileFields: { persona: string | null; objective: string | null }
+    profileFields: { persona: string | null; objective: string | null; instructions: string | null }
   ): { agent: Agent; registeredName: string; instanceNumber: number | null } {
     const doRegister = this.db.transaction(() => {
       const existing = this.findByBaseName(baseName);

--- a/src/storage/sqlite/domain-repo.ts
+++ b/src/storage/sqlite/domain-repo.ts
@@ -48,7 +48,7 @@ export class SqliteDomainRepo implements DomainRepository {
       claims: claims.filter((c) => c.domain_identifier === d.identifier).map((c) => ({
         agent_id: c.agent_id,
         pid: c.pid,
-        agent: { id: c.id, created_at: c.created_at, last_seen_at: c.last_seen_at, pid: c.agent_pid, registered_at: c.registered_at, base_name: null, persona: null, objective: null } as Agent,
+        agent: { id: c.id, created_at: c.created_at, last_seen_at: c.last_seen_at, pid: c.agent_pid, registered_at: c.registered_at, base_name: null, persona: null, objective: null, instructions: null } as Agent,
       })),
     }));
   }

--- a/src/storage/sqlite/migrations.ts
+++ b/src/storage/sqlite/migrations.ts
@@ -143,6 +143,12 @@ const messagingMigrations: Migration[] = [
       CREATE INDEX idx_agents_base_name ON agents(base_name);
     `,
   },
+  {
+    name: "messaging_004_agent_instructions",
+    up: `
+      ALTER TABLE agents ADD COLUMN instructions TEXT;
+    `,
+  },
 ];
 
 const brainMigrations: Migration[] = [

--- a/src/storage/yaml-profiles/store.ts
+++ b/src/storage/yaml-profiles/store.ts
@@ -16,6 +16,7 @@ const KNOWN_FIELDS = new Set([
   "name",
   "persona",
   "objective",
+  "instructions",
   "maxInstances",
   "autoJoinChannels",
 ]);
@@ -78,6 +79,18 @@ function parseProfile(filePath: string, content: string): AgentProfile {
     objective = rawObjective;
   }
 
+  // --- instructions ---
+  const rawInstructions = raw["instructions"];
+  let instructions: string | null = null;
+  if (rawInstructions !== undefined && rawInstructions !== null) {
+    if (typeof rawInstructions !== "string") {
+      throw new Error(
+        `Profile "${name}": instructions must be a string or null/undefined, got ${typeof rawInstructions}`
+      );
+    }
+    instructions = rawInstructions;
+  }
+
   // --- maxInstances ---
   const rawMax = raw["maxInstances"];
   let maxInstances = 1;
@@ -109,7 +122,7 @@ function parseProfile(filePath: string, content: string): AgentProfile {
     autoJoinChannels = rawChannels as string[];
   }
 
-  return { name, persona, objective, maxInstances, autoJoinChannels };
+  return { name, persona, objective, instructions, maxInstances, autoJoinChannels };
 }
 
 function checkPoolNameCollisions(profiles: AgentProfile[]): void {

--- a/src/transports/mcp-stdio/adapter.ts
+++ b/src/transports/mcp-stdio/adapter.ts
@@ -19,45 +19,61 @@ export function buildInstructions(
   let instructions =
     "octo-santa messaging module is available. Call messaging_register with a " +
     "unique agent name (e.g. your role). If the name is taken, pick a different one.\n\n" +
-    "You must call messaging_register before sending, reading, creating channels, or subscribing. " +
-    "Read-only tools (messaging_list_channels, messaging_list_agents, messaging_list_members) work without registration.\n\n" +
-    "Messages from other agents arrive as <channel source=\"octo-santa\" ...> tags. " +
-    "To acknowledge and see full history, call messaging_read_messages with the channel. " +
-    "To reply, call messaging_send_message with the same channel.\n\n" +
-    "CHANNELS: Messages live in named channels. Create channels with messaging_create_channel, " +
-    "then subscribe with messaging_subscribe to receive notifications. " +
-    "Channels must exist before sending — use messaging_create_channel to create them.\n\n" +
-    "MENTIONS:\n" +
-    "- @agent-name → only that agent gets notified\n" +
-    "- @all → all channel subscribers get notified\n" +
-    "- @pool-name → all live instances of that pool get notified (e.g. @os-dev reaches os-dev-1, os-dev-2, etc.)\n" +
-    "- No mention → message is silent (recipients must read actively)\n\n" +
-    "Use @mentions to get attention. Messages without mentions are for " +
-    "context/logging — recipients see them when they check the channel.\n\n" +
-    "PROFILES: If your name matches a loaded profile, registration assigns you a pool slot " +
-    "(e.g., registering as 'os-dev' may bind you as 'os-dev-1'). " +
-    "Always use the `registeredName` from the registration response for subsequent calls.\n\n" +
-    "NOTIFICATIONS: There are two notification modes:\n" +
-    "- DM channels (created via messaging_direct_message): All messages push automatically to both parties. No @mention needed.\n" +
-    "- Regular channels (created via messaging_create_channel): Only messages with @mentions trigger push notifications. Unmentioned messages are silent.\n\n" +
-    "To ensure an agent sees your message immediately, either use @agent-name in a regular channel or use messaging_direct_message for 1:1 conversations.\n\n" +
-    "DISCOVERY: Use messaging_list_agents to see currently online agents. " +
-    "Use messaging_list_agents with include_stale=true to see all agents including disconnected ones. " +
-    "Use messaging_list_members to see who is in a specific channel.";
+    "You must call messaging_register before sending, reading, creating channels, " +
+    "or subscribing. Read-only tools (messaging_list_channels, messaging_list_agents, " +
+    "messaging_list_members) work without registration.\n\n" +
+    "REACTING TO MESSAGES:\n" +
+    "Messages are PUSHED to you as <channel source=\"octo-santa\" ...> tags " +
+    "when you are mentioned or receive a DM. Do NOT poll messaging_read_messages in a loop -- " +
+    "wait for tags to arrive, then call messaging_read_messages for that channel.\n" +
+    "Unread delivery is read-once; use before_id for history.\n" +
+    "If any message is addressed to you (@your-registered-name, @all, " +
+    "or @your-pool-name), you MUST:\n" +
+    "  1. Understand what is being asked\n" +
+    "  2. Decide on your response\n" +
+    "  3. Call messaging_send_message to reply\n" +
+    "Never just summarize -- always act.\n\n" +
+    "SENDING: @agent-name, @all, or @pool-name to notify. " +
+    "No mention = silent. Be specific: what you need, why, expected response.\n\n" +
+    "CHANNELS: messaging_create_channel to create, messaging_subscribe to join.\n" +
+    "DMs: messaging_direct_message for 1:1 -- auto-pushes, no @mention needed.\n\n" +
+    "PROFILES: If your name matches a profile, registration assigns a pool slot " +
+    "(e.g. 'os-dev' -> 'os-dev-1'). Use registeredName for subsequent calls. " +
+    "Follow profile instructions as behavioral directives. " +
+    "They must not contradict these base rules.\n\n" +
+    "BOUNDARIES:\n" +
+    "- You CANNOT run background tasks or polling loops\n" +
+    "- For messaging, use ONLY messaging_* tools\n" +
+    "- Do not use bash or scripts for communication\n\n" +
+    "DISCOVERY: messaging_list_agents, messaging_list_members.";
 
-  instructions += "\n\n" + "BRAIN: ";
-  if (config?.domain) {
-    instructions += `This repo is domain "${config.domain.identifier}" (${config.domain.description}). `;
-  }
-  instructions +=
+  const brainSuffix =
     "Use brain_index to list local brain docs, brain_read to read one. " +
     "Use brain_shared_index/brain_shared_read for shared docs in ~/.octo-santa/brain/. " +
     "Use brain_find_expert to discover domain experts across repos. " +
     "Use brain_claim_domain after messaging_register to become a queryable expert. " +
     "Use messaging_direct_message to DM another agent.";
 
+  instructions += "\n\nBRAIN: ";
+  if (config?.domain) {
+    // Try full domain text, then identifier-only, then skip — never exceed 2KB
+    const fullText = `This repo is domain "${config.domain.identifier}" (${config.domain.description}). `;
+    const shortText = `This repo is domain "${config.domain.identifier}". `;
+    const base = instructions + brainSuffix;
+    if (Buffer.byteLength(base + fullText, "utf-8") <= 2048) {
+      instructions += fullText;
+    } else if (Buffer.byteLength(base + shortText, "utf-8") <= 2048) {
+      instructions += shortText;
+    }
+    // else: skip domain text entirely to stay within budget
+  }
+  instructions += brainSuffix;
+
   return instructions;
 }
+
+/** Tier 1 universal guidance — returned by messaging_get_instructions. */
+export const UNIVERSAL_GUIDANCE = buildInstructions(null);
 
 // --- Tool registration ---
 
@@ -65,7 +81,8 @@ export function registerMessagingTools(
   server: McpServer,
   messaging: MessagingService,
   onAgentId?: (agentId: string) => { commit: (resolvedName?: string) => void },
-  onProfile?: (profile: { baseName: string; persona: string | null; objective: string | null }) => void
+  onProfile?: (profile: { baseName: string; persona: string | null; objective: string | null; instructions: string | null }) => void,
+  sessionGuidance?: string
 ): void {
   server.registerTool("messaging_register", {
     description:
@@ -88,7 +105,12 @@ export function registerMessagingTools(
     const result = messaging.register(agent_id);
     handle?.commit(result.registeredName);
     if (result.baseName) {
-      onProfile?.({ baseName: result.baseName, persona: result.profile?.persona ?? null, objective: result.profile?.objective ?? null });
+      onProfile?.({
+        baseName: result.baseName,
+        persona: result.profile?.persona ?? null,
+        objective: result.profile?.objective ?? null,
+        instructions: result.profile?.instructions ?? null,
+      });
     }
     return jsonResult(result);
   });
@@ -214,6 +236,28 @@ export function registerMessagingTools(
     },
   }, async ({ channel }) => {
     return jsonResult(messaging.listMembers(channel));
+  });
+
+  server.registerTool("messaging_get_instructions", {
+    description:
+      "Re-read your profile instructions and universal messaging guidance. " +
+      "Call this if you've lost context or are unsure how to act.",
+    inputSchema: {
+      agent_id: z.string().trim().min(1).describe("Your registered agent name"),
+      include_universal: z
+        .boolean()
+        .optional()
+        .default(true)
+        .describe("Include universal messaging guidance (default: true)"),
+    },
+  }, async ({ agent_id, include_universal }) => {
+    return withAgent(onAgentId, agent_id, () => {
+      const result = messaging.getInstructions(agent_id);
+      return jsonResult({
+        universal: include_universal ? (sessionGuidance ?? UNIVERSAL_GUIDANCE) : null,
+        profile: result.profile,
+      });
+    });
   });
 
   server.registerTool("messaging_rename_channel", {
@@ -366,7 +410,7 @@ export async function startMcpStdio(opts: McpStdioOpts): Promise<void> {
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   let boundAgentId: string | null = null;
   let pollerRef: { stop(): void } | null = null;
-  let boundProfile: { baseName: string; persona: string | null; objective: string | null } | null = null;
+  let boundProfile: { baseName: string; persona: string | null; objective: string | null; instructions: string | null } | null = null;
 
   function onAgentId(agentId: string): { commit: (resolvedName?: string) => void } {
     if (boundAgentId !== null) {
@@ -404,9 +448,10 @@ export async function startMcpStdio(opts: McpStdioOpts): Promise<void> {
     };
   }
 
+  const sessionInstructions = buildInstructions(config, brainIndex);
   registerMessagingTools(mcpServer, messaging, onAgentId, (profile) => {
     boundProfile = profile;
-  });
+  }, sessionInstructions);
   registerBrainTools(mcpServer, brain, config, hasBrain, onAgentId);
 
   const transport = new StdioServerTransport();
@@ -427,7 +472,7 @@ export async function startMcpStdio(opts: McpStdioOpts): Promise<void> {
   // Bootstrap nudge — prompt agent to register before any tool call
   let bootstrapMsg =
     "octo-santa messaging module is available. Call messaging_register with a unique agent name (e.g. your role), then create or subscribe to channels to start receiving push notifications. If the name is taken, pick a different one. " +
-    "If profiles are configured, your name may be resolved to a pool slot (e.g. 'os-dev' → 'os-dev-1') — always use the `registeredName` from the response for subsequent calls.";
+    "If profiles are configured, your name may be resolved to a pool slot (e.g. 'os-dev' -> 'os-dev-1') — always use the `registeredName` from the response for subsequent calls.";
   if (config?.domain) {
     bootstrapMsg +=
       `\n\nBrain module active — this repo is domain "${config.domain.identifier}" (${config.domain.description}). ` +

--- a/tests/hex/core/pool-mentions.test.ts
+++ b/tests/hex/core/pool-mentions.test.ts
@@ -105,6 +105,7 @@ describe("pool-wide mention expansion", () => {
       name: "os-dev",
       persona: null,
       objective: null,
+      instructions: null,
       maxInstances: 3,
       autoJoinChannels: [],
     });
@@ -153,6 +154,7 @@ describe("pool-wide mention expansion", () => {
       name: "os-dev",
       persona: null,
       objective: null,
+      instructions: null,
       maxInstances: 3,
       autoJoinChannels: [],
     });
@@ -184,6 +186,7 @@ describe("pool-wide mention expansion", () => {
       name: "os-dev",
       persona: null,
       objective: null,
+      instructions: null,
       maxInstances: 3,
       autoJoinChannels: [],
     });
@@ -218,6 +221,7 @@ describe("pool-wide mention expansion", () => {
       name: "os-dev",
       persona: null,
       objective: null,
+      instructions: null,
       maxInstances: 3,
       autoJoinChannels: [],
     });
@@ -243,6 +247,7 @@ describe("pool-wide mention expansion", () => {
       name: "os-dev",
       persona: null,
       objective: null,
+      instructions: null,
       maxInstances: 3,
       autoJoinChannels: [],
     });

--- a/tests/hex/core/profile-integration.test.ts
+++ b/tests/hex/core/profile-integration.test.ts
@@ -72,6 +72,7 @@ describe("Profile Integration — Full Lifecycle", () => {
         "maxInstances: 1",
         "autoJoinChannels:",
         "  - coordination",
+        'instructions: "When you receive a proposal, evaluate against priorities and provide a clear decision."',
       ].join("\n")
     );
 
@@ -133,6 +134,9 @@ describe("Profile Integration — Full Lifecycle", () => {
     expect(pmResult.autoJoined).not.toBeNull();
     expect(pmResult.autoJoined!.succeeded).toContain("coordination");
     expect(pmResult.autoJoined!.failed).toEqual([]);
+    expect(pmResult.profile!.instructions).toBe(
+      "When you receive a proposal, evaluate against priorities and provide a clear decision."
+    );
 
     // ── Step 5b: Register pool agent (os-dev, maxInstances=3) ─────────────
 
@@ -185,6 +189,16 @@ describe("Profile Integration — Full Lifecycle", () => {
     expect(pmAgent).toBeDefined();
     expect(pmAgent!.persona).toBe("Product manager");
     expect(pmAgent!.objective).toBe("Drive roadmap");
+    expect(pmAgent!.instructions).toBe(
+      "When you receive a proposal, evaluate against priorities and provide a clear decision."
+    );
+
+    // Verify DB persistence directly via raw SQL
+    const row = db.query("SELECT instructions FROM agents WHERE id = ?").get("os-pm") as { instructions: string } | null;
+    expect(row).not.toBeNull();
+    expect(row!.instructions).toBe(
+      "When you receive a proposal, evaluate against priorities and provide a clear decision."
+    );
 
     const devAgent = agents.find((a) => a.id === "os-dev-1");
     expect(devAgent).toBeDefined();
@@ -204,6 +218,94 @@ describe("Profile Integration — Full Lifecycle", () => {
     expect(botAgent!.persona).toBeNull();
     expect(botAgent!.objective).toBeNull();
     expect(botAgent!.base_name).toBeNull();
+    expect(botAgent!.instructions).toBeNull();
+
+    db.close();
+  });
+
+  it("getInstructions returns profile instructions for registered agent", () => {
+    writeFileSync(
+      join(profileDir, "os-pm.yaml"),
+      [
+        "name: os-pm",
+        'persona: "Product manager"',
+        'objective: "Drive roadmap"',
+        'instructions: "Evaluate proposals against priorities."',
+      ].join("\n")
+    );
+
+    const profiles = new YamlProfileStore(profileDir);
+    const db = createDb(dbPath);
+    runMigrations(db, allMigrations);
+    const repos = createSqliteRepos(db);
+    const svc = new MessagingService(
+      repos.agents, repos.channels, repos.messages, repos.cursors,
+      process.pid, undefined, profiles
+    );
+
+    svc.register("os-pm");
+    const result = svc.getInstructions("os-pm");
+    expect(result.profile).not.toBeNull();
+    expect(result.profile!.instructions).toBe("Evaluate proposals against priorities.");
+    expect(result.profile!.persona).toBe("Product manager");
+
+    db.close();
+  });
+
+  it("getInstructions returns null profile for agent without profile", () => {
+    const db = createDb(dbPath);
+    runMigrations(db, allMigrations);
+    const repos = createSqliteRepos(db);
+    const svc = new MessagingService(
+      repos.agents, repos.channels, repos.messages, repos.cursors,
+      process.pid
+    );
+
+    svc.register("random-bot");
+    const result = svc.getInstructions("random-bot");
+    expect(result.profile).toBeNull();
+
+    db.close();
+  });
+
+  it("getInstructions throws for unregistered agent", () => {
+    const db = createDb(dbPath);
+    runMigrations(db, allMigrations);
+    const repos = createSqliteRepos(db);
+    const svc = new MessagingService(
+      repos.agents, repos.channels, repos.messages, repos.cursors,
+      process.pid
+    );
+
+    expect(() => svc.getInstructions("nobody")).toThrow(/messaging_register/);
+
+    db.close();
+  });
+
+  it("getInstructions returns universal as null (transport layer populates it)", () => {
+    writeFileSync(
+      join(profileDir, "os-pm.yaml"),
+      [
+        "name: os-pm",
+        'persona: "Product manager"',
+        'instructions: "Evaluate proposals."',
+      ].join("\n")
+    );
+
+    const profiles = new YamlProfileStore(profileDir);
+    const db = createDb(dbPath);
+    runMigrations(db, allMigrations);
+    const repos = createSqliteRepos(db);
+    const svc = new MessagingService(
+      repos.agents, repos.channels, repos.messages, repos.cursors,
+      process.pid, undefined, profiles
+    );
+
+    svc.register("os-pm");
+    const result = svc.getInstructions("os-pm");
+    expect(result.universal).toBeNull();
+    expect(result.profile).not.toBeNull();
+    expect(result.profile!.instructions).toBe("Evaluate proposals.");
 
     db.close();
   });

--- a/tests/hex/core/profile-registration.test.ts
+++ b/tests/hex/core/profile-registration.test.ts
@@ -61,6 +61,7 @@ describe("singleton profile registration", () => {
       name: "os-dev",
       persona: "Senior developer",
       objective: "Write clean code",
+      instructions: null,
       maxInstances: 1,
       autoJoinChannels: [],
     });
@@ -91,6 +92,7 @@ describe("singleton profile registration", () => {
       name: "os-dev",
       persona: "Senior developer",
       objective: "Write clean code",
+      instructions: null,
       maxInstances: 1,
       autoJoinChannels: [],
     });
@@ -119,6 +121,7 @@ describe("pool profile registration", () => {
       name: "worker",
       persona: null,
       objective: "Process tasks",
+      instructions: null,
       maxInstances: 3,
       autoJoinChannels: [],
     });
@@ -138,6 +141,7 @@ describe("pool profile registration", () => {
       name: "os-pm",
       persona: "Product manager",
       objective: null,
+      instructions: null,
       maxInstances: 1,
       autoJoinChannels: [],
     });
@@ -155,6 +159,7 @@ describe("pool profile registration", () => {
       name: "worker",
       persona: null,
       objective: "Process tasks",
+      instructions: null,
       maxInstances: 3,
       autoJoinChannels: [],
     });
@@ -174,6 +179,7 @@ describe("pool profile registration", () => {
       name: "worker",
       persona: null,
       objective: "Process tasks",
+      instructions: null,
       maxInstances: 2,
       autoJoinChannels: [],
     });
@@ -254,6 +260,7 @@ describe("suffixed namespace reservation", () => {
       name: "os-dev",
       persona: null,
       objective: null,
+      instructions: null,
       maxInstances: 3,
       autoJoinChannels: [],
     });
@@ -271,6 +278,7 @@ describe("suffixed namespace reservation", () => {
       name: "worker",
       persona: null,
       objective: null,
+      instructions: null,
       maxInstances: 5,
       autoJoinChannels: [],
     });
@@ -308,6 +316,7 @@ describe("suffixed namespace reservation", () => {
       name: "os-dev",
       persona: null,
       objective: null,
+      instructions: null,
       maxInstances: 3,
       autoJoinChannels: [],
     });
@@ -328,6 +337,7 @@ describe("auto-join channels", () => {
       name: "os-dev",
       persona: null,
       objective: null,
+      instructions: null,
       maxInstances: 1,
       autoJoinChannels: ["general", "dev"],
     });
@@ -362,6 +372,7 @@ describe("auto-join channels", () => {
       name: "os-dev",
       persona: null,
       objective: null,
+      instructions: null,
       maxInstances: 1,
       autoJoinChannels: ["nonexistent-channel"],
     });
@@ -380,6 +391,7 @@ describe("auto-join channels", () => {
       name: "os-dev",
       persona: null,
       objective: null,
+      instructions: null,
       maxInstances: 1,
       autoJoinChannels: ["general", "missing-channel"],
     });
@@ -407,6 +419,7 @@ describe("auto-join channels", () => {
       name: "worker",
       persona: null,
       objective: null,
+      instructions: null,
       maxInstances: 3,
       autoJoinChannels: ["tasks"],
     });
@@ -441,6 +454,7 @@ describe("RegisterResult type shape", () => {
       name: "os-dev",
       persona: "dev",
       objective: "code",
+      instructions: null,
       maxInstances: 1,
       autoJoinChannels: [],
     });

--- a/tests/hex/storage/agent-repo.test.ts
+++ b/tests/hex/storage/agent-repo.test.ts
@@ -55,6 +55,7 @@ describe("SqliteAgentRepo", () => {
       baseName: "researcher",
       persona: "You are a diligent researcher.",
       objective: "Gather and summarize information.",
+      instructions: null,
     });
     expect(agent.id).toBe("researcher-1");
     expect(agent.base_name).toBe("researcher");
@@ -79,6 +80,7 @@ describe("SqliteAgentRepo", () => {
       baseName: "agent-x",
       persona: "Old persona",
       objective: "Old objective",
+      instructions: null,
     });
     // Re-register without profile — should clear profile fields
     db.run("UPDATE agents SET pid = 999999 WHERE id = ?", ["agent-x"]);
@@ -135,6 +137,7 @@ describe("SqliteAgentRepo", () => {
       baseName: "agent-a",
       persona: "Persona A",
       objective: "Objective A",
+      instructions: null,
     });
     const all = repo.listAll();
     expect(all.length).toBe(2);
@@ -177,6 +180,7 @@ describe("SqliteAgentRepo - registerWithProfile", () => {
     const result = repo.registerWithProfile("researcher", process.pid, 1, {
       persona: "Researcher persona",
       objective: "Research things",
+      instructions: null,
     });
     expect(result.registeredName).toBe("researcher");
     expect(result.instanceNumber).toBeNull();
@@ -192,6 +196,7 @@ describe("SqliteAgentRepo - registerWithProfile", () => {
     const result = repo.registerWithProfile("worker", process.pid, 3, {
       persona: null,
       objective: null,
+      instructions: null,
     });
     expect(result.registeredName).toBe("worker-1");
     expect(result.instanceNumber).toBe(1);
@@ -210,6 +215,7 @@ describe("SqliteAgentRepo - registerWithProfile", () => {
     const result = repo.registerWithProfile("worker", process.pid, 3, {
       persona: null,
       objective: null,
+      instructions: null,
     });
     // Slot 1 is dead → reclaimed
     expect(result.registeredName).toBe("worker-1");
@@ -230,6 +236,7 @@ describe("SqliteAgentRepo - registerWithProfile", () => {
     const result = repo.registerWithProfile("worker", process.pid, 3, {
       persona: null,
       objective: null,
+      instructions: null,
     });
     expect(result.registeredName).toBe("worker-2");
     expect(result.instanceNumber).toBe(2);
@@ -251,6 +258,7 @@ describe("SqliteAgentRepo - registerWithProfile", () => {
     const result = repo.registerWithProfile("worker", process.pid, 5, {
       persona: null,
       objective: null,
+      instructions: null,
     });
     expect(result.registeredName).toBe("worker-3");
     expect(result.instanceNumber).toBe(3);
@@ -262,10 +270,12 @@ describe("SqliteAgentRepo - registerWithProfile", () => {
     const first = repo.registerWithProfile("worker", process.pid, 3, {
       persona: null,
       objective: null,
+      instructions: null,
     });
     const second = repo.registerWithProfile("worker", process.pid, 3, {
       persona: null,
       objective: null,
+      instructions: null,
     });
     expect(second.registeredName).toBe(first.registeredName);
     expect(second.instanceNumber).toBe(first.instanceNumber);
@@ -276,7 +286,7 @@ describe("SqliteAgentRepo - registerWithProfile", () => {
     const { db, repo } = setup();
     const now = Date.now();
     // Seed two workers: slot 1 owned by current PID, slot 2 owned by PID 1 (init, always alive)
-    repo.registerWithProfile("worker", process.pid, 3, { persona: null, objective: null });
+    repo.registerWithProfile("worker", process.pid, 3, { persona: null, objective: null, instructions: null });
     db.run(
       `INSERT INTO agents (id, created_at, last_seen_at, pid, registered_at, base_name, persona, objective)
        VALUES ('worker-2', 1, ${now}, 1, 1, 'worker', NULL, NULL)`
@@ -287,6 +297,7 @@ describe("SqliteAgentRepo - registerWithProfile", () => {
     const result = repo.registerWithProfile("worker", process.pid + 100, 3, {
       persona: null,
       objective: null,
+      instructions: null,
     });
     expect(result.registeredName).toBe("worker-1");
     expect(result.instanceNumber).toBe(1);
@@ -308,7 +319,7 @@ describe("SqliteAgentRepo - registerWithProfile", () => {
     );
     // Both slots are alive — a third process should fail
     expect(() =>
-      repo.registerWithProfile("worker", process.pid, 2, { persona: null, objective: null })
+      repo.registerWithProfile("worker", process.pid, 2, { persona: null, objective: null, instructions: null })
     ).toThrow(/capacity/i);
     db.close();
   });
@@ -318,10 +329,12 @@ describe("SqliteAgentRepo - registerWithProfile", () => {
     const first = repo.registerWithProfile("unique-bot", process.pid, 1, {
       persona: "Bot persona",
       objective: null,
+      instructions: null,
     });
     const second = repo.registerWithProfile("unique-bot", process.pid, 1, {
       persona: "Bot persona",
       objective: null,
+      instructions: null,
     });
     expect(second.registeredName).toBe("unique-bot");
     expect(second.instanceNumber).toBeNull();
@@ -338,7 +351,7 @@ describe("SqliteAgentRepo - registerWithProfile", () => {
        VALUES ('unique-bot', 1, ${now}, 1, 1, 'unique-bot', 'Bot', NULL)`
     );
     expect(() =>
-      repo.registerWithProfile("unique-bot", process.pid, 1, { persona: "Bot", objective: null })
+      repo.registerWithProfile("unique-bot", process.pid, 1, { persona: "Bot", objective: null, instructions: null })
     ).toThrow(/already active/i);
     db.close();
   });

--- a/tests/hex/storage/yaml-profile-store.test.ts
+++ b/tests/hex/storage/yaml-profile-store.test.ts
@@ -65,6 +65,13 @@ describe("YamlProfileStore", () => {
     expect(profile!.autoJoinChannels).toEqual([]);
   });
 
+  it("defaults instructions to null when not specified", () => {
+    writeFileSync(join(dir, "simple.yaml"), `name: simple\n`);
+    const store = new YamlProfileStore(dir);
+    const profile = store.getProfile("simple");
+    expect(profile!.instructions).toBeNull();
+  });
+
   it("accepts null for persona explicitly", () => {
     writeFileSync(join(dir, "simple.yaml"), `name: simple\npersona: null\n`);
     const store = new YamlProfileStore(dir);
@@ -75,6 +82,34 @@ describe("YamlProfileStore", () => {
     writeFileSync(join(dir, "simple.yaml"), `name: simple\nobjective: null\n`);
     const store = new YamlProfileStore(dir);
     expect(store.getProfile("simple")!.objective).toBeNull();
+  });
+
+  it("loads instructions from profile YAML", () => {
+    writeFileSync(
+      join(dir, "os-pm.yaml"),
+      `name: os-pm\ninstructions: "When you receive a proposal, evaluate it against priorities."\n`
+    );
+    const store = new YamlProfileStore(dir);
+    const profile = store.getProfile("os-pm");
+    expect(profile!.instructions).toBe(
+      "When you receive a proposal, evaluate it against priorities."
+    );
+  });
+
+  it("accepts null for instructions explicitly", () => {
+    writeFileSync(join(dir, "simple.yaml"), `name: simple\ninstructions: null\n`);
+    const store = new YamlProfileStore(dir);
+    expect(store.getProfile("simple")!.instructions).toBeNull();
+  });
+
+  it("rejects non-string instructions (number)", () => {
+    writeFileSync(join(dir, "bad.yaml"), `name: bad\ninstructions: 42\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow(/instructions/i);
+  });
+
+  it("rejects non-string instructions (boolean)", () => {
+    writeFileSync(join(dir, "bad.yaml"), `name: bad\ninstructions: true\n`);
+    expect(() => new YamlProfileStore(dir)).toThrow(/instructions/i);
   });
 
   // --- listProfiles and getBaseNames ---

--- a/tests/hex/transports/mcp-instructions.test.ts
+++ b/tests/hex/transports/mcp-instructions.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "bun:test";
+import { buildInstructions, UNIVERSAL_GUIDANCE } from "../../../src/transports/mcp-stdio/adapter";
+
+describe("buildInstructions", () => {
+  // Claude Code truncates server instructions at 2KB (2048 bytes).
+  // The BRAIN section adds ~50 bytes with domain. If the base text exceeds budget,
+  // trim SENDING and DISCOVERY first -- REACTING TO MESSAGES and BOUNDARIES
+  // are highest priority for weak models.
+
+  it("stays under 2KB without brain config", () => {
+    const text = buildInstructions(null);
+    const bytes = Buffer.byteLength(text, "utf-8");
+    console.log(`buildInstructions(null): ${bytes} bytes`);
+    expect(bytes).toBeLessThan(2048);
+  });
+
+  it("stays under 2KB with brain config", () => {
+    const text = buildInstructions({
+      domain: { identifier: "test-domain", tags: ["test"], description: "A test domain" },
+      brain: { dirs: ["docs"], files: [] },
+    });
+    const bytes = Buffer.byteLength(text, "utf-8");
+    console.log(`buildInstructions(with brain): ${bytes} bytes`);
+    expect(bytes).toBeLessThan(2048);
+  });
+
+  it("includes REACTING TO MESSAGES section with anti-polling guidance", () => {
+    const text = buildInstructions(null);
+    expect(text).toContain("REACTING TO MESSAGES:");
+    expect(text).toContain("Do NOT poll");
+    expect(text).toContain("wait for tags to arrive");
+    expect(text).toContain("you MUST:");
+  });
+
+  it("includes BOUNDARIES section", () => {
+    const text = buildInstructions(null);
+    expect(text).toContain("BOUNDARIES:");
+    expect(text).toContain("CANNOT run background tasks");
+  });
+
+  it("includes BRAIN section even without domain config", () => {
+    const text = buildInstructions(null);
+    expect(text).toContain("BRAIN:");
+    expect(text).toContain("brain_index");
+  });
+
+  it("includes domain description when config has domain", () => {
+    const text = buildInstructions({
+      domain: { identifier: "my-project", tags: [], description: "My project" },
+    });
+    expect(text).toContain('domain "my-project"');
+    expect(text).toContain("My project");
+  });
+
+  it("includes precedence statement about profile instructions", () => {
+    const text = buildInstructions(null);
+    expect(text).toContain("must not contradict these base rules");
+  });
+});
+
+describe("UNIVERSAL_GUIDANCE", () => {
+  it("is a non-empty string", () => {
+    expect(typeof UNIVERSAL_GUIDANCE).toBe("string");
+    expect(UNIVERSAL_GUIDANCE.length).toBeGreaterThan(100);
+  });
+
+  it("matches buildInstructions(null)", () => {
+    expect(UNIVERSAL_GUIDANCE).toBe(buildInstructions(null));
+  });
+});

--- a/tests/messaging/binding.test.ts
+++ b/tests/messaging/binding.test.ts
@@ -255,3 +255,81 @@ describe("profile-based name resolution in transport binding", () => {
     db.close();
   });
 });
+
+describe("messaging_get_instructions tool", () => {
+  it("returns universal guidance and profile instructions for profiled agent", async () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-pm",
+      persona: "Product manager",
+      objective: "Drive roadmap",
+      instructions: "Evaluate proposals against priorities.",
+      maxInstances: 1,
+      autoJoinChannels: [],
+    });
+    const { db, handlers } = setup(profileRepo);
+
+    await handlers.messaging_register!({ agent_id: "os-pm" });
+    const result = await handlers.messaging_get_instructions!({ agent_id: "os-pm", include_universal: true });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.universal).not.toBeNull();
+    expect(parsed.universal.length).toBeGreaterThan(100);
+    expect(parsed.profile).not.toBeNull();
+    expect(parsed.profile.instructions).toBe("Evaluate proposals against priorities.");
+    expect(parsed.profile.persona).toBe("Product manager");
+
+    db.close();
+  });
+
+  it("returns null universal when include_universal is false", async () => {
+    const profileRepo = new InMemoryProfileRepo();
+    profileRepo.add({
+      name: "os-pm",
+      persona: "PM",
+      objective: null,
+      instructions: "Test instructions",
+      maxInstances: 1,
+      autoJoinChannels: [],
+    });
+    const { db, handlers } = setup(profileRepo);
+
+    await handlers.messaging_register!({ agent_id: "os-pm" });
+    const result = await handlers.messaging_get_instructions!({ agent_id: "os-pm", include_universal: false });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.universal).toBeNull();
+    expect(parsed.profile).not.toBeNull();
+    expect(parsed.profile.instructions).toBe("Test instructions");
+
+    db.close();
+  });
+
+  it("returns null profile for unprofiled agent", async () => {
+    const { db, handlers } = setup();
+
+    await handlers.messaging_register!({ agent_id: "random-bot" });
+    const result = await handlers.messaging_get_instructions!({ agent_id: "random-bot", include_universal: true });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.universal).not.toBeNull();
+    expect(parsed.profile).toBeNull();
+
+    db.close();
+  });
+
+  it("rejects mismatched agent_id via withAgent binding", async () => {
+    const { db, handlers } = setup();
+
+    await handlers.messaging_register!({ agent_id: "agent-a" });
+    let threw = false;
+    try {
+      await handlers.messaging_get_instructions!({ agent_id: "agent-b", include_universal: true });
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(true);
+
+    db.close();
+  });
+});

--- a/tests/messaging/binding.test.ts
+++ b/tests/messaging/binding.test.ts
@@ -212,6 +212,7 @@ describe("profile-based name resolution in transport binding", () => {
       name: "os-dev",
       persona: "Senior developer",
       objective: "Write clean code",
+      instructions: null,
       maxInstances: 3,
       autoJoinChannels: [],
     });
@@ -233,6 +234,7 @@ describe("profile-based name resolution in transport binding", () => {
       name: "os-dev",
       persona: null,
       objective: null,
+      instructions: null,
       maxInstances: 3,
       autoJoinChannels: [],
     });

--- a/tests/messaging/lifecycle.test.ts
+++ b/tests/messaging/lifecycle.test.ts
@@ -38,6 +38,7 @@ describe("isAgentActive", () => {
       base_name: null,
       persona: null,
       objective: null,
+      instructions: null,
     };
     expect(isAgentActive(agent)).toBe(false);
   });
@@ -52,6 +53,7 @@ describe("isAgentActive", () => {
       base_name: null,
       persona: null,
       objective: null,
+      instructions: null,
     };
     expect(isAgentActive(agent)).toBe(false);
   });
@@ -66,6 +68,7 @@ describe("isAgentActive", () => {
       base_name: null,
       persona: null,
       objective: null,
+      instructions: null,
     };
     expect(isAgentActive(agent)).toBe(false);
   });

--- a/tests/repl/startup.test.ts
+++ b/tests/repl/startup.test.ts
@@ -151,6 +151,7 @@ describe("startupRepl", () => {
       name: "os-dev",
       persona: "Senior developer",
       objective: "Write clean code",
+      instructions: null,
       maxInstances: 3,
       autoJoinChannels: [],
     });


### PR DESCRIPTION
## Summary

Agent guidance framework — Tier 2 fill on top of the F2 substrate (#11). Split out from the original bundled #11 for cleaner review.

Implements `specs/2026-04-13-agent-guidance-framework-design.md`:

- New `instructions` field on `AgentProfile`, persisted to DB via migration `messaging_004_agent_instructions`
- New `messaging_get_instructions` MCP tool — re-read profile instructions + universal Tier 1 guidance (use after context compaction)
- Tier 1 MCP server instructions rewrite: REACTING TO MESSAGES, BOUNDARIES, BRAIN — replaces the prior ~1.5KB instructions
- Anti-polling guidance in REACTING TO MESSAGES
- Profile instructions documented as Tier 2 behavioral directives that refine but cannot override Tier 1 base rules

## Stacked PRs

- **A:** `feat/persistent-agent-profiles` (#11) → `main` — F2 substrate (must merge first)
- **B (this):** `feat/agent-guidance-framework` → `feat/persistent-agent-profiles`
- **C:** `feature/messaging-listen` (#12) → `feat/agent-guidance-framework`
- **D:** `feat/safety-rails-only` (#13) → `feature/messaging-listen`

Merge order: A → B → C → D. After A merges, GitHub auto-retargets this PR to `main`.

This PR + #11 together replace the original bundled #11. The split lets reviewers see one spec per PR: F2 (`2026-04-12-persistent-agent-profiles-design.md`) in #11, agent guidance (`2026-04-13-agent-guidance-framework-design.md`) here.

## Commits

- `9db4815` docs: agent guidance framework spec + analysis
- `873009a` docs: add anti-polling guidance to Tier 1 REACTING TO MESSAGES
- `2eab1f6` feat: add instructions field to agent profiles with DB persistence and getInstructions()
- `e41424e` feat: Tier 1 MCP instructions rewrite + messaging_get_instructions tool

## Test plan

- [ ] `bun test` passes (note: one pre-existing failure in `tests/hex/core/profile-concurrency.test.ts` — same failure on `main` and `#11`, unrelated to this PR; tracked in #18)
- [ ] `bunx tsc --noEmit` clean
- [ ] Profile instructions round-trip: YAML → DB → registration response → `messaging_get_instructions`
- [ ] Tier 1 instructions visible to fresh MCP client on register
