### PR TITLE
fix(migrations): document channels.max_hops stale column-default footgun

### DIFF
--- a/src/storage/sqlite/migrations.ts
+++ b/src/storage/sqlite/migrations.ts
@@ -163,6 +163,18 @@ const messagingMigrations: Migration[] = [
       UPDATE channels SET max_hops = ${DEFAULT_MAX_HOPS} WHERE max_hops = 50;
     `,
   },
+  // NOTE: the channels.max_hops COLUMN default is still 50 (set by 005). 006 only
+  // backfilled existing rows — it does not change the column default, and we do not
+  // change it here. Doing so needs a full table rebuild (SQLite has no ALTER COLUMN
+  // SET DEFAULT), and `channels` is an FK parent of `messages`/`cursors`; a rebuild
+  // requires `PRAGMA foreign_keys=OFF`, which is a no-op inside the BEGIN EXCLUSIVE
+  // wrapper runMigrations uses (and `defer_foreign_keys` can't clear the deferred-
+  // violation counter the parent DROP creates) — so on a populated DB the rebuild's
+  // COMMIT throws and bricks startup. The column default is harmless: the only insert
+  // path, SqliteChannelRepo.create(), always supplies `maxHops ?? DEFAULT_MAX_HOPS`,
+  // so new channels get 200 (regression-locked by tests/hex/storage/channel-repo.test.ts
+  // "create with default maxHops"). The stale 50 only bites a code path that omits the
+  // column entirely — none exists since 0.7.3 (commit 36ba3e5).
 ];
 
 const brainMigrations: Migration[] = [


### PR DESCRIPTION
## Summary

Documents a latent hop-limit footgun flagged by a new DM channel silently getting `max_hops=50` instead of the platform default 200.

**Root cause (diagnosed, not a current-code bug):**
- Migration `005` added `channels.max_hops` with column `DEFAULT 50`.
- Migration `006` backfilled existing rows (`WHERE max_hops=50` → 200) **but never changed the column default**.
- The app insert path (`SqliteChannelRepo.create`) was fixed in `36ba3e5` / 0.7.3 to always pass `maxHops ?? DEFAULT_MAX_HOPS`, so **new channels get 200 today** (verified empirically). The stale-50 channel was created by an older binary that omitted the column and fell through to the column default.

## What this PR does (Option 2 — surgical)

A single doc comment in `migrations.ts` converting the silent footgun into documented intent. The app-layer 200 enforcement is already regression-locked by `tests/hex/storage/channel-repo.test.ts` ("create with default maxHops").

## What this PR deliberately does NOT do

It does **not** rebuild the `channels` table to change the column default. That was attempted and **empirically proven to brick startup on a populated DB**:
- `channels` is an FK parent (`messages.channel_id`, `cursors.channel_id`).
- A rebuild needs `PRAGMA foreign_keys=OFF`, which is a no-op inside the `BEGIN EXCLUSIVE` wrapper `runMigrations` uses.
- `defer_foreign_keys=ON` does not save it: `DROP TABLE channels`' implicit delete bumps the deferred-violation counter, `RENAME` doesn't clear it → `PRAGMA foreign_key_check` returns clean but `COMMIT` still throws `FOREIGN KEY constraint failed`. (Green only ever appears on an empty DB, which masks the brick.)

Changing the literal column default would require a `runMigrations` `foreign_keys=OFF` change (broader infra surface + an enforcement-off window mid-migration) — disproportionate for a footgun unreachable by current code. Revisit only if a non-`channel-repo` insert path ever appears.

## Out of band

The one affected live channel was corrected directly via SQL (`UPDATE channels SET max_hops=500 WHERE id=1103`) — not part of this diff.

## Test plan

- `bunx tsc --noEmit` — clean
- `bun test tests/migrations.test.ts tests/hex/storage/channel-repo.test.ts` — 24 pass / 0 fail
- Comment lives outside any migration `up` string, so no checksum drift on existing DBs.
