### PR TITLE
Upgrade to MCP SDK v2 with structured tool output; add resource-subscriptions spec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Each agent runs as its own OS process (MCP subprocess). There is no shared memor
 ## APIs
 
 - `bun:sqlite` for SQLite — only in `src/storage/sqlite/`. Don't use `better-sqlite3`.
-- `@modelcontextprotocol/sdk` for MCP — only in `src/transports/mcp-stdio/`.
+- `@modelcontextprotocol/server` (SDK v2) for MCP — only in `src/transports/mcp-stdio/`.
 
 ## SQLite Concurrency
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "octo-santa",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.27.1",
+        "@modelcontextprotocol/server": "2.0.0",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -18,9 +18,9 @@
     },
   },
   "packages": {
-    "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
+    "@modelcontextprotocol/core": ["@modelcontextprotocol/core@2.0.0", "", { "dependencies": { "zod": "^4.2.0" } }, "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
+    "@modelcontextprotocol/server": ["@modelcontextprotocol/server@2.0.0", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0", "zod": "^4.2.0" } }, "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -34,12 +34,6 @@
 
     "@zerollup/ts-helpers": ["@zerollup/ts-helpers@1.7.18", "", { "dependencies": { "resolve": "^1.12.0" }, "peerDependencies": { "typescript": ">=3.7.2" } }, "sha512-S9zN+y+i5yN/evfWquzSO3lubqPXIsPQf6p9OiPMpRxDx/0totPLF39XoRw48Dav5dSvbIE8D2eAPpXXJxvKwg=="],
 
-    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
-
-    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
-
-    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
-
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
@@ -50,19 +44,11 @@
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
-
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
-
-    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
-
-    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
-
-    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
@@ -72,103 +58,35 @@
 
     "color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 
-    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
-
-    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
-
-    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
-
-    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
-
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
-
-    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
-
-    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
-
-    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
-    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
-
-    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "duplexer2": ["duplexer2@0.1.4", "", { "dependencies": { "readable-stream": "^2.0.2" } }, "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA=="],
 
-    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
-
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
-
-    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
-
-    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
-
-    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
-    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
-
     "escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
-    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
-
-    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
-
-    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
-
-    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
-
-    "express-rate-limit": ["express-rate-limit@8.3.1", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw=="],
-
-    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
-
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
-
-    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
-    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
-
-    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
-
-    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
-
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
-
-    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
-
-    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-stdin": ["get-stdin@8.0.0", "", {}, "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg=="],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
-    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
-
     "has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
-
-    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
-    "hono": ["hono@4.12.8", "", {}, "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A=="],
-
-    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
-
-    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
-
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
-
-    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
-
-    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
 
@@ -180,81 +98,33 @@
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
-    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
-
     "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
-    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
-
-    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
-
     "json-colorizer": ["json-colorizer@2.2.2", "", { "dependencies": { "chalk": "^2.4.1", "lodash.get": "^4.4.2" } }, "sha512-56oZtwV1piXrQnRNTtJeqRv+B9Y/dXAYLqBBaYl/COcUdoZxgLBLAO88+CnkbT6MxNs0c5E9mPBIb2sFcNz3vw=="],
-
-    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
     "lodash.get": ["lodash.get@4.4.2", "", {}, "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="],
 
-    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
-
-    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
-
-    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
-
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
-    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
-
-    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
-
-    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
-
-    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "node-stream": ["node-stream@1.7.0", "", { "dependencies": { "lodash": "^4.17.2", "readable-stream": "^2.3.3", "split2": "^2.1.0", "stream-combiner2": "^1.1.1", "through2": "^2.0.1" } }, "sha512-AB1qHzJWjAuxpDvTr/n1wvKVOg8c9BjAHV21QXq+q9yEUNr7wSqfHmAhAzvpQWSbf8mQQle3fjsnu3R14jrElA=="],
 
-    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
-
-    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
-
-    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
-
-    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
-
-    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
-
-    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
-
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
-
-    "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
     "pegjs-backtrace": ["pegjs-backtrace@0.2.1", "", {}, "sha512-rnVQiHyTE1wZG14Vl3Xk33ecrF7ZJ7ZW7jSgSlw4LdzBuhbyGVQ+oVApQ6tRi4QsII/xHgByHb6Ax68K6SPLhw=="],
 
     "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
-
     "plantuml-parser": ["plantuml-parser@0.4.0", "", { "dependencies": { "async": "^3.2.0", "fast-glob": "^3.2.4", "get-stdin": "^8.0.0", "json-colorizer": "^2.2.2", "pegjs-backtrace": "^0.2.0", "read-vinyl-file-stream": "^2.0.3", "require-dir": "^1.2.0", "serialize-error": "^7.0.1", "yargs": "^16.0.3" }, "bin": { "plantuml-parser": "dist/bin/cli.js" } }, "sha512-IwbkQNgQK/kvXbSYxZWZpcAItk46ECZm6QFA66+smFZqSIjdglXGNTFniO2VLPpgt8uY8EE0uLOsGgvBrerU5Q=="],
 
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
 
-    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
-
-    "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
-
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
-
-    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
-
-    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "read-vinyl-file-stream": ["read-vinyl-file-stream@2.0.3", "", { "dependencies": { "node-stream": "^1.5.0", "through2": "^2.0.1" } }, "sha512-ZbtobBf+n/va3eRcIkMDYsp7DCnnjh46YFOOdj42aCiWFirp9T/+YGMCTfVpEFIuiH3c5Kp13jpn3i5DoygxLw=="],
 
@@ -264,43 +134,17 @@
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
-    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
-
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
-
-    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
-    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
-
-    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
-
     "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
 
-    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
-
-    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
-
-    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
-
-    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
-
-    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
-
-    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
-
-    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
-
-    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
-
     "split2": ["split2@2.2.0", "", { "dependencies": { "through2": "^2.0.2" } }, "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw=="],
-
-    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "stream-combiner2": ["stream-combiner2@1.1.1", "", { "dependencies": { "duplexer2": "~0.1.0", "readable-stream": "^2.0.2" } }, "sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw=="],
 
@@ -318,27 +162,15 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
-    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
-
     "type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
-
-    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
-    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
-
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
-    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
-
-    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
-
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
-    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
@@ -349,8 +181,6 @@
     "yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,7 +85,7 @@ src/
 
   transports/                    ← Transport adapters (how external clients connect)
     mcp-stdio/
-      adapter.ts                 ← MCP tool registration, agent binding, server startup
+      adapter.ts                 ← MCP tool registration, per-connection server factory (SDK v2 serveStdio)
       helpers.ts                 ← jsonResult(), withAgent()
 
   notifications/                 ← Notification adapter (how agents receive push)
@@ -203,9 +203,19 @@ and `listMembers()`. Liveness is transport-independent.
 ### 3. Agent Registration and Disconnect
 
 The service handles `register()` and `unregister()` as pure storage operations.
-Transport adapters manage session lifecycle — MCP stdio binds the session to the
-first agent that completes a tool call and unregisters on close. The service
-doesn't know the trigger.
+Transport adapters manage connection lifecycle — MCP stdio binds the connection
+to the first agent that completes a tool call and unregisters on close. The
+service doesn't know the trigger.
+
+The MCP transport uses SDK v2's `serveStdio(factory)` entry: one fresh
+`McpServer` instance is built per stdio connection, and all per-connection state
+(agent binding, notification poller, heartbeat timer) lives in that instance's
+closure. The protocol itself is stateless as of MCP revision 2026-07-28 — no
+initialize handshake, no protocol-level sessions, every tool request
+self-contained (which is why every tool takes `agent_id` explicitly). The same
+factory also serves 2025-era clients, which still open with the legacy
+initialize handshake. Durable state never lives in the connection: SQLite holds
+all of it.
 
 ### 4. DM Channel Creation
 
@@ -273,6 +283,8 @@ process boundary without an IPC bridge.
 
 For octo-santa's N-process model (each agent is its own subprocess sharing a SQLite
 file), **some form of polling will always be needed for cross-process notification.**
-Future work (MCP 2.0 server-initiated push, long-poll transports) may change the
-delivery mechanism, but the shared-SQLite-requires-polling constraint remains until
-the process model changes.
+MCP's 2026-07-28 revision (SDK v2) made the protocol stateless and removed
+server→client requests, but stdio connections remain long-lived pipes, and custom
+extension notifications like `notifications/claude/channel` pass through on both
+protocol eras — so push delivery is unchanged. The shared-SQLite-requires-polling
+constraint remains until the process model changes.

--- a/docs/specs/2026-07-29-mcp-v2-stateless-upgrade.md
+++ b/docs/specs/2026-07-29-mcp-v2-stateless-upgrade.md
@@ -1,0 +1,91 @@
+# MCP SDK v2 Upgrade — Stateless Serving
+
+**Date:** 2026-07-29
+**Status:** Implemented
+
+## Background
+
+The MCP TypeScript SDK v2 (stable `2.0.0`, released alongside protocol revision
+2026-07-28) replaces the monolithic `@modelcontextprotocol/sdk` with focused
+packages and makes the protocol stateless. This spec records what was verified
+empirically against the installed `@modelcontextprotocol/server@2.0.0` package
+and the official docs, and the decisions applied to octo-santa.
+
+## What changed in MCP v2 / revision 2026-07-28
+
+- **Package split.** `@modelcontextprotocol/sdk` → `@modelcontextprotocol/server`
+  (servers), `/client`, `/core` (schemas), plus framework adapters. Requires
+  zod `^4.2.0` (zod 3 dropped) and Node 20+ (Bun fine).
+- **Stateless protocol.** The `initialize` handshake and protocol-level sessions
+  are gone on 2026-07-28 connections. Requests are self-contained; identity
+  flows per-request in `_meta` envelopes. Server→client JSON-RPC requests are
+  removed (sampling/elicitation/roots become `input_required` multi-round-trip
+  results); `sendLoggingMessage` is deprecated.
+- **Factory-based serving.** `serveStdio(factory)` from
+  `@modelcontextprotocol/server/stdio` owns the transport and the era decision:
+  it calls the factory when the connection's opening message arrives, pins ONE
+  fresh instance per connection, and serves 2025-era (legacy `initialize`)
+  and 2026-07-28 (modern) clients from the same factory. A `server/discover`
+  probe instance may be built and discarded.
+- **Notifications are opt-in on modern connections** — for spec-defined change
+  notifications. Clients open `subscriptions/listen` streams; the stdio entry's
+  listen router gates exactly four methods (`notifications/tools/list_changed`,
+  `prompts/list_changed`, `resources/list_changed`, `resources/updated`).
+  **Verified in the SDK source:** any other outbound notification method
+  returns `'passthrough'` from the router and is written to the wire as-is on
+  both eras, and `assertNotificationCapability` has no default-case check for
+  custom methods. Custom extension notifications are explicitly era-blind.
+- **API compatibility.** `McpServer`, `registerTool(name, config, cb)`,
+  `ServerOptions.instructions`, `capabilities.experimental`, low-level
+  `server.notification()`, `Server.oninitialized` and `Protocol.onclose` all
+  survive. Raw-shape `inputSchema` records are deprecated in favor of
+  `z.object({...})`. Tool callbacks receive `(args, ctx)` where `ctx` replaces
+  v1's `extra`.
+
+## Decisions
+
+1. **Depend on `@modelcontextprotocol/server` `^2.0.0`; drop
+   `@modelcontextprotocol/sdk`.** Only `src/transports/mcp-stdio/` touches it
+   (hexagonal boundary unchanged; the boundary tests match any
+   `@modelcontextprotocol/*` import).
+2. **Serve via `serveStdio(factory)`.** `startMcpStdio()` becomes synchronous
+   and returns the `StdioServerHandle`. The factory builds a fresh `McpServer`
+   per connection; all per-connection state (agent binding, poller, heartbeat)
+   lives in the factory closure. Nothing binds on a discarded probe instance
+   because binding only happens on a committed tool call.
+3. **Keep `notifications/claude/channel` push unchanged.** It is a custom
+   extension notification, verified passthrough on both eras. Push stays
+   best-effort; `messaging_read_messages` (SQLite poll) remains the fallback;
+   SQLite persistence remains the delivery invariant.
+4. **Tool requests stay self-contained.** Every mutating tool already takes
+   `agent_id` explicitly — exactly the stateless per-request model. The
+   per-connection binding is not protocol session state: it is the push/liveness
+   lifecycle (which agent this process's poller and heartbeat serve), inherent
+   to the one-agent-per-process deployment model.
+5. **Bootstrap nudge is era-aware.** 2025-era connections get the bootstrap
+   `notifications/claude/channel` once the initialize handshake completes
+   (`oninitialized` — strictly better timing than v1's fire-after-connect).
+   2026-07-28 connections have no handshake and no expectation of unsolicited
+   pre-request notifications; they receive the same guidance as server
+   `instructions`, served through `server/discover`.
+6. **Schemas wrapped in `z.object()`** to move off the deprecated raw-shape
+   registration form. Existing zod `^4.3.6` already satisfies the SDK's
+   `^4.2.0` requirement.
+
+## Non-changes
+
+- Core, storage, and notification adapters are untouched — the upgrade is
+  confined to the transport adapter, composition root, and docs.
+- `registerMessagingTools(server, messaging, onAgentId)` keeps its signature,
+  so binding-enforcement tests drive it unchanged.
+- The SQLite watcher → MCP channel push design is unchanged (see
+  2026-04-10-cross-process-notification-poller.md).
+
+## References (validated 2026-07-29)
+
+- https://ts.sdk.modelcontextprotocol.io/v2/ — SDK v2 docs
+- https://ts.sdk.modelcontextprotocol.io/v2/migration/upgrade-to-v2 — v1→v2 guide
+- https://ts.sdk.modelcontextprotocol.io/v2/migration/support-2026-07-28 — protocol revision guide
+- https://blog.modelcontextprotocol.io/posts/sdk-betas-2026-07-28/ — spec/SDK announcement
+- `@modelcontextprotocol/server@2.0.0` dist sources (`serveStdio`, listen
+  router, capability assertions) — inspected directly in `node_modules`.

--- a/docs/specs/2026-07-30-resource-subscriptions-push.md
+++ b/docs/specs/2026-07-30-resource-subscriptions-push.md
@@ -1,0 +1,448 @@
+# Spec-Native Push via MCP Resources + subscriptions/listen
+
+**Date:** 2026-07-30
+**Status:** Draft (prototype validated)
+
+## Background
+
+octo-santa's push channel today is the custom `notifications/claude/channel`
+extension notification: each agent's server process polls the shared SQLite
+file (2s watcher, adapter-owned HWM) and pushes mention/DM-filtered messages
+to its bound agent. It is Claude-specific, transport-specific (stdio only),
+and invisible to standard MCP clients. Poll fallback is
+`messaging_read_messages`; SQLite persistence is the delivery invariant.
+
+Protocol revision 2026-07-28 (SDK v2, `@modelcontextprotocol/server@2.0.0` —
+already adopted on this branch) offers a standards-native alternative:
+
+- **Resources**: a server exposes addressable, readable documents
+  (`resources/list`, `resources/templates/list`, `resources/read`).
+- **Opt-in change notifications**: a modern client opens a
+  `subscriptions/listen` stream with a filter
+  `{toolsListChanged?, promptsListChanged?, resourcesListChanged?,
+  resourceSubscriptions?: string[]}`. The stdio entry's listen router
+  (`StdioListenRouter`) acks with `notifications/subscriptions/acknowledged`
+  (the filter narrowed against the server's *declared* capabilities), then
+  routes exactly four outbound methods onto subscribed streams —
+  `notifications/{tools,prompts,resources}/list_changed` and
+  `notifications/resources/updated` (per-URI, exact string match) — each
+  stamped with `_meta["io.modelcontextprotocol/subscriptionId"]`. Everything
+  else, including our custom notification, is passthrough on both eras.
+- The 2025-era `resources/subscribe`/`resources/unsubscribe` requests were
+  **removed** from the 2026-07-28 wire registry; on the legacy path SDK v2
+  keeps them in the 2025 registry but registers **no handler** (verified:
+  `-32601 Method not found`).
+
+This spec models channel history as MCP resources and maps the existing
+SQLite watcher onto `notifications/resources/updated`, giving any
+spec-compliant 2026-07-28 client wake-up pings without octo-santa's custom
+vocabulary. It is a **sibling** to the custom push, not a replacement.
+
+## Design
+
+### Resources model and URI scheme
+
+One resource template registered on every connection server:
+
+```
+octo-santa://channels/{channel}/messages
+```
+
+- **Canonical URI**: `octo-santa://channels/<encodeURIComponent(name)>/messages`,
+  minted only by a single helper `channelResourceUri(name)`. Channel names
+  allow `[\w.,@#-]`; `#` starts a URI fragment, and the SDK's `UriTemplate`
+  `{var}` match regex is `([^/,]+)` so a raw `,` (every DM channel name)
+  would never match. Percent-encoding solves both; `UriTemplate.match()` does
+  **not** decode, so the read callback applies `decodeURIComponent`.
+  Because the listen router's per-URI filter is an **exact string
+  comparison** (`resourceSubscriptions.includes(event.uri)`), every mint —
+  list, read, updated-ping — must go through the one helper.
+- **list callback** enumerates `MessagingService.listChannels()` (parity with
+  the public `messaging_list_channels` tool, DM channels included — same
+  pre-existing exposure).
+- **resources/read** is a **pure history read**: it returns the newest 50
+  messages (all senders, ascending) and never touches the unread cursor.
+  This required a new seam — see below.
+
+### New core seams (the port decision)
+
+1. **`MessageRepository.readRecent(channelId, limit)`** (new port method,
+   `src/core/ports.ts`) + SQLite implementation: transaction-free WAL read of
+   the newest N messages. Neither existing read fit: `readForwardAndAdvance`
+   consumes the cursor; `readBefore` requires a `beforeId` and excludes the
+   reader's own messages (inbox semantics, wrong for a history document).
+2. **`MessagingService.readHistory(agentId, channelName, limit)`**: same
+   guards as `read()` (registered + `assertDmAccess` + membership) but pure.
+3. **`NotificationPort.notifyChannelActivity?(channelName)`** — the update
+   wiring. The poller (notification adapter) is the only component that sees
+   cross-process message arrival; `sendResourceUpdated` lives in the
+   transport. `NotificationPort` in `core/ports.ts` is the existing seam
+   shared by exactly these two adapters, so it gains one **optional** method:
+   fired at most once per tick per distinct channel with new messages,
+   **regardless of mentions** (a resource subscriber asked for all activity,
+   not just mentions; the mention filter stays on `notify()` only). The
+   signal is deliberately domain-shaped — "this channel has activity", a
+   channel *name*, not a URI or an MCP method — so the port serves core
+   vocabulary and the resources mapping stays entirely inside the transport
+   adapter. A second dedicated port was considered and rejected: same two
+   adapters, same lifecycle, same wiring path through `startPoller(port,
+   agentId)`; a second port would duplicate the plumbing for no decoupling
+   gain. Being optional, non-MCP transports and existing tests are untouched.
+
+### Update wiring
+
+In the transport adapter's per-connection `NotificationPort`:
+
+- `notifyChannelActivity(name)` → `server.sendResourceUpdated({ uri:
+  channelResourceUri(name) })`. On modern connections the listen router
+  delivers it only to subscriptions whose filter contains that exact URI,
+  stamped with the subscription id; with no matching subscription it is
+  dropped at the entry (verified — "the modern era never delivers an
+  un-requested change type").
+- **First-seen heuristic for `list_changed`**: when a channel produces
+  activity this connection hasn't seen before, also emit
+  `sendResourceListChanged()`. This piggybacks on the same seam — no new
+  storage queries — and covers cross-process channel *creation* and *rename*
+  organically, because both produce a message in the channel (rename posts an
+  announcement message), which the poller surfaces under the new name.
+  It does not cover silent channel creation (create with no message) —
+  acceptable for a hint-grade notification; see Open questions.
+
+### Capability declaration
+
+```ts
+capabilities: {
+  experimental: { "claude/channel": {} },
+  resources: { subscribe: true, listChanged: true },
+}
+```
+
+Empirically verified requirements: `resources.subscribe: true` is mandatory
+or the router's `honoredSubset` **strips `resourceSubscriptions` from the
+ack** (silently — the client sees its URIs vanish from the honored filter).
+`resources.listChanged: true` gates `resourcesListChanged` the same way.
+Nothing auto-sets `subscribe`; declare it in the constructor options — the
+entry hands `server.getCapabilities()` to the listen router immediately after
+the factory returns (`connectInstance`), and `mergeCapabilities` preserves
+the `subscribe` bit when `setResourceRequestHandlers` later merges its
+`listChanged` default. (`tools.listChanged: true` is auto-set by
+`registerTool`; prompts stay undeclared, so `promptsListChanged` is stripped
+— all observed in the ack.)
+
+### Era behavior
+
+- **Modern (2026-07-28)**: full feature. `subscriptions/listen` requires the
+  per-request `_meta` envelope. Multiple concurrent listen subscriptions per
+  connection work (each keyed by its request id); `notifications/cancelled`
+  tears one down.
+- **Legacy (2025-era)**: **no spec push**. `resources/subscribe` is
+  `-32601 Method not found` (SDK v2 serves no handler and offers no
+  McpServer-level registration for it). Outbound change notifications are NOT
+  routed on legacy — they would pass through **unsolicited and unstamped** to
+  a client that never asked (verified) — so the adapter gates
+  `notifyChannelActivity` emission to modern connections. Legacy keeps the
+  custom `notifications/claude/channel` push unchanged. `resources/read`,
+  `resources/list` do work on legacy (handlers are era-blind).
+- **Both eras**: the custom push is passthrough and unchanged.
+
+## Expected outcome
+
+Clients gain:
+
+- **Standards-native wake-ups**: any 2026-07-28 MCP client — not just Claude
+  — can subscribe to a channel URI and receive `notifications/resources/updated`
+  when the channel gains messages, with proper subscription-id stamping,
+  without knowing octo-santa's custom vocabulary.
+- **Unfiltered channel-activity signal**: pings for *all* new messages in
+  subscribed channels, not only mentions/DMs (a superset of the custom push's
+  triggering conditions, by client opt-in).
+- **Pure history reads**: `resources/read` gives channel history without
+  consuming the unread cursor — tooling/dashboards can inspect channels
+  without eating an agent's inbox.
+- **Discovery**: `resources/list` enumerates channels as first-class MCP
+  resources.
+
+Unchanged: the custom push (both eras), all messaging tools and their cursor
+semantics, the poller cadence and HWM, SQLite as the only cross-process
+bridge, delivery guarantees (spec push is best-effort exactly like the custom
+push; persistence remains the invariant), and the one-agent-per-process
+deployment model.
+
+## Pros
+
+- **Spec compliance with near-zero mechanism cost**: the SDK's listen router
+  does subscription bookkeeping, filtering, stamping, and graceful teardown;
+  the adapter only calls `sendResourceUpdated`. Same poller tick as the
+  custom push — measured arrival delta **0.7ms** (see findings) — zero added
+  latency.
+- **Sound privacy by construction**: update pings can only describe channels
+  the connection's bound agent is a member of, because the emitting poller
+  query is membership-scoped and each process serves exactly one agent. A
+  non-member subscribing to a guessable DM URI gets an ack echo but **zero
+  pings ever** (verified cross-process), and `resources/read` enforces DM
+  access + membership through the same service guards as the tools.
+- **Coarse signal = cheap and race-free**: "channel changed, re-read if you
+  care" carries no message content; no second cursor, no double-delivery
+  concern with the custom push (independent HWM already exists).
+- **Hexagonal boundaries intact**: one optional domain-shaped port method;
+  core still knows nothing about MCP; storage gains a pure read; the arch
+  test suite passes unmodified.
+- **Modern-era drop semantics are free hygiene**: with no listen stream, spec
+  pings vanish at the entry while the custom push still flows — no
+  double-notification for current Claude clients.
+
+## Cons
+
+- **No legacy story at all**: 2025-era clients cannot get spec push —
+  `resources/subscribe` is unserved by SDK v2, and honoring it ourselves
+  would mean hand-registering the handler *and* hand-filtering per-URI in the
+  adapter (the entry routes nothing on legacy). Feature is modern-only.
+- **Capability advertisement wart**: the legacy `initialize` result
+  advertises `resources: { subscribe: true }` (observed) — a capability the
+  connection cannot serve. Fixable by declaring `subscribe` only on
+  modern-era instances (factory receives the era).
+- **Ack does not validate URIs**: the router honors any
+  `resourceSubscriptions` entry verbatim — a non-member's subscription to a
+  DM URI is *acknowledged* (observed). No data leaks (no pings, reads
+  denied), but the ack falsely implies the subscription is live. A client
+  cannot distinguish "valid but quiet channel" from "channel I'll never hear
+  about". DM-privacy leakage in pings is structurally nil (membership-scoped
+  poller, one agent per process); the residual exposure is channel *names*
+  in `resources/list` — identical to the existing `messaging_list_channels`
+  exposure, so nothing new leaks, but resources/list now re-states it in a
+  second place to keep in mind if list semantics ever tighten.
+- **Exact-match URI fragility**: subscription matching is byte-for-byte. Any
+  client that builds the URI without percent-encoding (or encodes
+  differently, e.g. lowercase hex) silently never matches. Channel renames
+  silently orphan subscriptions to the old URI (mitigated, not solved, by the
+  `list_changed` hint).
+- **Unread-history asymmetry**: `resources/read` returns newest-50 of *all*
+  messages including your own — deliberately a history document — but a
+  client that treats it as an inbox will re-see read messages. Docs must be
+  explicit that cursors belong to `messaging_read_messages` only.
+- **Two push vocabularies to maintain**: mention-filtered content push
+  (custom) and unfiltered activity ping (spec) coexist; instructions text
+  must explain when to use which, inside a 2KB budget.
+
+## Prototype findings
+
+Prototype built in a throwaway worktree (diff summary below): resource
+template + pure read path + poller channel-activity hook + capability
+declaration. Smoke-tested end-to-end with real `bun run src/main.ts`
+subprocesses sharing a temp SQLite DB (poll interval 200ms),
+newline-delimited JSON-RPC over stdio, envelope-stamped modern clients and a
+handshake legacy client. **All 33 checks across 4 scenarios passed.**
+
+**Listen ack (verbatim)** — request id 3 becomes the subscription id; filter
+honored verbatim because `resources.subscribe` was declared:
+
+```json
+{"jsonrpc":"2.0","method":"notifications/subscriptions/acknowledged","params":{"notifications":{"resourcesListChanged":true,"resourceSubscriptions":["octo-santa://channels/design.review/messages","octo-santa://channels/smoke-a%2Csmoke-b/messages"]},"_meta":{"io.modelcontextprotocol/subscriptionId":3}}}
+```
+
+**Updated notification (verbatim)** — emitted by agent A's poller after
+agent B (separate OS process) posted to the channel:
+
+```json
+{"jsonrpc":"2.0","method":"notifications/resources/updated","params":{"uri":"octo-santa://channels/design.review/messages","_meta":{"io.modelcontextprotocol/subscriptionId":3}}}
+```
+
+**Latency vs custom push**: both notifications for the same message arrived
+from the same poller tick, delta **0.7ms** (custom push first — the poller
+loop notifies per-message before flushing the per-tick channel set).
+End-to-end latency is bounded by the poll interval for both, i.e. identical.
+
+**Cursor purity**: after receiving the ping, A's `resources/read` returned
+the message; a subsequent `messaging_read_messages` **still returned it as
+unread**; a second `messaging_read_messages` returned empty — proving
+`resources/read` consumed nothing and the tool remains the only consumer.
+
+**Capability narrowing** (server run without `resources.subscribe`):
+
+```json
+{"jsonrpc":"2.0","method":"notifications/subscriptions/acknowledged","params":{"notifications":{"toolsListChanged":true,"resourcesListChanged":true},"_meta":{"io.modelcontextprotocol/subscriptionId":2}}}
+```
+
+`resourceSubscriptions` stripped; `promptsListChanged` stripped (no prompts
+capability); `toolsListChanged` kept (auto-set by `registerTool`).
+
+**DM privacy (cross-process)**: non-member D's listen ack echoed the DM URI
+`octo-santa://channels/smoke-a%2Csmoke-b/messages` (no URI validation in the
+router), but across multiple DM sends and poller ticks D received **zero**
+updated notifications, and D's `resources/read` was denied:
+`{"error":{"code":-32603,"message":"DM channel \"smoke-a,smoke-b\" is private to smoke-a and smoke-b"}}`.
+An unbound connection's read is likewise denied.
+
+**URI encoding round-trip**: channel `a#b,c@d.e-f` worked end-to-end —
+subscription, ping (`octo-santa://channels/a%23b%2Cc%40d.e-f/messages`,
+stamped with the *second* concurrent subscription's id 9, proving per-URI
+routing across multiple listens), and read.
+
+**list_changed**: first activity on an unseen channel emitted
+`notifications/resources/list_changed` routed + stamped onto the
+`resourcesListChanged: true` subscription.
+
+**Legacy era**: `initialize` negotiated `2025-11-25` and advertised
+`resources:{subscribe:true,listChanged:true}` (the wart noted above);
+`resources/subscribe` returned verbatim
+`{"jsonrpc":"2.0","id":4,"error":{"code":-32601,"message":"Method not found"}}` —
+**there is no working legacy equivalent in SDK v2**. With the era gate the
+legacy connection received no spec notifications; with the gate
+force-disabled (prototype env flag) the passthrough was observed verbatim —
+unsolicited and unstamped:
+`{"jsonrpc":"2.0","method":"notifications/resources/updated","params":{"uri":"octo-santa://channels/legacy-chan/messages"}}` —
+confirming the gate is required for legacy spec-compliance.
+
+**Modern without listen**: custom push arrived; spec change notifications
+were dropped at the entry (zero on the wire).
+
+**Suite status**: `bunx tsc --noEmit` clean; `bun test` 263 pass / 0 fail
+(incl. the hexagonal-boundary arch tests) with the prototype applied.
+
+## Recommendation
+
+**Adopt, with changes.** The mechanism is sound, empirically verified
+cross-process, costs one optional port method and ~100 adapter lines, adds
+zero latency, and leaks nothing. Changes before landing:
+
+1. Declare `resources.subscribe` **only on modern-era instances** (factory
+   already receives the era) so legacy `initialize` stops advertising an
+   unserved capability. Keep the emission gate regardless (defense in depth).
+2. Drop the two prototype env flags (`OCTO_SANTA_NO_SUB_CAP`,
+   `OCTO_SANTA_LEGACY_RESOURCE_PUSH`) — test-only scaffolding.
+3. Map adapter denials to proper JSON-RPC error codes instead of the generic
+   `-32603` (at minimum resource-not-found for unknown channels).
+4. Document in the server instructions (2KB budget) that resources/updated is
+   an unfiltered activity ping and `resources/read` never consumes unread.
+5. Add unit tests: poller channel-activity dedup, `readHistory` purity +
+   guards, `channelResourceUri` round-trip, era gating.
+
+## Open questions
+
+1. **Rename churn**: should the old-URI subscription get any terminal signal
+   on rename? (The spec has none for "resource gone"; today it just goes
+   silent, with `list_changed` as the only hint.) Consider an explicit
+   `updated` ping on the old URI at rename time so subscribers re-read, fail
+   with not-found, and re-list.
+2. **Silent channel creation**: `list_changed` currently fires on first
+   *activity*, not creation. Is a channels-table watermark in the poller
+   (max channel id + rename detection) worth the extra per-tick query?
+3. **DM channels in `resources/list`**: parity with
+   `messaging_list_channels` today, but should DM resources be listed only to
+   their members once the resources surface becomes the discovery mechanism
+   for standard clients?
+4. **Ack-echo of never-deliverable URIs**: should the adapter pre-validate
+   subscription URIs? The router offers no hook for it today (entry-served
+   before the instance sees the request) — likely an SDK-level question.
+5. **Non-member reads of public channels**: `readHistory` requires
+   membership (tool parity). Should public-channel resources be readable
+   without membership, since names/members are already public?
+6. **Read-window shape**: fixed newest-50 for now; expose paging (query
+   params in the URI template, e.g. `{?before,limit}`) later?
+7. **HTTP transport future**: the HTTP listen router (`createListenRouter`)
+   uses SSE streams and a server event bus — the port seam chosen here maps
+   onto it unchanged, but the bus wiring differs; revisit when an HTTP
+   transport lands.
+
+## Appendix: prototype diff summary
+
+The prototype lived in a throwaway worktree (not committed); this records
+what was touched so the implementation can be redone cleanly.
+
+**`src/core/ports.ts`** — two additions: pure-history read on the message
+port, optional activity signal on the notification port.
+
+```ts
+// MessageRepository:
+  // Pure history snapshot: most recent `limit` messages in ascending order,
+  // all senders included. Never touches cursors.
+  readRecent(channelId: number, limit: number): Message[];
+
+// NotificationPort:
+  notifyChannelActivity?(channelName: string): Promise<void>;
+```
+
+**`src/storage/sqlite/message-repo.ts`** — `readRecent` implementation:
+`SELECT * FROM messages WHERE channel_id = ? ORDER BY id DESC LIMIT ?` then
+`rows.reverse()`; transaction-free WAL read, no cursor involvement.
+
+**`src/core/messaging/service.ts`** — new `readHistory(agentId, channelName,
+limit = 50)`: `requireRegistered` + `assertDmAccess` + membership check (same
+guards as `read()`), then `messages.readRecent(channel.id, limit)`. Never
+advances the cursor; includes the reader's own messages.
+
+**`src/notifications/poller/poller.ts`** — inside `tick()`, collect
+`activeChannels = new Set<string>()` from **all** fetched messages (before
+the mention filter), then after the per-message loop:
+`for (const channelName of activeChannels)
+port.notifyChannelActivity?.(channelName).catch(...)`. One ping per channel
+per tick; HWM logic untouched.
+
+**`src/transports/mcp-stdio/adapter.ts`** — four changes:
+
+1. Import `ResourceTemplate`; capability declaration in
+   `buildConnectionServer`:
+
+```ts
+capabilities: {
+  experimental: { "claude/channel": {} },
+  resources: { subscribe: true, listChanged: true },
+},
+```
+
+2. Resource registration (new exported `channelResourceUri` +
+   `registerChannelResources`, called from `buildConnectionServer` with
+   `() => boundAgentId`):
+
+```ts
+export function channelResourceUri(name: string): string {
+  return `octo-santa://channels/${encodeURIComponent(name)}/messages`;
+}
+
+server.registerResource(
+  "channel-messages",
+  new ResourceTemplate("octo-santa://channels/{channel}/messages", {
+    list: () => ({
+      resources: messaging.listChannels().map((channel) => ({
+        uri: channelResourceUri(channel.name),
+        name: channel.name,
+        description: `Message history of channel "${channel.name}"`,
+        mimeType: "application/json",
+      })),
+    }),
+  }),
+  { title: "Channel messages", description: "Recent message history of a channel. Pure read — never advances the unread cursor.", mimeType: "application/json" },
+  async (uri, variables) => {
+    const raw = variables["channel"];
+    const channelName = decodeURIComponent(Array.isArray(raw) ? raw[0] ?? "" : raw ?? "");
+    const agentId = getBoundAgentId();
+    if (agentId === null) throw new Error("Channel resources require a bound agent: call messaging_register first");
+    const messages = messaging.readHistory(agentId, channelName, 50);
+    return { contents: [{ uri: uri.toString(), mimeType: "application/json", text: JSON.stringify(messages) }] };
+  }
+);
+```
+
+3. Update hook — in the `commit()` closure of `onAgentId`, added to the
+   per-connection `NotificationPort` (alongside the untouched `notify`),
+   era-gated with a per-connection first-seen set:
+
+```ts
+const seenChannels = new Set<string>();
+const emitResourceUpdates = era === "modern";
+// ...
+notifyChannelActivity: async (channelName) => {
+  if (!emitResourceUpdates) return;
+  if (!seenChannels.has(channelName)) {
+    seenChannels.add(channelName);
+    mcpServer.sendResourceListChanged();
+  }
+  await mcpServer.server.sendResourceUpdated({ uri: channelResourceUri(channelName) });
+},
+```
+
+4. One-line wiring after `registerMessagingTools`:
+   `registerChannelResources(mcpServer, messaging, () => boundAgentId);`
+
+**`src/main.ts`** — no changes needed; the port flows through the existing
+`startPoller(port, agentId)` wiring untouched.

--- a/docs/specs/2026-07-30-structured-tool-output.md
+++ b/docs/specs/2026-07-30-structured-tool-output.md
@@ -1,0 +1,66 @@
+# Structured Tool Output and Tool Metadata
+
+**Date:** 2026-07-30
+**Status:** Implemented
+**Builds on:** 2026-07-29-mcp-v2-stateless-upgrade.md
+
+## What
+
+Adopt two SDK v2 capabilities across all nine messaging tools:
+
+1. **`outputSchema` + `structuredContent`** — every tool declares a zod output
+   schema (advertised as JSON Schema in `tools/list`, validated server-side by
+   the SDK on every successful result) and returns `structuredContent`
+   alongside the JSON text block. Supersedes the parse-JSON-out-of-text-blocks
+   convention.
+2. **`title` + `annotations`** — human-readable titles and accurate behavior
+   hints: `openWorldHint: false` everywhere (octo-santa only touches the local
+   shared SQLite database), `destructiveHint: false` everywhere (all writes are
+   additive), `readOnlyHint: true` on exactly the three pure list tools, and
+   honest idempotency hints. `messaging_read_messages` is deliberately NOT
+   read-only — its default mode consumes the unread cursor (read-once).
+   Icons are deliberately omitted: octo-santa has no visual surface.
+
+## Result shape contract
+
+Every tool result is a **top-level object** — object-shaped `structuredContent`
+projects identically onto the 2025 and 2026-07-28 wire eras (non-object values
+get era-dependent `{result: …}` wrapping, verified in the SDK's
+`projectCallToolResult`). List results are therefore wrapped in named keys, and
+the text block always mirrors `structuredContent` exactly
+(`text === JSON.stringify(structuredContent)`):
+
+| Tool | structuredContent |
+|------|-------------------|
+| messaging_register | `Agent` |
+| messaging_create_channel | `Channel` |
+| messaging_subscribe | `{subscribed: true, channel}` |
+| messaging_list_channels | `{channels: Channel[]}` |
+| messaging_send | `Message` |
+| messaging_read_messages | `{messages: Message[]}` |
+| messaging_list_agents | `{agents: Agent[]}` |
+| messaging_list_members | `{members: {agent_id, active}[]}` |
+| messaging_rename_channel | `Channel` |
+
+**Breaking change:** the four list-shaped tools previously returned bare JSON
+arrays in their text block; they now return the wrapped object. Text and
+structured payloads stay identical by construction, so there is exactly one
+shape to consume.
+
+Wire schemas live in `src/transports/mcp-stdio/schemas.ts`, tied to the core
+domain types two ways: `satisfies z.ZodType<CoreType>` fails compilation when
+a core field is removed or renamed, and the contract test
+(`tests/hex/transports/tool-metadata.test.ts`) runs every tool against the
+real service and validates `structuredContent` with the exact schema the tool
+advertises.
+
+Error results (`isError: true`) intentionally carry no `structuredContent`;
+the SDK skips output validation for them.
+
+## Verified
+
+- 268 tests pass, `tsc --noEmit` clean.
+- End-to-end over real stdio pipes on both eras: `tools/list` advertises
+  title/annotations/JSON-Schema outputSchema; `tools/call` returns
+  object-shaped `structuredContent` unwrapped on the 2025 wire and the
+  2026-07-28 wire alike.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@modelcontextprotocol/server": "^2.0.0",
     "zod": "^4.3.6"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@ async function main() {
   const heartbeatIntervalMs = Number(process.env.OCTO_SANTA_HEARTBEAT_INTERVAL_MS) || 10_000;
   const pollIntervalMs = Number(process.env.OCTO_SANTA_POLL_INTERVAL_MS) || undefined;
 
-  await startMcpStdio({
+  startMcpStdio({
     messaging,
     agents: repos.agents,
     startPoller: (port, agentId) => {

--- a/src/transports/mcp-stdio/adapter.ts
+++ b/src/transports/mcp-stdio/adapter.ts
@@ -5,7 +5,22 @@ import type { MessagingService } from "../../core/messaging/service";
 import type { NotificationPort, AgentRepository } from "../../core/ports";
 import { log } from "../../log";
 import { jsonResult, withAgent } from "./helpers";
+import {
+  RegisterOutput,
+  CreateChannelOutput,
+  SubscribeOutput,
+  ListChannelsOutput,
+  SendOutput,
+  ReadMessagesOutput,
+  ListAgentsOutput,
+  ListMembersOutput,
+  RenameChannelOutput,
+} from "./schemas";
 import pkg from "../../../package.json";
+
+// Everything octo-santa touches is the local shared SQLite database — no tool
+// reaches an open-world external system.
+const LOCAL = { openWorldHint: false } as const;
 
 // Claude Code truncates server instructions at 2KB — keep this text under
 // that limit.
@@ -46,8 +61,11 @@ export function registerMessagingTools(
   onAgentId?: (agentId: string) => { commit: () => void }
 ): void {
   server.registerTool("messaging_register", {
+    title: "Register agent",
     description:
       "Register this agent under a unique name to start receiving messages.",
+    annotations: { ...LOCAL, readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+    outputSchema: RegisterOutput,
     inputSchema: z.object({
       agent_id: z
         .string()
@@ -67,8 +85,11 @@ export function registerMessagingTools(
   });
 
   server.registerTool("messaging_create_channel", {
+    title: "Create channel",
     description:
       "Create a named channel and auto-join it as a member.",
+    annotations: { ...LOCAL, readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+    outputSchema: CreateChannelOutput,
     inputSchema: z.object({
       agent_id: z.string().trim().min(1).describe("Your agent/project name"),
       name: z.string().trim().min(1).max(128, "Channel name must not exceed 128 characters").regex(/^[\w.,@#-]+$/, "Channel name must contain only letters, digits, underscores, hyphens, dots, commas, @ or #").describe("Channel name"),
@@ -81,8 +102,11 @@ export function registerMessagingTools(
   });
 
   server.registerTool("messaging_subscribe", {
+    title: "Subscribe to channel",
     description:
       "Subscribe to an existing channel to start receiving notifications.",
+    annotations: { ...LOCAL, readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+    outputSchema: SubscribeOutput,
     inputSchema: z.object({
       agent_id: z.string().trim().min(1).describe("Your agent/project name"),
       channel: z
@@ -99,14 +123,20 @@ export function registerMessagingTools(
   });
 
   server.registerTool("messaging_list_channels", {
+    title: "List channels",
     description: "List all messaging channels",
+    annotations: { ...LOCAL, readOnlyHint: true, idempotentHint: true },
+    outputSchema: ListChannelsOutput,
   }, async () => {
-    return jsonResult(messaging.listChannels());
+    return jsonResult({ channels: messaging.listChannels() });
   });
 
   server.registerTool("messaging_send", {
+    title: "Send message or DM",
     description:
       "Send a message: set `channel` to post to a channel, or `to` to DM an agent (auto-creates the DM and pushes to both -- no @mention needed). Provide exactly one. In channels, @agent-name or @all notifies; no mention is silent.",
+    annotations: { ...LOCAL, readOnlyHint: false, destructiveHint: false, idempotentHint: false },
+    outputSchema: SendOutput,
     inputSchema: z.object({
       agent_id: z.string().trim().min(1).describe("Your agent/project name"),
       channel: z.string().trim().min(1).optional().describe("Channel to post to (mutually exclusive with `to`)"),
@@ -127,8 +157,12 @@ export function registerMessagingTools(
   });
 
   server.registerTool("messaging_read_messages", {
+    title: "Read messages",
     description:
       "Read unread messages from a channel, or fetch older history with before_id. Requires channel membership.",
+    // Not readOnly: the default mode consumes the unread cursor (read-once).
+    annotations: { ...LOCAL, readOnlyHint: false, destructiveHint: false, idempotentHint: false },
+    outputSchema: ReadMessagesOutput,
     inputSchema: z.object({
       agent_id: z.string().trim().min(1).describe("Your agent/project name"),
       channel: z.string().trim().min(1).describe("Channel name"),
@@ -149,13 +183,16 @@ export function registerMessagingTools(
     }),
   }, async ({ agent_id, channel, limit, before_id }) => {
     return withAgent(onAgentId, agent_id, () =>
-      jsonResult(messaging.read(agent_id, channel, { limit, before_id }))
+      jsonResult({ messages: messaging.read(agent_id, channel, { limit, before_id }) })
     );
   });
 
   server.registerTool("messaging_list_agents", {
+    title: "List agents",
     description:
       "List agents — active only by default; set include_stale to include disconnected ones.",
+    annotations: { ...LOCAL, readOnlyHint: true, idempotentHint: true },
+    outputSchema: ListAgentsOutput,
     inputSchema: z.object({
       include_stale: z
         .boolean()
@@ -166,21 +203,27 @@ export function registerMessagingTools(
         ),
     }),
   }, async ({ include_stale }) => {
-    return jsonResult(messaging.listAgents(include_stale));
+    return jsonResult({ agents: messaging.listAgents(include_stale) });
   });
 
   server.registerTool("messaging_list_members", {
+    title: "List channel members",
     description:
       "List a channel's members with their active/inactive status.",
+    annotations: { ...LOCAL, readOnlyHint: true, idempotentHint: true },
+    outputSchema: ListMembersOutput,
     inputSchema: z.object({
       channel: z.string().trim().min(1).describe("Channel name"),
     }),
   }, async ({ channel }) => {
-    return jsonResult(messaging.listMembers(channel));
+    return jsonResult({ members: messaging.listMembers(channel) });
   });
 
   server.registerTool("messaging_rename_channel", {
+    title: "Rename channel",
     description: "Rename a channel. You must be a member.",
+    annotations: { ...LOCAL, readOnlyHint: false, destructiveHint: false, idempotentHint: false },
+    outputSchema: RenameChannelOutput,
     inputSchema: z.object({
       agent_id: z.string().trim().min(1).describe("Your agent/project name"),
       channel: z.string().trim().min(1).describe("Current channel name"),

--- a/src/transports/mcp-stdio/adapter.ts
+++ b/src/transports/mcp-stdio/adapter.ts
@@ -1,5 +1,5 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { McpServer } from "@modelcontextprotocol/server";
+import { serveStdio, type StdioServerHandle } from "@modelcontextprotocol/server/stdio";
 import { z } from "zod";
 import type { MessagingService } from "../../core/messaging/service";
 import type { NotificationPort, AgentRepository } from "../../core/ports";
@@ -48,7 +48,7 @@ export function registerMessagingTools(
   server.registerTool("messaging_register", {
     description:
       "Register this agent under a unique name to start receiving messages.",
-    inputSchema: {
+    inputSchema: z.object({
       agent_id: z
         .string()
         .trim()
@@ -58,7 +58,7 @@ export function registerMessagingTools(
           "Must be letters, digits, underscores, or hyphens"
         )
         .describe("Your agent/project name"),
-    },
+    }),
   }, async ({ agent_id }) => {
     const handle = onAgentId?.(agent_id);
     const result = messaging.register(agent_id);
@@ -69,10 +69,10 @@ export function registerMessagingTools(
   server.registerTool("messaging_create_channel", {
     description:
       "Create a named channel and auto-join it as a member.",
-    inputSchema: {
+    inputSchema: z.object({
       agent_id: z.string().trim().min(1).describe("Your agent/project name"),
       name: z.string().trim().min(1).max(128, "Channel name must not exceed 128 characters").regex(/^[\w.,@#-]+$/, "Channel name must contain only letters, digits, underscores, hyphens, dots, commas, @ or #").describe("Channel name"),
-    },
+    }),
   }, async ({ agent_id, name }) => {
     return withAgent(onAgentId, agent_id, () => {
       const channel = messaging.createChannel(agent_id, name);
@@ -83,14 +83,14 @@ export function registerMessagingTools(
   server.registerTool("messaging_subscribe", {
     description:
       "Subscribe to an existing channel to start receiving notifications.",
-    inputSchema: {
+    inputSchema: z.object({
       agent_id: z.string().trim().min(1).describe("Your agent/project name"),
       channel: z
         .string()
         .trim()
         .min(1)
         .describe("Channel name to subscribe to"),
-    },
+    }),
   }, async ({ agent_id, channel }) => {
     return withAgent(onAgentId, agent_id, () => {
       messaging.subscribe(agent_id, channel);
@@ -107,12 +107,12 @@ export function registerMessagingTools(
   server.registerTool("messaging_send", {
     description:
       "Send a message: set `channel` to post to a channel, or `to` to DM an agent (auto-creates the DM and pushes to both -- no @mention needed). Provide exactly one. In channels, @agent-name or @all notifies; no mention is silent.",
-    inputSchema: {
+    inputSchema: z.object({
       agent_id: z.string().trim().min(1).describe("Your agent/project name"),
       channel: z.string().trim().min(1).optional().describe("Channel to post to (mutually exclusive with `to`)"),
       to: z.string().trim().min(1).optional().describe("Agent to direct-message (mutually exclusive with `channel`)"),
       content: z.string().trim().min(1).max(100_000, "Message content must not exceed 100,000 characters").describe("Message content"),
-    },
+    }),
   }, async ({ agent_id, channel, to, content }) => {
     return withAgent(onAgentId, agent_id, () => {
       if ((channel == null) === (to == null)) {
@@ -129,7 +129,7 @@ export function registerMessagingTools(
   server.registerTool("messaging_read_messages", {
     description:
       "Read unread messages from a channel, or fetch older history with before_id. Requires channel membership.",
-    inputSchema: {
+    inputSchema: z.object({
       agent_id: z.string().trim().min(1).describe("Your agent/project name"),
       channel: z.string().trim().min(1).describe("Channel name"),
       limit: z
@@ -146,7 +146,7 @@ export function registerMessagingTools(
         .describe(
           "Get messages before this ID (history mode, does not advance cursor)"
         ),
-    },
+    }),
   }, async ({ agent_id, channel, limit, before_id }) => {
     return withAgent(onAgentId, agent_id, () =>
       jsonResult(messaging.read(agent_id, channel, { limit, before_id }))
@@ -156,7 +156,7 @@ export function registerMessagingTools(
   server.registerTool("messaging_list_agents", {
     description:
       "List agents — active only by default; set include_stale to include disconnected ones.",
-    inputSchema: {
+    inputSchema: z.object({
       include_stale: z
         .boolean()
         .optional()
@@ -164,7 +164,7 @@ export function registerMessagingTools(
         .describe(
           "If true, include stale/disconnected agents (default: active only)"
         ),
-    },
+    }),
   }, async ({ include_stale }) => {
     return jsonResult(messaging.listAgents(include_stale));
   });
@@ -172,20 +172,20 @@ export function registerMessagingTools(
   server.registerTool("messaging_list_members", {
     description:
       "List a channel's members with their active/inactive status.",
-    inputSchema: {
+    inputSchema: z.object({
       channel: z.string().trim().min(1).describe("Channel name"),
-    },
+    }),
   }, async ({ channel }) => {
     return jsonResult(messaging.listMembers(channel));
   });
 
   server.registerTool("messaging_rename_channel", {
     description: "Rename a channel. You must be a member.",
-    inputSchema: {
+    inputSchema: z.object({
       agent_id: z.string().trim().min(1).describe("Your agent/project name"),
       channel: z.string().trim().min(1).describe("Current channel name"),
       new_name: z.string().trim().min(1).describe("New channel name"),
-    },
+    }),
   }, async ({ agent_id, channel, new_name }) => {
     return withAgent(onAgentId, agent_id, () =>
       jsonResult(messaging.renameChannel(agent_id, channel, new_name))
@@ -202,7 +202,19 @@ export interface McpStdioOpts {
   onDisconnect: (agentId: string) => void;
 }
 
-export async function startMcpStdio(opts: McpStdioOpts): Promise<void> {
+const BOOTSTRAP_MSG =
+  "octo-santa messaging module is available. Call messaging_register with a unique agent name (e.g. your role), then create or subscribe to channels to start receiving push notifications. If the name is taken, pick a different one.";
+
+// Builds one server instance for one stdio connection. serveStdio calls this
+// factory when the connection's opening message arrives and pins the instance
+// for the connection lifetime (a `server/discover` probe instance may also be
+// built and discarded — it never sees a tool call, so nothing binds on it).
+// All per-connection state (agent binding, poller, heartbeat) lives in this
+// closure; everything durable lives in SQLite.
+function buildConnectionServer(
+  opts: McpStdioOpts,
+  era: "legacy" | "modern"
+): McpServer {
   const {
     messaging,
     agents,
@@ -225,7 +237,7 @@ export async function startMcpStdio(opts: McpStdioOpts): Promise<void> {
   let boundAgentId: string | null = null;
   let pollerRef: { stop(): void } | null = null;
 
-  // Binds the session to the first agent id that completes a tool call.
+  // Binds the connection to the first agent id that completes a tool call.
   // Binding is deferred until commit() so a failed register doesn't bind.
   function onAgentId(agentId: string): { commit: () => void } {
     if (boundAgentId !== null) {
@@ -241,6 +253,9 @@ export async function startMcpStdio(opts: McpStdioOpts): Promise<void> {
         if (boundAgentId !== null) return;
         boundAgentId = agentId;
         const port: NotificationPort = {
+          // Custom extension notifications are era-blind in SDK v2: the stdio
+          // entry passes any non-spec notification method straight through to
+          // the wire on both 2025-era and 2026-07-28 connections.
           notify: (content, meta) =>
             mcpServer.server.notification({
               method: "notifications/claude/channel",
@@ -262,10 +277,7 @@ export async function startMcpStdio(opts: McpStdioOpts): Promise<void> {
 
   registerMessagingTools(mcpServer, messaging, onAgentId);
 
-  const transport = new StdioServerTransport();
-  await mcpServer.connect(transport);
-
-  mcpServer.server.onclose = async () => {
+  mcpServer.server.onclose = () => {
     try {
       if (heartbeatTimer !== null) clearInterval(heartbeatTimer);
       pollerRef?.stop();
@@ -276,12 +288,32 @@ export async function startMcpStdio(opts: McpStdioOpts): Promise<void> {
     }
   };
 
-  const bootstrapMsg =
-    "octo-santa messaging module is available. Call messaging_register with a unique agent name (e.g. your role), then create or subscribe to channels to start receiving push notifications. If the name is taken, pick a different one.";
-  await mcpServer.server.notification({
-    method: "notifications/claude/channel",
-    params: { content: bootstrapMsg, meta: { type: "bootstrap" } },
+  if (era === "legacy") {
+    // 2025-era connections complete an initialize handshake; nudge the agent
+    // once it finishes. 2026-07-28 connections are stateless — no handshake,
+    // and clients must opt in to notification streams — so the same guidance
+    // reaches them as server instructions via `server/discover` instead.
+    mcpServer.server.oninitialized = () => {
+      void mcpServer.server
+        .notification({
+          method: "notifications/claude/channel",
+          params: { content: BOOTSTRAP_MSG, meta: { type: "bootstrap" } },
+        })
+        .catch((error) => log(`bootstrap notification failed: ${error}`));
+    };
+  }
+
+  return mcpServer;
+}
+
+export function startMcpStdio(opts: McpStdioOpts): StdioServerHandle {
+  // serveStdio owns the transport and the protocol-era decision: the same
+  // factory serves stateless 2026-07-28 connections and 2025-era handshake
+  // connections, pinning one fresh instance per connection.
+  const handle = serveStdio((ctx) => buildConnectionServer(opts, ctx.era), {
+    onerror: (error) => log(`mcp stdio error: ${error}`),
   });
 
   log("octo-santa MCP server running");
+  return handle;
 }

--- a/src/transports/mcp-stdio/helpers.ts
+++ b/src/transports/mcp-stdio/helpers.ts
@@ -1,5 +1,11 @@
-export function jsonResult(data: unknown) {
-  return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
+// Tool results carry the same object twice: human/legacy-readable JSON text
+// and validated structuredContent. Keep results top-level objects — object
+// shapes project identically onto both protocol eras.
+export function jsonResult<T extends object>(data: T) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data) }],
+    structuredContent: data,
+  };
 }
 
 export function withAgent<T>(

--- a/src/transports/mcp-stdio/schemas.ts
+++ b/src/transports/mcp-stdio/schemas.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+import type { Agent, Channel, Message } from "../../core/messaging/types";
+
+// Wire schemas for structured tool output (SDK v2 outputSchema). These mirror
+// the core domain types; the `satisfies` clauses fail compilation if a core
+// field is removed or renamed, and the tool-metadata contract tests validate
+// real service output against them at runtime.
+
+export const AgentSchema = z.object({
+  id: z.string().describe("Agent name"),
+  created_at: z.number().describe("Unix ms timestamp of first registration"),
+  last_seen_at: z.number().describe("Unix ms timestamp of last heartbeat"),
+  pid: z.number().nullable().describe("Owning process id, null when disconnected"),
+  registered_at: z.number().nullable().describe("Unix ms timestamp of current registration, null when disconnected"),
+}) satisfies z.ZodType<Agent>;
+
+export const ChannelSchema = z.object({
+  id: z.number().describe("Channel id"),
+  name: z.string().describe("Channel name"),
+  created_by: z.string().describe("Agent that created the channel"),
+  created_at: z.number().describe("Unix ms timestamp of creation"),
+}) satisfies z.ZodType<Channel>;
+
+export const MessageSchema = z.object({
+  id: z.number().describe("Message id (monotonic; usable as before_id)"),
+  channel_id: z.number().describe("Channel id"),
+  agent_id: z.string().describe("Sender agent name"),
+  content: z.string().describe("Message content"),
+  created_at: z.number().describe("Unix ms timestamp"),
+  mentions: z.string().describe('JSON array of mentioned agent names, e.g. \'["agent-a"]\' or \'["*"]\''),
+}) satisfies z.ZodType<Message>;
+
+export const MemberSchema = z.object({
+  agent_id: z.string().describe("Agent name"),
+  active: z.boolean().describe("Whether the agent is currently active"),
+});
+
+// Per-tool output schemas. Every result is a top-level OBJECT: object-shaped
+// structuredContent projects identically onto the 2025 and 2026-07-28 wire
+// eras (non-object values get era-dependent wrapping), so lists are wrapped
+// in named keys.
+
+export const RegisterOutput = AgentSchema;
+export const CreateChannelOutput = ChannelSchema;
+export const SubscribeOutput = z.object({
+  subscribed: z.literal(true),
+  channel: z.string().describe("Channel name subscribed to"),
+});
+export const ListChannelsOutput = z.object({ channels: z.array(ChannelSchema) });
+export const SendOutput = MessageSchema;
+export const ReadMessagesOutput = z.object({ messages: z.array(MessageSchema) });
+export const ListAgentsOutput = z.object({ agents: z.array(AgentSchema) });
+export const ListMembersOutput = z.object({ members: z.array(MemberSchema) });
+export const RenameChannelOutput = ChannelSchema;

--- a/tests/hex/transports/tool-metadata.test.ts
+++ b/tests/hex/transports/tool-metadata.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { cleanupDb, testDbPath, setupTestDb } from "../../helpers/db";
+import { allMigrations } from "../../../src/storage/sqlite/migrations";
+import { createSqliteRepos } from "../../../src/storage/sqlite";
+import { MessagingService } from "../../../src/core/messaging/service";
+import { registerMessagingTools } from "../../../src/transports/mcp-stdio/adapter";
+
+const TEST_DB = testDbPath("tool-metadata");
+
+afterEach(() => {
+  cleanupDb(TEST_DB);
+});
+
+const ALL_TOOLS = [
+  "messaging_register",
+  "messaging_create_channel",
+  "messaging_subscribe",
+  "messaging_list_channels",
+  "messaging_send",
+  "messaging_read_messages",
+  "messaging_list_agents",
+  "messaging_list_members",
+  "messaging_rename_channel",
+];
+
+const READ_ONLY_TOOLS = new Set([
+  "messaging_list_channels",
+  "messaging_list_agents",
+  "messaging_list_members",
+]);
+
+function setup() {
+  const db = setupTestDb(TEST_DB, allMigrations);
+  const repos = createSqliteRepos(db);
+  const svc = new MessagingService(repos.agents, repos.channels, repos.messages, process.pid);
+
+  const configs: Record<string, any> = {};
+  const handlers: Record<string, (...args: any[]) => Promise<any>> = {};
+  const mockServer = {
+    registerTool: (name: string, config: any, cb: (...args: any[]) => Promise<any>) => {
+      configs[name] = config;
+      handlers[name] = cb;
+    },
+  } as any;
+
+  registerMessagingTools(mockServer, svc);
+  return { db, configs, handlers };
+}
+
+describe("tool metadata (SDK v2)", () => {
+  it("every tool declares title, description, annotations, and outputSchema", () => {
+    const { db, configs } = setup();
+    expect(Object.keys(configs).sort()).toEqual([...ALL_TOOLS].sort());
+    for (const name of ALL_TOOLS) {
+      const config = configs[name];
+      expect(config.title, `${name} title`).toBeTruthy();
+      expect(config.description, `${name} description`).toBeTruthy();
+      expect(config.outputSchema, `${name} outputSchema`).toBeDefined();
+      expect(config.annotations, `${name} annotations`).toBeDefined();
+    }
+    db.close();
+  });
+
+  it("annotations mark octo-santa as a closed-world local system", () => {
+    const { db, configs } = setup();
+    for (const name of ALL_TOOLS) {
+      expect(configs[name].annotations.openWorldHint, `${name} openWorldHint`).toBe(false);
+      // Nothing in octo-santa destroys data — sends, joins, and renames are additive.
+      expect(configs[name].annotations.destructiveHint ?? false, `${name} destructiveHint`).toBe(false);
+    }
+    db.close();
+  });
+
+  it("readOnlyHint is true exactly for the pure list tools", () => {
+    const { db, configs } = setup();
+    for (const name of ALL_TOOLS) {
+      expect(configs[name].annotations.readOnlyHint, `${name} readOnlyHint`).toBe(
+        READ_ONLY_TOOLS.has(name)
+      );
+    }
+    db.close();
+  });
+
+  it("messaging_read_messages is NOT readOnly (default mode consumes the unread cursor)", () => {
+    const { db, configs } = setup();
+    expect(configs.messaging_read_messages.annotations.readOnlyHint).toBe(false);
+    db.close();
+  });
+});
+
+describe("structured output contract", () => {
+  // Runs every tool against the real service and validates structuredContent
+  // with the exact zod schema each tool advertises — the runtime drift guard
+  // between core return shapes and the wire contract.
+  it("every tool's real result parses against its declared outputSchema", async () => {
+    const { db, configs, handlers } = setup();
+
+    const invoke = async (name: string, args: Record<string, unknown>) => {
+      const result = await handlers[name]!(args);
+      const parsed = configs[name].outputSchema.safeParse(result.structuredContent);
+      expect(parsed.success, `${name} structuredContent vs outputSchema: ${JSON.stringify(parsed.error?.issues)}`).toBe(true);
+      expect(result.content[0].text, `${name} text mirrors structuredContent`).toBe(
+        JSON.stringify(result.structuredContent)
+      );
+      return result.structuredContent;
+    };
+
+    await invoke("messaging_register", { agent_id: "meta-agent" });
+    await invoke("messaging_create_channel", { agent_id: "meta-agent", name: "meta-ch" });
+    await invoke("messaging_create_channel", { agent_id: "meta-agent", name: "meta-ch2" });
+    await invoke("messaging_subscribe", { agent_id: "meta-agent", channel: "meta-ch2" });
+    await invoke("messaging_send", { agent_id: "meta-agent", channel: "meta-ch", content: "hello meta" });
+    await invoke("messaging_read_messages", { agent_id: "meta-agent", channel: "meta-ch" });
+    await invoke("messaging_list_channels", {});
+    await invoke("messaging_list_agents", {});
+    const members = await invoke("messaging_list_members", { channel: "meta-ch" });
+    expect(members.members).toHaveLength(1);
+    await invoke("messaging_rename_channel", {
+      agent_id: "meta-agent",
+      channel: "meta-ch",
+      new_name: "meta-renamed",
+    });
+
+    db.close();
+  });
+});

--- a/tests/messaging/binding.test.ts
+++ b/tests/messaging/binding.test.ts
@@ -143,7 +143,7 @@ describe("agent binding enforcement", () => {
     await handlers.messaging_send!({ agent_id: "agent-a", channel: "ch", content: "hi" });
 
     const result = await handlers.messaging_list_members!({ channel: "ch" });
-    const members = JSON.parse(result.content[0].text);
+    const { members } = JSON.parse(result.content[0].text);
     expect(members).toHaveLength(1);
     expect(members[0].agent_id).toBe("agent-a");
     expect(members[0].active).toBe(true);
@@ -157,11 +157,11 @@ describe("agent binding enforcement", () => {
     db.run("INSERT INTO agents (id, created_at, last_seen_at) VALUES (?, ?, ?)", ["no-pid-agent", Date.now(), Date.now()]);
 
     const allResult = await handlers.messaging_list_agents!({ include_stale: true });
-    const allAgents = JSON.parse(allResult.content[0].text);
+    const { agents: allAgents } = JSON.parse(allResult.content[0].text);
     expect(allAgents.length).toBeGreaterThanOrEqual(2); // agent-a + no-pid-agent
 
     const activeResult = await handlers.messaging_list_agents!({ include_stale: false });
-    const activeAgents = JSON.parse(activeResult.content[0].text);
+    const { agents: activeAgents } = JSON.parse(activeResult.content[0].text);
     expect(activeAgents).toHaveLength(1);
     expect(activeAgents[0].id).toBe("agent-a");
     db.close();
@@ -174,7 +174,7 @@ describe("agent binding enforcement", () => {
     db.run("INSERT INTO agents (id, created_at, last_seen_at) VALUES (?, ?, ?)", ["stale-agent", Date.now(), Date.now()]);
 
     const result = await handlers.messaging_list_agents!({});
-    const agents = JSON.parse(result.content[0].text);
+    const { agents } = JSON.parse(result.content[0].text);
     expect(agents.length).toBe(1);
     expect(agents[0].id).toBe("agent-a");
     db.close();
@@ -196,7 +196,7 @@ describe("messaging_send tool — channel vs DM modes", () => {
     expect(JSON.parse(result.content[0].text).content).toBe("hey b");
 
     const members = await handlers.messaging_list_members!({ channel: "agent-a,agent-b" });
-    const ids = JSON.parse(members.content[0].text).map((m: any) => m.agent_id).sort();
+    const ids = JSON.parse(members.content[0].text).members.map((m: any) => m.agent_id).sort();
     expect(ids).toEqual(["agent-a", "agent-b"]);
     db.close();
   });


### PR DESCRIPTION
## Summary

Upgrade octo-santa to MCP SDK v2 (`@modelcontextprotocol/server@2.0.0`) with protocol revision 2026-07-28, adding structured tool output and tool metadata. Also adds the **design spec** for spec-native resource subscriptions — the implementation of that spec lands separately in #34, which stacks on this branch.

## Key Changes

**MCP SDK v2 Migration**
- Replace `@modelcontextprotocol/sdk@^1.27.1` with `@modelcontextprotocol/server@^2.0.0`
- Adopt `serveStdio(factory)` entry point: one fresh `McpServer` instance per stdio connection, with per-connection state (agent binding, poller, heartbeat) in the factory closure
- Support both 2025-era (legacy `initialize` handshake) and 2026-07-28 (modern stateless) clients from the same factory
- Keep custom `notifications/claude/channel` push unchanged and verified passthrough on both eras
- Era-aware bootstrap nudge: legacy connections get it on `oninitialized`; modern connections get the same guidance as instructions via `server/discover`

**Structured Tool Output & Metadata**
- Add `outputSchema` (zod) to all nine messaging tools with validated `structuredContent` on every result
- Add `title` and `annotations` (openWorldHint, destructiveHint, readOnlyHint, idempotentHint) to all tools
- Wrap list results in named keys (`{channels: […]}`, `{messages: […]}`, etc.) for consistent top-level object shape across both protocol eras
- New `src/transports/mcp-stdio/schemas.ts` with per-tool output schemas tied to core domain types via `satisfies` clauses
- Add contract test (`tests/hex/transports/tool-metadata.test.ts`) validating real service output against declared schemas

**Resource-Subscriptions Design Spec (document only)**
- Adds `docs/specs/2026-07-30-resource-subscriptions-push.md`: models channel history as MCP resources (`octo-santa://channels/{channel}/messages`) and maps the SQLite watcher onto `notifications/resources/updated`, as a sibling to the custom push
- Prototype-validated design with verbatim wire captures, era behavior, privacy analysis, and adoption recommendation
- The code implementing this spec is in #34 (`claude/resource-subscriptions-push-fqbvkk`), which builds directly on this branch

## Verified

- 268 tests pass, `tsc --noEmit` clean
- End-to-end over real stdio pipes on both eras: handshake/discover, tools/list, register, binding enforcement, and cross-process DM push in both directions (modern <-> legacy) through shared SQLite

https://claude.ai/code/session_0125pVTCP9S7ToBsiSimGYGx

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSmQuK8AWkwRuZ96jkFgNT